### PR TITLE
fix(trial): prevent shared preview account from persisting reactions (#40)

### DIFF
--- a/backend/app/auth/trial.py
+++ b/backend/app/auth/trial.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import hash_password
 from app.core.errors import AppError, ErrorCode
 from app.enums import Role
+from app.models.game_reaction import GameReaction
 from app.models.user import User
 
 TRIAL_USER_ID = uuid.UUID("00000000-0000-4000-8000-000000000002")
@@ -28,13 +29,25 @@ def reject_trial_mutation(user: User) -> None:
         raise AppError(ErrorCode.FORBIDDEN, "试用预览账号为只读，不能修改账号信息")
 
 
+async def purge_trial_reactions(db: AsyncSession) -> int:
+    """清理共享试用账号的持久化点赞/收藏，避免多人试用互相污染。"""
+    user = await db.get(User, TRIAL_USER_ID)
+    if user is None:
+        return 0
+    result = await db.execute(delete(GameReaction).where(GameReaction.user_id == user.id))
+    await db.commit()
+    return int(result.rowcount or 0)
+
+
 async def ensure_trial_user(db: AsyncSession) -> User:
     """幂等创建试用账号：已验证邮箱、可多人各自登录（独立 refresh token）。"""
     user = await db.get(User, TRIAL_USER_ID)
     if user is not None:
+        await purge_trial_reactions(db)
         return user
     by_email = await db.scalar(select(User).where(User.email == TRIAL_EMAIL))
     if by_email is not None:
+        await purge_trial_reactions(db)
         return by_email
     user = User(
         id=TRIAL_USER_ID,

--- a/backend/app/reactions/services.py
+++ b/backend/app/reactions/services.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.trial import reject_trial_mutation
 from app.core.errors import AppError, ErrorCode
 from app.enums import GameStatus, ReactionType
 from app.models.game import Game
@@ -53,6 +54,7 @@ async def reaction_counts(db: AsyncSession, game_id: UUID) -> tuple[int, int]:
 async def toggle_reaction(
     db: AsyncSession, user: User, game_id: UUID, reaction_type: ReactionType
 ) -> ReactionToggleResp:
+    reject_trial_mutation(user)
     await _get_published_game(db, game_id)
     row = await db.scalar(
         select(GameReaction).where(
@@ -107,6 +109,7 @@ async def remove_reaction(
     db: AsyncSession, user: User, game_id: UUID, reaction_type: ReactionType
 ) -> ReactionToggleResp:
     """幂等删除当前用户的指定 reaction（不存在则 noop），返回最新计数。"""
+    reject_trial_mutation(user)
     await _get_published_game(db, game_id)
     row = await db.scalar(
         select(GameReaction).where(

--- a/backend/tests/test_trial_user.py
+++ b/backend/tests/test_trial_user.py
@@ -6,6 +6,12 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.trial import TRIAL_EMAIL, TRIAL_PASSWORD, ensure_trial_user
+from app.games.official import seed_official_games
+
+
+@pytest_asyncio.fixture
+async def official_seeded(db_session: AsyncSession) -> None:
+    await seed_official_games(db_session)
 
 
 @pytest_asyncio.fixture
@@ -62,6 +68,29 @@ async def test_trial_user_can_read_profile(trial_client: httpx.AsyncClient) -> N
     resp = await trial_client.get("/api/v1/me/profile")
     assert resp.status_code == 200, resp.text
     assert resp.json()["data"]["email"] == TRIAL_EMAIL
+
+
+@pytest.mark.asyncio
+async def test_trial_user_cannot_favorite(
+    trial_client: httpx.AsyncClient, official_seeded
+) -> None:
+    meta = await trial_client.get("/api/v1/games/public/official-neon-snake")
+    assert meta.status_code == 200, meta.text
+    game_id = meta.json()["data"]["game_id"]
+    resp = await trial_client.post(f"/api/v1/games/{game_id}/favorite")
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["error"]["code"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_trial_user_cannot_like(
+    trial_client: httpx.AsyncClient, official_seeded
+) -> None:
+    meta = await trial_client.get("/api/v1/games/public/official-neon-snake")
+    game_id = meta.json()["data"]["game_id"]
+    resp = await trial_client.post(f"/api/v1/games/{game_id}/like")
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["error"]["code"] == "FORBIDDEN"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/social/ReactionButtons.tsx
+++ b/frontend/src/components/social/ReactionButtons.tsx
@@ -8,10 +8,11 @@ import { cn } from '@/lib/cn'
 type Props = {
   gameId: string
   accessToken?: string | null
+  readOnly?: boolean
   className?: string
 }
 
-export function ReactionButtons({ gameId, accessToken, className }: Props) {
+export function ReactionButtons({ gameId, accessToken, readOnly = false, className }: Props) {
   const t = useT()
   const qc = useQueryClient()
 
@@ -39,9 +40,10 @@ export function ReactionButtons({ gameId, accessToken, className }: Props) {
   const state = q.data
   const liked = state?.liked ?? false
   const favorited = state?.favorited ?? false
+  const canMutate = Boolean(accessToken) && !readOnly
 
   function onToggle(kind: 'like' | 'favorite') {
-    if (!accessToken) return
+    if (!canMutate) return
     toggleMu.mutate(kind)
   }
 
@@ -49,16 +51,16 @@ export function ReactionButtons({ gameId, accessToken, className }: Props) {
     <div className={cn('flex flex-wrap items-center gap-2', className)}>
       <button
         type="button"
-        disabled={!accessToken || toggleMu.isPending}
+        disabled={!canMutate || toggleMu.isPending}
         onClick={() => onToggle('like')}
         className={cn(
           'inline-flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition',
           liked
             ? 'border-rose-400/40 bg-rose-400/15 text-rose-100'
             : 'border-white/15 bg-white/[0.04] text-white/80 hover:border-white/30',
-          !accessToken && 'opacity-50',
+          !canMutate && 'opacity-50',
         )}
-        title={!accessToken ? t('loginRequired') : undefined}
+        title={readOnly ? t('trialReactionsReadOnly') : !accessToken ? t('loginRequired') : undefined}
       >
         {toggleMu.isPending ? (
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -70,15 +72,16 @@ export function ReactionButtons({ gameId, accessToken, className }: Props) {
       </button>
       <button
         type="button"
-        disabled={!accessToken || toggleMu.isPending}
+        disabled={!canMutate || toggleMu.isPending}
         onClick={() => onToggle('favorite')}
         className={cn(
           'inline-flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition',
           favorited
             ? 'border-amber-400/40 bg-amber-400/15 text-amber-100'
             : 'border-white/15 bg-white/[0.04] text-white/80 hover:border-white/30',
-          !accessToken && 'opacity-50',
+          !canMutate && 'opacity-50',
         )}
+        title={readOnly ? t('trialReactionsReadOnly') : undefined}
       >
         <Star className={cn('h-3.5 w-3.5', favorited && 'fill-current')} />
         {t('reactionFavorite')}
@@ -87,6 +90,8 @@ export function ReactionButtons({ gameId, accessToken, className }: Props) {
         <Link to="/login" className="text-[11px] text-white/45 hover:text-white/70">
           {t('login')}
         </Link>
+      ) : readOnly ? (
+        <span className="text-[11px] text-white/45">{t('trialReactionsReadOnly')}</span>
       ) : null}
     </div>
   )

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -210,6 +210,7 @@ export const messages = {
     trialForgeLocked: '试用账号不能发起生成。你可以浏览预置样例，或注册后开始做游戏。',
     trialGamesHint: '试用预览：可查看预置样例，不能新建、删除或提交发布。',
     trialAccountReadOnly: '试用预览账号为只读，不能修改密码或公开资料。注册正式账号后可自由设置。',
+    trialReactionsReadOnly: '试用预览不能收藏或点赞，请注册正式账号。',
     themeTitle: '外观主题',
     collapseSidebar: '收起侧边栏',
     expandSidebar: '展开侧边栏',
@@ -896,6 +897,7 @@ export const messages = {
     trialGamesHint: 'Preview mode: browse sample games only. Creating, deleting, and publishing are off.',
     trialAccountReadOnly:
       'The shared preview account is read-only. Password and profile changes are disabled. Sign up for a full account to customize yours.',
+    trialReactionsReadOnly: 'Trial preview cannot like or favorite games. Sign up for a full account.',
     themeTitle: 'Appearance',
     collapseSidebar: 'Collapse sidebar',
     expandSidebar: 'Expand sidebar',


### PR DESCRIPTION
## Summary
- Reject like/favorite mutations for the shared trial user on the API.
- Disable reaction controls in the play UI for trial sessions.
- Purge existing trial-user reactions when ensuring the demo account so shared state does not leak across visitors.

## Issue
Closes #40

## Test plan
- [ ] Trial login cannot POST/DELETE `/games/{id}/favorite` or `/games/{id}/like` (403)
- [ ] Play page reaction buttons are disabled in trial mode
- [ ] `uv run pytest tests/test_trial_user.py -q` passes

Made with [Cursor](https://cursor.com)