### PR TITLE
fix(ci): sync openapi snapshot after locale and featured API changes

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -19,7 +19,9 @@
 
 ## 未发布（working copy）
 
-## 未发布（working copy）
+- MODIFIED: `GET /games/public`、`GET /games/featured`、`GET /official/games` — 增 `locale` query（zh | en，官方样例标题随 locale 切换）
+- MODIFIED: `GET /play/{slug}/` — 增 `locale` query（en 时优先返回英文静态页）
+- MODIFIED: `PublicGameMeta` — 增 `featured: bool`（由 `featured_rank` 推导）
 
 - ADDED: Run 事件 Redis 缓冲 + WS 连接时 replay；`GET /runs/{id}/events` HTTP 回退
 - ADDED: `GET /me/runs/active` — 跨游戏进行中的 run 列表（刷新/跳转后找回）

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -1470,6 +1470,24 @@
               "default": "updated_at",
               "title": "Sort"
             }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "zh | en，官方样例标题随 locale 切换",
+              "title": "Locale"
+            },
+            "description": "zh | en，官方样例标题随 locale 切换"
           }
         ],
         "responses": {
@@ -1527,6 +1545,24 @@
               "default": 20,
               "title": "Size"
             }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "zh | en，官方样例标题随 locale 切换",
+              "title": "Locale"
+            },
+            "description": "zh | en，官方样例标题随 locale 切换"
           }
         ],
         "responses": {
@@ -1569,6 +1605,24 @@
               "type": "string",
               "title": "Slug"
             }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "zh | en，官方样例标题随 locale 切换",
+              "title": "Locale"
+            },
+            "description": "zh | en，官方样例标题随 locale 切换"
           }
         ],
         "responses": {
@@ -2812,6 +2866,26 @@
         ],
         "summary": "List Official Games",
         "operationId": "list_official_games_api_v1_official_games_get",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "zh | en",
+              "title": "Locale"
+            },
+            "description": "zh | en"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -2819,6 +2893,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiResponse_list_OfficialGameItem__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -5373,6 +5457,22 @@
             "schema": {
               "type": "string",
               "title": "Slug"
+            }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lang"
             }
           }
         ],
@@ -8831,6 +8931,11 @@
           "play_count": {
             "type": "integer",
             "title": "Play Count"
+          },
+          "featured": {
+            "type": "boolean",
+            "title": "Featured",
+            "default": false
           },
           "like_count": {
             "type": "integer",

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2922,6 +2922,11 @@ export interface components {
             /** Play Count */
             play_count: number;
             /**
+             * Featured
+             * @default false
+             */
+            featured: boolean;
+            /**
              * Like Count
              * @default 0
              */
@@ -4527,6 +4532,8 @@ export interface operations {
                 page?: number;
                 size?: number;
                 sort?: string;
+                /** @description zh | en，官方样例标题随 locale 切换 */
+                locale?: string | null;
             };
             header?: never;
             path?: never;
@@ -4559,6 +4566,8 @@ export interface operations {
             query?: {
                 page?: number;
                 size?: number;
+                /** @description zh | en，官方样例标题随 locale 切换 */
+                locale?: string | null;
             };
             header?: never;
             path?: never;
@@ -4588,7 +4597,10 @@ export interface operations {
     };
     get_public_game_meta_api_v1_games_public__slug__get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description zh | en，官方样例标题随 locale 切换 */
+                locale?: string | null;
+            };
             header?: never;
             path: {
                 slug: string;
@@ -5434,7 +5446,10 @@ export interface operations {
     };
     list_official_games_api_v1_official_games_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description zh | en */
+                locale?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -5448,6 +5463,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiResponse_list_OfficialGameItem__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -7148,7 +7172,9 @@ export interface operations {
     };
     play_play__slug__get: {
         parameters: {
-            query?: never;
+            query?: {
+                lang?: string | null;
+            };
             header?: never;
             path: {
                 slug: string;


### PR DESCRIPTION
## Summary
- Regenerate contracts/openapi.json after #48/#43 API changes (locale query params, PublicGameMeta.featured)
- Regenerate frontend/src/api/types.gen.ts from updated contract
- Document contract deltas in contracts/CHANGELOG.md

Fixes CI failure: tests/test_openapi.py::test_snapshot_matches_committed (run 31873354848)

## Test plan
- [x] uv run pytest tests/test_openapi.py
- [x] pnpm gen:api (types.gen.ts matches openapi.json)

Made with [Cursor](https://cursor.com)