### PR TITLE
ci: 添加 GitHub Actions 持续集成

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,77 @@
+name: 持续集成
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: 前端检查
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: 拉取代码
+        uses: actions/checkout@v4
+
+      - name: 配置 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: 启用 pnpm
+        run: corepack enable
+
+      - name: 安装依赖
+        run: pnpm install --frozen-lockfile
+
+      - name: 静态检查
+        run: pnpm lint
+
+      - name: 运行测试
+        run: pnpm test
+
+      - name: 构建生产包
+        run: pnpm build
+
+  backend:
+    name: 后端检查
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: 拉取代码
+        uses: actions/checkout@v4
+
+      - name: 配置 Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 配置 uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: 安装依赖
+        run: uv sync --group dev --frozen
+
+      - name: 静态检查
+        run: uv run ruff check .
+
+      - name: 运行测试
+        run: uv run pytest -q


### PR DESCRIPTION
## 改动内容

- 新增 GitHub Actions 自动检查工作流，覆盖拉取请求、推送至 main 和手动触发。
- 前端在 Ubuntu 环境依次执行依赖安装、静态检查、测试和生产构建。
- 后端在 Ubuntu 环境依次执行依赖安装、Ruff 静态检查和 pytest 测试。
- 仅授予工作流读取仓库内容的权限；同一分支的新检查会取消旧检查。

## 本地验证

- 前端：lint、54 项测试和生产构建均通过（lint 有项目已有的 Hook 警告）。
- 后端：Ruff 检查通过；pytest 结果为 221 通过、1 跳过、2 失败。

## 说明

- 后端失败的两项为 Windows 环境缺少 sh 导致的既有 sandbox 测试差异。本工作流使用 Ubuntu 运行器，提交后将由 GitHub Actions 给出最终检查结果。