### PR TITLE
fix(ui): collapse AppShell sidebar into mobile drawer (#41)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,6 +1,18 @@
 import { useEffect, useState } from 'react'
 import { NavLink, Outlet, Link, useLocation } from 'react-router-dom'
-import { Gamepad2, Hammer, Compass, Languages, Palette, PanelLeftClose, PanelLeftOpen, Settings, Shield } from 'lucide-react'
+import {
+  Gamepad2,
+  Hammer,
+  Compass,
+  Languages,
+  Menu,
+  Palette,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Settings,
+  Shield,
+  X,
+} from 'lucide-react'
 import { Role } from '@/api/enums'
 import { isTrialUser } from '@/lib/trial'
 import { useT } from '@/i18n/use-t'
@@ -41,12 +53,26 @@ export function AppShell() {
   const trial = isTrialUser(user)
   const [themeOpen, setThemeOpen] = useState(false)
   const [onboardingOpen, setOnboardingOpen] = useState(false)
+  const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
   useEffect(() => {
     if (token && user && !trial && !isOnboardingDone()) {
       setOnboardingOpen(true)
     }
   }, [token, user, trial])
+
+  useEffect(() => {
+    setMobileNavOpen(false)
+  }, [location.pathname])
+
+  useEffect(() => {
+    if (!mobileNavOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [mobileNavOpen])
 
   const navItems = [
     { to: '/games', icon: Gamepad2, label: t('games') },
@@ -55,98 +81,145 @@ export function AppShell() {
     { to: '/settings', icon: Settings, label: t('settings') },
   ] as const
 
+  const sidebarContent = (
+    <>
+      <Link
+        to="/home"
+        title={t('backToHome')}
+        className={cn(
+          'gf-interactive flex items-center gap-2.5 rounded-xl px-2 py-1.5 hover:bg-black/[0.03]',
+          collapsed && 'justify-center px-0',
+        )}
+        onClick={() => setMobileNavOpen(false)}
+      >
+        <span className="gf-logo-badge gf-interactive grid h-9 w-9 shrink-0 place-items-center rounded-xl text-sm font-black">
+          GF
+        </span>
+        {collapsed ? null : (
+          <span>
+            <span className="gf-page-body block text-sm font-semibold tracking-tight">GameForge</span>
+            <span className="gf-page-muted block text-[10px]">{t('home')}</span>
+          </span>
+        )}
+      </Link>
+
+      <button
+        type="button"
+        title={collapsed ? t('expandSidebar') : t('collapseSidebar')}
+        aria-label={collapsed ? t('expandSidebar') : t('collapseSidebar')}
+        aria-expanded={!collapsed}
+        onClick={toggleSidebar}
+        className={cn(
+          'gf-interactive gf-page-muted mt-3 hidden cursor-pointer items-center justify-center gap-2 rounded-lg px-2 py-1.5 text-xs transition hover:bg-black/[0.04] hover:text-[var(--gf-text)] lg:flex',
+          collapsed && 'px-0',
+        )}
+      >
+        {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+        {collapsed ? null : <span>{t('collapseSidebar')}</span>}
+      </button>
+
+      <nav className="mt-6 flex flex-1 flex-col gap-1">
+        {navItems.map(({ to, icon: Icon, label }) => (
+          <NavLink
+            key={to}
+            to={to}
+            title={collapsed ? label : undefined}
+            className={({ isActive }) => cn(navLinkClass({ isActive }), collapsed && navLinkCollapsedClass)}
+            end={to === '/games'}
+            onClick={() => setMobileNavOpen(false)}
+          >
+            <Icon className="h-4 w-4 shrink-0 opacity-80" />
+            {collapsed ? null : label}
+          </NavLink>
+        ))}
+        {user?.role === Role.admin ? (
+          <NavLink
+            to="/admin"
+            title={collapsed ? t('admin') : undefined}
+            className={({ isActive }) => cn(navLinkClass({ isActive }), collapsed && navLinkCollapsedClass)}
+            onClick={() => setMobileNavOpen(false)}
+          >
+            <Shield className="h-4 w-4 shrink-0 opacity-80" />
+            {collapsed ? null : t('admin')}
+          </NavLink>
+        ) : null}
+      </nav>
+
+      <div className="gf-border-subtle mt-auto space-y-3 border-t pt-4">
+        <div className={cn('flex items-center justify-between px-1', collapsed && 'flex-col gap-2 px-0')}>
+          <NotificationBell />
+          <div className={cn('flex items-center gap-1', collapsed && 'flex-col gap-2')}>
+            <button
+              type="button"
+              title={t('themeTitle')}
+              aria-label={t('themeTitle')}
+              onClick={() => setThemeOpen(true)}
+              className={iconButtonClass}
+            >
+              <Palette className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              title={locale === 'zh' ? t('switchToEnglish') : t('switchToChinese')}
+              aria-label={locale === 'zh' ? t('switchToEnglish') : t('switchToChinese')}
+              onClick={() => setLocale(locale === 'zh' ? 'en' : 'zh')}
+              className={cn(iconButtonClass, 'gf-page-muted hover:text-[var(--gf-text)]')}
+            >
+              <Languages className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        <UserMenu collapsed={collapsed} />
+      </div>
+    </>
+  )
+
   return (
     <div className="gf-workshop relative" data-collapsed={collapsed ? 'true' : 'false'}>
       <ThemeBackground />
-      <aside className="gf-sidebar flex flex-col border-r px-3 py-4 backdrop-blur-xl">
-        <Link
-          to="/home"
-          title={t('backToHome')}
-          className={cn(
-            'gf-interactive flex items-center gap-2.5 rounded-xl px-2 py-1.5 hover:bg-black/[0.03]',
-            collapsed && 'justify-center px-0',
-          )}
-        >
-          <span className="gf-logo-badge gf-interactive grid h-9 w-9 shrink-0 place-items-center rounded-xl text-sm font-black">
-            GF
-          </span>
-          {collapsed ? null : (
-            <span>
-              <span className="gf-page-body block text-sm font-semibold tracking-tight">GameForge</span>
-              <span className="gf-page-muted block text-[10px]">{t('home')}</span>
-            </span>
-          )}
-        </Link>
 
+      {mobileNavOpen ? (
         <button
           type="button"
-          title={collapsed ? t('expandSidebar') : t('collapseSidebar')}
-          aria-label={collapsed ? t('expandSidebar') : t('collapseSidebar')}
-          aria-expanded={!collapsed}
-          onClick={toggleSidebar}
-          className={cn(
-            'gf-interactive gf-page-muted mt-3 flex cursor-pointer items-center justify-center gap-2 rounded-lg px-2 py-1.5 text-xs transition hover:bg-black/[0.04] hover:text-[var(--gf-text)]',
-            collapsed && 'px-0',
-          )}
+          aria-label={t('closeMenu')}
+          className="gf-app-overlay fixed inset-0 z-40 border-0 bg-slate-900/40 backdrop-blur-[2px] lg:hidden"
+          onClick={() => setMobileNavOpen(false)}
+        />
+      ) : null}
+
+      <aside
+        className={cn(
+          'gf-sidebar flex flex-col border-r px-3 py-4 backdrop-blur-xl',
+          mobileNavOpen && 'is-open',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setMobileNavOpen(false)}
+          aria-label={t('closeMenu')}
+          className="gf-interactive absolute right-2 top-2 grid h-8 w-8 cursor-pointer place-items-center rounded-lg text-[var(--gf-text-muted)] transition hover:bg-black/[0.04] lg:hidden"
         >
-          {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
-          {collapsed ? null : <span>{t('collapseSidebar')}</span>}
+          <X className="h-4 w-4" />
         </button>
-
-        <nav className="mt-6 flex flex-1 flex-col gap-1">
-          {navItems.map(({ to, icon: Icon, label }) => (
-            <NavLink
-              key={to}
-              to={to}
-              title={collapsed ? label : undefined}
-              className={({ isActive }) => cn(navLinkClass({ isActive }), collapsed && navLinkCollapsedClass)}
-              end={to === '/games'}
-            >
-              <Icon className="h-4 w-4 shrink-0 opacity-80" />
-              {collapsed ? null : label}
-            </NavLink>
-          ))}
-          {user?.role === Role.admin ? (
-            <NavLink
-              to="/admin"
-              title={collapsed ? t('admin') : undefined}
-              className={({ isActive }) => cn(navLinkClass({ isActive }), collapsed && navLinkCollapsedClass)}
-            >
-              <Shield className="h-4 w-4 shrink-0 opacity-80" />
-              {collapsed ? null : t('admin')}
-            </NavLink>
-          ) : null}
-        </nav>
-
-        <div className="gf-border-subtle mt-auto space-y-3 border-t pt-4">
-          <div className={cn('flex items-center justify-between px-1', collapsed && 'flex-col gap-2 px-0')}>
-            <NotificationBell />
-            <div className={cn('flex items-center gap-1', collapsed && 'flex-col gap-2')}>
-              <button
-                type="button"
-                title={t('themeTitle')}
-                aria-label={t('themeTitle')}
-                onClick={() => setThemeOpen(true)}
-                className={iconButtonClass}
-              >
-                <Palette className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                title={locale === 'zh' ? t('switchToEnglish') : t('switchToChinese')}
-                aria-label={locale === 'zh' ? t('switchToEnglish') : t('switchToChinese')}
-                onClick={() => setLocale(locale === 'zh' ? 'en' : 'zh')}
-                className={cn(iconButtonClass, 'gf-page-muted hover:text-[var(--gf-text)]')}
-              >
-                <Languages className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
-          <UserMenu collapsed={collapsed} />
-        </div>
+        {sidebarContent}
       </aside>
 
-      <div className="gf-shell-main relative z-[1] flex flex-col">
+      <div
+        className="gf-shell-main relative z-[1] flex flex-col"
+        inert={mobileNavOpen ? true : undefined}
+      >
+        <div className="flex shrink-0 items-center gap-3 border-b border-[var(--gf-border)] bg-[var(--gf-sidebar-bg)] px-4 py-2.5 backdrop-blur-xl lg:hidden">
+          <button
+            type="button"
+            onClick={() => setMobileNavOpen(true)}
+            aria-label={t('openMenu')}
+            className="gf-interactive grid h-9 w-9 cursor-pointer place-items-center rounded-lg text-[var(--gf-text-muted)] transition hover:bg-black/[0.04] hover:text-[var(--gf-text)]"
+          >
+            <Menu className="h-4 w-4" />
+          </button>
+          <span className="gf-page-body text-sm font-semibold tracking-tight">GameForge</span>
+        </div>
+
         {trial ? (
           <div
             role="status"

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -210,6 +210,8 @@ export const messages = {
     trialForgeLocked: '试用账号不能发起生成。你可以浏览预置样例，或注册后开始做游戏。',
     trialGamesHint: '试用预览：可查看预置样例，不能新建、删除或提交发布。',
     trialAccountReadOnly: '试用预览账号为只读，不能修改密码或公开资料。注册正式账号后可自由设置。',
+    openMenu: '打开导航菜单',
+    closeMenu: '关闭导航菜单',
     themeTitle: '外观主题',
     collapseSidebar: '收起侧边栏',
     expandSidebar: '展开侧边栏',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1273,6 +1273,24 @@ body.gf-forge-dock-resizing * {
 
 /* mobile sidebar 抽屉：<1024px 隐藏，is-open 滑入。不动全局 .gf-sidebar */
 @media (max-width: 1023px) {
+  .gf-workshop {
+    --gf-sidebar-w: 0px;
+  }
+
+  .gf-workshop .gf-sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    width: min(280px, 86vw);
+  }
+
+  .gf-workshop .gf-sidebar.is-open {
+    transform: none;
+  }
+
+  .gf-shell-main {
+    margin-left: 0;
+  }
+
   /* 抽屉：绝对定位浮在主内容上，默认 translateX 隐藏，is-open 滑入 */
   .gf-admin-sidebar {
     position: absolute;


### PR DESCRIPTION
## Summary
- Add a mobile menu button and off-canvas sidebar drawer for viewports below 1024px.
- Remove fixed sidebar margin on narrow screens so discover and other AppShell routes use full width.

## Issue
Closes #41

## Test plan
- [ ] At 390px width, sidebar is hidden by default and opens via menu button
- [ ] Main content uses full viewport width when drawer is closed
- [ ] Overlay tap and route change close the drawer

Made with [Cursor](https://cursor.com)