### PR TITLE
fix(favorites): render favorited public games with PublicGameCard

### DIFF
--- a/backend/app/api/favorites.py
+++ b/backend/app/api/favorites.py
@@ -5,17 +5,17 @@ from fastapi import APIRouter, Query
 from app.auth.deps import CurrentUser, DbSession
 from app.core.response import PaginatedData
 from app.reactions import services
-from app.schemas.reactions import FavoriteGameItem
+from app.schemas.reactions import PublicGameMeta
 
 router = APIRouter(prefix="/me/favorites", tags=["reactions"])
 
 
-@router.get("", response_model=PaginatedData[FavoriteGameItem])
+@router.get("", response_model=PaginatedData[PublicGameMeta])
 async def list_favorites(
     user: CurrentUser,
     db: DbSession,
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
-) -> PaginatedData[FavoriteGameItem]:
+) -> PaginatedData[PublicGameMeta]:
     rows, total = await services.list_favorites(db, user, page, size)
     return PaginatedData(data=rows, total=total, page=page, size=size)

--- a/backend/app/reactions/services.py
+++ b/backend/app/reactions/services.py
@@ -12,7 +12,13 @@ from app.enums import GameStatus, ReactionType
 from app.models.game import Game
 from app.models.game_reaction import GameReaction
 from app.models.user import User
-from app.schemas.reactions import FavoriteGameItem, ReactionStateResp, ReactionToggleResp
+from app.profile import services as profile_services
+from app.schemas.reactions import (
+    CreatorBrief,
+    PublicGameMeta,
+    ReactionStateResp,
+    ReactionToggleResp,
+)
 
 
 async def _get_published_game(db: AsyncSession, game_id: UUID) -> Game:
@@ -121,9 +127,28 @@ async def remove_reaction(
     )
 
 
+async def _public_game_meta(db: AsyncSession, game: Game) -> PublicGameMeta:
+    """收藏列表与公开广场共用同一公开元数据形状（无 owner PII）。"""
+    handle, display_name = await profile_services.get_owner_brief(db, game.owner_id)
+    like_count, favorite_count = await reaction_counts(db, game.id)
+    return PublicGameMeta(
+        game_id=game.id,
+        title=game.title,
+        slug=game.slug or "",
+        cover_url=(
+            f"/play/{game.slug}/thumb.png" if game.cover_path and game.slug else None
+        ),
+        published_at=game.published_at,
+        play_count=game.play_count,
+        like_count=like_count,
+        favorite_count=favorite_count,
+        creator=CreatorBrief(handle=handle, display_name=display_name),
+    )
+
+
 async def list_favorites(
     db: AsyncSession, user: User, page: int, size: int
-) -> tuple[list[FavoriteGameItem], int]:
+) -> tuple[list[PublicGameMeta], int]:
     base = (
         select(GameReaction, Game)
         .join(Game, Game.id == GameReaction.game_id)
@@ -140,15 +165,5 @@ async def list_favorites(
             .offset((page - 1) * size)
         )
     ).all()
-    items = [
-        FavoriteGameItem(
-            game_id=game.id,
-            title=game.title,
-            slug=game.slug or "",
-            status=GameStatus(game.status),
-            play_count=game.play_count,
-            favorited_at=reaction.created_at,
-        )
-        for reaction, game in rows
-    ]
+    items = [await _public_game_meta(db, game) for _reaction, game in rows]
     return items, int(total or 0)

