### PR TITLE
fix(ci): remove unused pytest import in test_official_games

### DIFF
--- a/backend/tests/test_official_games.py
+++ b/backend/tests/test_official_games.py
@@ -4,7 +4,6 @@ import shutil
 import uuid
 
 import httpx
-import pytest
 
 from app.games.official import OFFICIAL_CATALOG, seed_official_games
 


### PR DESCRIPTION
## Summary
Fix backend Ruff CI failure (F401): \pytest\ was imported in \	ests/test_official_games.py\ after \official_seeded\ fixture moved to \conftest.py\ in #48.

## CI
Fixes failed run: https://github.com/ByteTitan-star/GameForge-Copilot/actions/runs/31873114719

## Test plan
- [x] \uv run ruff check tests/test_official_games.py\
- [x] \uv run pytest tests/test_official_games.py -q\ (10 passed)

Made with [Cursor](https://cursor.com)