### PR TITLE
fix(docker): include scripts in backend image for official game seed (#39)

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -16,6 +16,7 @@ RUN uv sync --frozen --no-dev
 COPY backend/app ./app
 COPY backend/alembic ./alembic
 COPY backend/alembic.ini ./
+COPY backend/scripts ./scripts
 
 RUN useradd -m -u 1001 app && chown -R app:app /app
 USER app


### PR DESCRIPTION
## Summary
- Copy `backend/scripts` (including `official_assets`) into the backend Docker image so documented seed commands work on fresh Compose setups.

## Issue
Closes #39

## Test plan
- [ ] Fresh `docker compose up` then `docker compose exec backend uv run python -m scripts.seed_official_games` succeeds
- [ ] Backend startup dev seed no longer fails with missing `scripts` module or asset paths

Made with [Cursor](https://cursor.com)