--- a/backend/tests/test_reactions.py
+++ b/backend/tests/test_reactions.py
@@ -25,7 +25,27 @@ async def test_like_and_favorite(
 
     listing = await verified_client.get("/api/v1/me/favorites")
     assert listing.status_code == 200
-    assert any(g["game_id"] == str(gid) for g in listing.json()["data"])
+    fav = next(g for g in listing.json()["data"] if g["game_id"] == str(gid))
+    assert fav["slug"]
+    assert "published_at" in fav
+    assert fav["play_count"] >= 0
+
+
+async def test_favorites_return_public_metadata_not_owned_shape(
+    verified_client: httpx.AsyncClient, admin_client: httpx.AsyncClient
+) -> None:
+    """收藏项应携带公开元数据（slug/play URL），而非可被 GameCard 误用的 owned 字段。"""
+    from tests.helpers_publish import publish_test_game
+
+    gid = await publish_test_game(verified_client, admin_client)
+    await verified_client.post(f"/api/v1/games/{gid}/favorite")
+    listing = await verified_client.get("/api/v1/me/favorites")
+    assert listing.status_code == 200, listing.text
+    item = next(g for g in listing.json()["data"] if g["game_id"] == str(gid))
+    assert item["slug"]
+    assert "current_version" not in item
+    assert "updated_at" not in item
+    assert "creator" in item
 
 
 async def test_get_reaction_state_reflects_toggle(

--- a/frontend/src/api/public-games.ts
+++ b/frontend/src/api/public-games.ts
@@ -13,7 +13,7 @@ export type PublicGame = {
   /** 生成时自动截图的真封面；无则回退官方静态 PNG → 渐变（见 PublicGameCard） */
   cover_url?: string | null
   play_count: number
-  published_at: string
+  published_at?: string | null
   author_display?: string
   author_handle?: string | null
   creator?: CreatorRef | null

--- a/frontend/src/components/games/GameDashboard.tsx
+++ b/frontend/src/components/games/GameDashboard.tsx
@@ -14,6 +14,8 @@ import { cn } from '@/lib/cn'
 import { isTrialUser } from '@/lib/trial'
 import { DeleteConfirmModal } from './DeleteConfirmModal'
 import { GameCard } from './GameCard'
+import { PublicGameCard } from './PublicGameCard'
+import type { PublicGame } from '@/api/public-games'
 import { GameDetailDrawer } from './GameDetailDrawer'
 
 import type { MessageKey } from '@/i18n/messages'
@@ -75,23 +77,12 @@ export function GameDashboard() {
     return { all: rows.length, draft, published, pipeline, favorites: favoritesQ.data?.length ?? 0 }
   }, [rows, favoritesQ.data?.length])
 
-  const list = useMemo(() => {
-    if (filter === 'favorites') {
-      const favRows = favoritesQ.data ?? []
-      return favRows
-        .filter((g) => !q || g.title.toLowerCase().includes(q.toLowerCase()))
-        .map(
-          (g) =>
-            ({
-              game_id: g.game_id,
-              title: g.title,
-              status: 'published',
-              current_version: 1,
-              slug: g.slug,
-              updated_at: g.published_at,
-            }) as GameSummary,
-        )
-    }
+  const favoriteList = useMemo(() => {
+    const favRows = favoritesQ.data ?? []
+    return favRows.filter((g) => !q || g.title.toLowerCase().includes(q.toLowerCase()))
+  }, [favoritesQ.data, q])
+
+  const ownedList = useMemo(() => {
     return rows.filter((g) => {
       if (q && !g.title.toLowerCase().includes(q.toLowerCase())) return false
       if (filter === 'draft') return g.status === GameStatus.draft || g.status === GameStatus.rejected
@@ -100,10 +91,13 @@ export function GameDashboard() {
         return g.status === GameStatus.submitted || g.status === GameStatus.reviewing
       return true
     })
-  }, [filter, q, rows, favoritesQ.data])
+  }, [filter, q, rows])
+
+  const showingFavorites = filter === 'favorites'
+  const list = showingFavorites ? [] : ownedList
 
   // favorites 视图为他人已发布游戏的只读集合；不参与多选/删除
-  const selectable = !trial && filter !== 'favorites'
+  const selectable = !trial && !showingFavorites
   const listIds = useMemo(() => list.map((g) => g.game_id), [list])
   const allSelected = selectable && listIds.length > 0 && listIds.every((id) => selectedIds.has(id))
 
@@ -359,7 +353,7 @@ export function GameDashboard() {
         </div>
       ) : null}
 
-      {query.isLoading || (filter === 'favorites' && favoritesQ.isLoading) ? (
+      {query.isLoading || (showingFavorites && favoritesQ.isLoading) ? (
         <p className="gf-page-muted text-sm">{t('loading')}</p>
       ) : null}
       {query.isError ? (
@@ -368,7 +362,9 @@ export function GameDashboard() {
         </p>
       ) : null}
 
-      {!query.isLoading && !(filter === 'favorites' && favoritesQ.isLoading) && list.length === 0 ? (
+      {!query.isLoading &&
+      !(showingFavorites && favoritesQ.isLoading) &&
+      (showingFavorites ? favoriteList.length === 0 : list.length === 0) ? (
         <div className="gf-glass flex flex-col items-center rounded-2xl px-6 py-20 text-center">
           <div className="relative">
             <div className="gf-empty-glow absolute inset-0 scale-150 rounded-full blur-3xl" aria-hidden />
@@ -389,6 +385,16 @@ export function GameDashboard() {
             </>
           )}
         </div>
+      ) : showingFavorites ? (
+        <motion.div
+          className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          {favoriteList.map((g: PublicGame) => (
+            <PublicGameCard key={g.game_id} game={g} variant="theme" showFeaturedBadge={false} />
+          ))}
+        </motion.div>
       ) : (
         <motion.div
           className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
@@ -408,7 +414,7 @@ export function GameDashboard() {
                 >
                   <GameCard
                     game={g}
-                    readOnly={trial || filter === 'favorites'}
+                    readOnly={trial}
                     selectable={selectable}
                     selected={selectedIds.has(g.game_id)}
                     onToggleSelect={toggleSelect}
@@ -416,7 +422,7 @@ export function GameDashboard() {
                     onRequestDelete={setConfirmStateDeleteSingle}
                     onRequestUnpublish={trial ? undefined : setConfirmStateUnpublish}
                     onRequestWithdraw={trial ? undefined : setConfirmStateWithdraw}
-                    onRename={trial || filter === 'favorites' ? undefined : renameGame}
+                    onRename={trial ? undefined : renameGame}
                     onOpenDetail={g.current_version > 0 ? setDetailGame : undefined}
                   />
                 </motion.div>

--- a/frontend/src/components/games/PublicGameCard.test.tsx
+++ b/frontend/src/components/games/PublicGameCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { PublicGameCard } from './PublicGameCard'
+
+describe('PublicGameCard', () => {
+  it('omits timestamp when published_at is absent', () => {
+    render(
+      <MemoryRouter>
+        <PublicGameCard
+          game={{
+            game_id: '00000000-0000-4000-8000-0000000000a3',
+            title: 'Tower Stub',
+            slug: 'official-tower-stub',
+            play_count: 12,
+          }}
+          variant="theme"
+          showFeaturedBadge={false}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('heading', { name: 'Tower Stub' })).toBeTruthy()
+    expect(screen.queryByText(/Invalid Date/i)).toBeNull()
+  })
+
+  it('links play action to public slug route', () => {
+    render(
+      <MemoryRouter>
+        <PublicGameCard
+          game={{
+            game_id: 'g1',
+            title: 'Neon Snake',
+            slug: 'official-neon-snake',
+            play_count: 3,
+            published_at: '2026-01-01T00:00:00Z',
+          }}
+          variant="theme"
+          showFeaturedBadge={false}
+        />
+      </MemoryRouter>,
+    )
+    const links = screen.getAllByRole('link')
+    expect(links.some((a) => a.getAttribute('href') === '/play/official-neon-snake')).toBe(true)
+  })
+})

--- a/frontend/src/components/games/PublicGameCard.tsx
+++ b/frontend/src/components/games/PublicGameCard.tsx
@@ -143,12 +143,16 @@ export function PublicGameCard({
             )}
           >
             <span>{t('playCount').replace('{n}', String(game.play_count))}</span>
-            <span className={theme ? 'opacity-30' : 'text-white/30'} aria-hidden>
-              ·
-            </span>
-            <span title={new Date(game.published_at).toLocaleString()}>
-              {formatRelativeTime(game.published_at, locale)}
-            </span>
+            {game.published_at ? (
+              <>
+                <span className={theme ? 'opacity-30' : 'text-white/30'} aria-hidden>
+                  ·
+                </span>
+                <span title={new Date(game.published_at).toLocaleString()}>
+                  {formatRelativeTime(game.published_at, locale)}
+                </span>
+              </>
+            ) : null}
           </div>
         </div>
 


### PR DESCRIPTION
Return PublicGameMeta from GET /me/favorites so favorites carry slug, cover_url, published_at, and creator info. Render the Favorites tab with PublicGameCard instead of casting items into owned GameSummary/GameCard, which previously opened Forge routes and owner-only detail APIs. Omit relative timestamps when published_at is missing and add backend/frontend regression tests.