### PR TITLE
fix(play): resolve play page metadata via public game API

### DIFF
--- a/backend/tests/test_official_games.py
+++ b/backend/tests/test_official_games.py
@@ -30,6 +30,16 @@ async def test_play_official_slug(client: httpx.AsyncClient, official_seeded) ->
     assert "canvas" in r.text
 
 
+async def test_public_game_meta_by_slug(client: httpx.AsyncClient, official_seeded) -> None:
+    """Play shell resolves metadata via GET /games/public/{slug} (no /play/{slug}/meta 404)."""
+    r = await client.get("/api/v1/games/public/official-neon-snake")
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["slug"] == "official-neon-snake"
+    assert data["title"]
+    assert "play_count" in data
+
+
 async def test_fork_official_game(
     verified_client: httpx.AsyncClient, official_seeded
 ) -> None:

--- a/frontend/src/api/play.test.ts
+++ b/frontend/src/api/play.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { playApi } from './play'
+
+describe('playApi.getMeta', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('loads metadata from GET /games/public/{slug} without list fallback', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            game_id: '00000000-0000-4000-8000-0000000000a1',
+            title: 'Neon Snake',
+            slug: 'official-neon-snake',
+            play_count: 42,
+            published_at: '2026-01-01T00:00:00Z',
+            creator: { handle: 'official', display_name: 'GameForge Official' },
+          },
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const meta = await playApi.getMeta('official-neon-snake')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toMatch(/\/games\/public\/official-neon-snake$/)
+    expect(meta.title).toBe('Neon Snake')
+    expect(meta.game_id).toBe('00000000-0000-4000-8000-0000000000a1')
+    expect(meta.author_handle).toBe('official')
+    expect(meta.play_count).toBe(42)
+  })
+})

--- a/frontend/src/api/play.ts
+++ b/frontend/src/api/play.ts
@@ -1,5 +1,4 @@
-import { env } from '@/lib/env'
-import { publicGamesApi } from './public-games'
+import { publicGamesApi, type PublicGame } from './public-games'
 
 export type PlayMeta = {
   game_id?: string
@@ -10,46 +9,30 @@ export type PlayMeta = {
   play_count: number
 }
 
-async function tryFetchMeta(slug: string): Promise<PlayMeta | null> {
-  const res = await fetch(`${env.apiBaseUrl}/play/${encodeURIComponent(slug)}/meta`, {
-    headers: { Accept: 'application/json' },
-  })
-  if (!res.ok) return null
-  const json = (await res.json()) as { data?: PlayMeta }
-  if (!json.data?.title) return null
-  return json.data
+function toPlayMeta(game: PublicGame): PlayMeta {
+  return {
+    game_id: game.game_id,
+    title: game.title,
+    author_display: game.creator?.display_name ?? game.author_display ?? 'GameForge',
+    author_handle: game.creator?.handle ?? game.author_handle ?? null,
+    published_at: game.published_at ?? null,
+    play_count: game.play_count,
+  }
 }
 
 export const playApi = {
-  /** meta 端点未就绪时从公开列表或 slug 回退 */
+  /** 通过契约端点 GET /games/public/{slug} 解析试玩页元数据（不再请求未实现的 /play/{slug}/meta）。 */
   async getMeta(slug: string): Promise<PlayMeta> {
     try {
-      const live = await tryFetchMeta(slug)
-      if (live) return live
+      const game = await publicGamesApi.getBySlug(slug)
+      return toPlayMeta(game)
     } catch {
-      /* fallback */
-    }
-    try {
-      const pub = await publicGamesApi.list()
-      const match = pub.find((g) => g.slug === slug)
-      if (match) {
-        return {
-          game_id: match.game_id,
-          title: match.title,
-          author_display: match.author_display ?? 'GameForge',
-          author_handle: match.author_handle ?? match.creator?.handle ?? null,
-          published_at: match.published_at,
-          play_count: match.play_count,
-        }
+      return {
+        title: slug,
+        author_display: '',
+        published_at: null,
+        play_count: 0,
       }
-    } catch {
-      /* fallback */
-    }
-    return {
-      title: slug,
-      author_display: '',
-      published_at: null,
-      play_count: 0,
     }
   },
 }

--- a/frontend/src/api/public-games.ts
+++ b/frontend/src/api/public-games.ts
@@ -1,6 +1,5 @@
 import { apiRequest } from './client'
 
-/** 公开广场条目（契约 B2） */
 export type CreatorRef = {
   handle: string
   display_name?: string | null
@@ -13,7 +12,7 @@ export type PublicGame = {
   /** 生成时自动截图的真封面；无则回退官方静态 PNG → 渐变（见 PublicGameCard） */
   cover_url?: string | null
   play_count: number
-  published_at: string
+  published_at?: string | null
   author_display?: string
   author_handle?: string | null
   creator?: CreatorRef | null
@@ -23,5 +22,9 @@ export type PublicGame = {
 export const publicGamesApi = {
   async list(): Promise<PublicGame[]> {
     return apiRequest<PublicGame[]>('/games/public')
+  },
+
+  async getBySlug(slug: string): Promise<PublicGame> {
+    return apiRequest<PublicGame>(`/games/public/${encodeURIComponent(slug)}`)
   },
 }


### PR DESCRIPTION
Stop calling the unimplemented GET /play/{slug}/meta endpoint that always returned 404. PlayPage now loads metadata from the existing GET /games/public/{slug} contract, removing the full public-catalog fallback on every load. Add backend and frontend regression tests.