### PR TITLE
fix(discover): include featured flag in public games list (#43)

### DIFF
--- a/backend/app/api/games.py
+++ b/backend/app/api/games.py
@@ -110,6 +110,7 @@ async def _public_item(db: DbSession, game: Game) -> PublicGameMeta:
         cover_url=(f"/play/{game.slug}/thumb.png" if game.cover_path and game.slug else None),
         published_at=game.published_at,
         play_count=game.play_count,
+        featured=game.featured_rank is not None,
         like_count=like_count,
         favorite_count=favorite_count,
         creator=CreatorBrief(handle=handle, display_name=display_name),

--- a/backend/app/reactions/services.py
+++ b/backend/app/reactions/services.py
@@ -140,6 +140,7 @@ async def _public_game_meta(db: AsyncSession, game: Game) -> PublicGameMeta:
         ),
         published_at=game.published_at,
         play_count=game.play_count,
+        featured=game.featured_rank is not None,
         like_count=like_count,
         favorite_count=favorite_count,
         creator=CreatorBrief(handle=handle, display_name=display_name),

--- a/backend/app/schemas/reactions.py
+++ b/backend/app/schemas/reactions.py
@@ -13,6 +13,7 @@ class CreatorBrief(BaseModel):
 
 
 class PublicGameMeta(PublicGameItem):
+    featured: bool = False
     like_count: int = 0
     favorite_count: int = 0
     creator: CreatorBrief | None = None

--- a/backend/tests/test_featured.py
+++ b/backend/tests/test_featured.py
@@ -19,5 +19,10 @@ async def test_featured_games(
     assert featured.status_code == 200
     assert any(g["game_id"] == str(gid) for g in featured.json()["data"])
 
+    public = await verified_client.get("/api/v1/games/public")
+    assert public.status_code == 200
+    pub_row = next(g for g in public.json()["data"] if g["game_id"] == str(gid))
+    assert pub_row["featured"] is True
+
     logs = await admin_client.get("/api/v1/admin/audit-logs")
     assert any(row["action"] == "feature_game" for row in logs.json()["data"])


### PR DESCRIPTION
## Summary
- Add `featured: bool` to `PublicGameMeta` derived from `featured_rank`.
- Populate the field in `GET /games/public` and favorites metadata so the Discover **Featured only** filter matches the featured strip.

## Issue
Closes #43

## Test plan
- [ ] Mark a published game with `featured_rank`; `GET /games/public` returns `featured: true` for that game
- [ ] Discover **Featured only** filter shows curated games instead of zero results
- [ ] `uv run pytest tests/test_featured.py -q` passes

Made with [Cursor](https://cursor.com)