### PR TITLE
fix(#56): worker 毒消息重试上限 + DLQ

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -70,6 +70,8 @@ MAX_CONCURRENT_RUNS=3
 # worker 进程内同时处理的任务数（RabbitMQ prefetch_count）；慢 LLM 不再阻塞消费。
 # 扩容再多开 worker 进程：docker compose up -d --scale worker=N（或设 WORKER_REPLICAS）
 MAX_CONCURRENT_TASKS=3
+# 消费侧毒消息重试上限；超过后写入 gameforge.worker.dlq，避免无限 requeue
+WORKER_MAX_REDELIVERIES=5
 MAX_VERSIONS_PER_GAME=20
 MAX_DRAFTS_PER_USER=20
 MAX_PUBLISHED_PER_USER=50

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,6 +79,8 @@ class Settings(BaseSettings):
     create_run_idempotency_ttl: int = 86_400
     max_concurrent_runs: int = 3  # 每用户同时进行中的 run 上限（docs/05）
     max_concurrent_tasks: int = 3  # worker 进程内同时处理的任务数（RabbitMQ prefetch_count）
+    # 消费侧毒消息重试上限：超过后 ack 并写入 DLQ，避免无限 requeue 饿死 worker
+    worker_max_redeliveries: int = 5
     max_versions_per_game: int = 20  # 版本保留上限（docs/04），超出删最旧
     max_drafts_per_user: int = 20  # 每用户草稿游戏数上限
     max_published_per_user: int = 50  # 每用户已发布游戏数上限

--- a/backend/app/messaging/rabbit.py
+++ b/backend/app/messaging/rabbit.py
@@ -23,6 +23,7 @@ from aio_pika.abc import AbstractChannel, AbstractConnection, AbstractQueue
 from app.core.config import settings
 from app.enums import WSEventType
 from app.messaging.tasks import (
+    TASK_DLQ,
     TASK_EXCHANGE,
     TASK_EXECUTE_RUN,
     TASK_QUEUE,
@@ -126,7 +127,9 @@ async def _task_channel() -> tuple[AbstractChannel, aio_pika.abc.AbstractExchang
         TASK_QUEUE,             # 队列名：gameforge.worker
         durable=True            # 持久化
     )
-    
+    # 死信队列：毒消息耗尽重试后由 worker 显式写入（不自动 DLX，便于带上失败原因 header）
+    await channel.declare_queue(TASK_DLQ, durable=True)
+
     # 6. 绑定队列到交换器：将 5 个路由键绑定到队列
     #    这样发送到 gameforge.tasks 交换器、routing_key 匹配的消息
     #    都会被路由到 gameforge.worker 队列

--- a/backend/app/messaging/tasks.py
+++ b/backend/app/messaging/tasks.py
@@ -36,6 +36,10 @@ TASK_SCAN_SCHEDULES = "scan_schedules"         # 定时扫描到期游戏下架
 
 TASK_EXCHANGE = "gameforge.tasks"   # 任务交换器：生产者发送消息到这里
 TASK_QUEUE = "gameforge.worker"     # 任务队列：Worker 从此队列消费消息
+TASK_DLQ = "gameforge.worker.dlq"   # 死信队列：毒消息耗尽重试后落入此处
+
+# 消费侧重投计数（应用层 header；RabbitMQ 原生 requeue 不递增计数）
+HEADER_RETRY_COUNT = "x-retry-count"
 
 WS_EXCHANGE = "gameforge.ws"        # WebSocket 交换器：用于推送实时进度给前端
 

--- a/backend/app/messaging/worker.py
+++ b/backend/app/messaging/worker.py
@@ -14,7 +14,12 @@ from app.core.config import settings
 from app.core.logging import setup_logging
 from app.messaging.handlers import dispatch_task  # 任务分发器
 from app.messaging.rabbit import _task_channel, close_connection  # RabbitMQ 连接管理
-from app.messaging.tasks import TASK_QUEUE, decode_task  # 队列名称和消息解码
+from app.messaging.tasks import (  # 队列名称和消息解码
+    HEADER_RETRY_COUNT,
+    TASK_DLQ,
+    TASK_QUEUE,
+    decode_task,
+)
 
 log = logging.getLogger(__name__)
 
@@ -102,28 +107,123 @@ async def _outbox_loop() -> None:
         await asyncio.sleep(2)
 
 
+def _message_retry_count(message: AbstractIncomingMessage) -> int:
+    """读取应用层重投计数；非法/缺失按 0 处理。"""
+    headers = message.headers or {}
+    raw = headers.get(HEADER_RETRY_COUNT, 0)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _merged_headers(
+    message: AbstractIncomingMessage, **extra: object
+) -> dict[str, object]:
+    headers = dict(message.headers or {})
+    headers.update(extra)
+    return headers
+
+
+async def _republish_task(
+    message: AbstractIncomingMessage, task: str, *, retry_count: int
+) -> None:
+    """带递增重试计数重新入队（ack 原消息后由调用方完成）。"""
+    import aio_pika
+    from aio_pika import Message
+
+    channel, exchange = await _task_channel()
+    try:
+        await exchange.publish(
+            Message(
+                body=message.body,
+                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                headers=_merged_headers(message, **{HEADER_RETRY_COUNT: retry_count}),
+            ),
+            routing_key=task,
+        )
+    finally:
+        await channel.close()
+
+
+async def _publish_to_dlq(
+    message: AbstractIncomingMessage, task: str, *, retry_count: int, error: str
+) -> None:
+    """毒消息写入死信队列，保留原 body 与失败元数据。"""
+    import aio_pika
+    from aio_pika import Message
+
+    channel, _exchange = await _task_channel()
+    try:
+        await channel.declare_queue(TASK_DLQ, durable=True)
+        await channel.default_exchange.publish(
+            Message(
+                body=message.body,
+                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                headers=_merged_headers(
+                    message,
+                    **{
+                        HEADER_RETRY_COUNT: retry_count,
+                        "x-death-task": task,
+                        "x-death-reason": error[:500],
+                    },
+                ),
+            ),
+            routing_key=TASK_DLQ,
+        )
+    finally:
+        await channel.close()
+
+
 async def _run_one(message: AbstractIncomingMessage) -> None:
     """处理单条消息。
 
-    ack 持有到任务结束：成功则 ack；抛异常则 nack(requeue=True) 重投，保证 at-least-once。
-    慢任务（如 LLM 生成）在独立 task 里跑，不阻塞消费循环（见 _consume 的 prefetch 并发）。
+    成功 → ack；TaskLeaseBusy → 短暂休眠后原计数重投；
+    其他失败 → 递增 x-retry-count 重投，超过 worker_max_redeliveries 写入 DLQ 后 ack，
+    避免毒消息无限占用 prefetch 槽位。
     """
-    async with message.process(requeue=True):
+    # requeue=False：由本函数显式 republish / DLQ，避免无计数的裸 nack 循环
+    async with message.process(requeue=False):
         task, payload = decode_task(message.body)
-        log.info("task=%s payload_keys=%s", task, list(payload.keys()))
+        retry = _message_retry_count(message)
+        log.info(
+            "task=%s payload_keys=%s retry=%s",
+            task,
+            list(payload.keys()),
+            retry,
+        )
         try:
             await dispatch_task(task, payload)
         except Exception as exc:
             from app.forge.runner import TaskLeaseBusy
 
             if isinstance(exc, TaskLeaseBusy):
-                # Avoid a tight nack/requeue loop while the current owner is alive.
+                # 租约冲突不算毒消息：不递增计数，短暂退避后原样重投
                 await asyncio.sleep(2)
-                log.info("task lease busy; requeue task=%s", task)
-                raise
-            # 失败重新抛出 → message.process 捕获后 nack(requeue=True) 重投
-            log.exception("task=%s failed", task)
-            raise
+                log.info("task lease busy; requeue task=%s retry=%s", task, retry)
+                await _republish_task(message, task, retry_count=retry)
+                return
+
+            max_retries = settings.worker_max_redeliveries
+            if retry >= max_retries:
+                log.exception(
+                    "task=%s poison → DLQ after %s retries",
+                    task,
+                    retry,
+                )
+                await _publish_to_dlq(
+                    message, task, retry_count=retry, error=str(exc)
+                )
+                return
+
+            next_retry = retry + 1
+            log.exception(
+                "task=%s failed; requeue retry=%s/%s",
+                task,
+                next_retry,
+                max_retries,
+            )
+            await _republish_task(message, task, retry_count=next_retry)
 
 
 async def _consume() -> None:

--- a/backend/tests/test_worker_concurrency.py
+++ b/backend/tests/test_worker_concurrency.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from app.core import langfuse as lf
 from app.core.config import settings
 from app.messaging import worker as worker_mod

--- a/backend/tests/test_worker_concurrency.py
+++ b/backend/tests/test_worker_concurrency.py
@@ -1,9 +1,10 @@
 """并发消费：_run_one 的 ack/nack 生命周期（at-least-once）+ _consume 的 prefetch 并发。
 
 不连真实 RabbitMQ：用 fake message/channel 复刻 aio_pika 的 message.process() 语义
-（正常退出 ack，抛异常 nack(requeue) 并 re-raise）。重点锁住改造后的两条不变量：
-  1. ack 持有到任务结束 —— 失败必须 nack 重投，不能丢消息。
-  2. 每条消息独立 task —— 多条消息的 dispatch 能真正并发，慢 LLM 不阻塞后续消费。
+（正常退出 ack，抛异常 nack(requeue) 并 re-raise）。重点锁住改造后的不变量：
+  1. 成功 ack；失败显式 republish（带 x-retry-count）后仍 ack 原消息。
+  2. 超过 worker_max_redeliveries → DLQ，不再重投。
+  3. 每条消息独立 task —— 多条消息的 dispatch 能真正并发。
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import pytest
 from app.core import langfuse as lf
 from app.core.config import settings
 from app.messaging import worker as worker_mod
-from app.messaging.tasks import encode_task
+from app.messaging.tasks import HEADER_RETRY_COUNT, encode_task
 
 
 class _FakeProcess:
@@ -37,8 +38,9 @@ class _FakeProcess:
 
 
 class _FakeMessage:
-    def __init__(self, body: bytes) -> None:
+    def __init__(self, body: bytes, *, headers: dict | None = None) -> None:
         self.body = body
+        self.headers = headers
         self.acked = False
         self.nack_requeue: bool | None = None
 
@@ -116,18 +118,74 @@ async def test_run_one_acks_on_success(monkeypatch) -> None:
     assert seen == ["send_verification_email"]
 
 
-async def test_run_one_nacks_and_reraises_on_failure(monkeypatch) -> None:
-    """任务抛异常 → nack(requeue=True) 重投，且异常继续上抛（at-least-once）。"""
+async def test_run_one_republishes_on_failure(monkeypatch) -> None:
+    """任务抛异常且未超限 → 带递增 retry 重投，原消息 ack（at-least-once）。"""
     msg = _FakeMessage(_body())
+    republished: list[tuple[str, int]] = []
 
     async def _boom(task: str, payload: dict) -> None:  # noqa: ARG001
         raise RuntimeError("boom")
 
+    async def _republish(message, task: str, *, retry_count: int) -> None:  # noqa: ARG001
+        republished.append((task, retry_count))
+
     monkeypatch.setattr(worker_mod, "dispatch_task", _boom)
-    with pytest.raises(RuntimeError, match="boom"):
-        await worker_mod._run_one(msg)
-    assert msg.acked is False
-    assert msg.nack_requeue is True  # 重投
+    monkeypatch.setattr(worker_mod, "_republish_task", _republish)
+    await worker_mod._run_one(msg)
+    assert msg.acked is True
+    assert msg.nack_requeue is None
+    assert republished == [("send_verification_email", 1)]
+
+
+async def test_run_one_poison_goes_to_dlq(monkeypatch) -> None:
+    """重试耗尽 → 写入 DLQ，不再 republish。"""
+    msg = _FakeMessage(
+        _body(),
+        headers={HEADER_RETRY_COUNT: settings.worker_max_redeliveries},
+    )
+    dlq: list[tuple[str, int]] = []
+    republished: list[object] = []
+
+    async def _boom(task: str, payload: dict) -> None:  # noqa: ARG001
+        raise RuntimeError("poison")
+
+    async def _to_dlq(message, task: str, *, retry_count: int, error: str) -> None:  # noqa: ARG001
+        dlq.append((task, retry_count))
+
+    async def _republish(*args, **kwargs) -> None:  # noqa: ARG001
+        republished.append(1)
+
+    monkeypatch.setattr(worker_mod, "dispatch_task", _boom)
+    monkeypatch.setattr(worker_mod, "_publish_to_dlq", _to_dlq)
+    monkeypatch.setattr(worker_mod, "_republish_task", _republish)
+    await worker_mod._run_one(msg)
+    assert msg.acked is True
+    assert dlq == [("send_verification_email", settings.worker_max_redeliveries)]
+    assert republished == []
+
+
+async def test_run_one_lease_busy_republishes_without_increment(monkeypatch) -> None:
+    """TaskLeaseBusy → 不递增计数重投。"""
+    from app.forge.runner import TaskLeaseBusy
+
+    msg = _FakeMessage(_body(), headers={HEADER_RETRY_COUNT: 2})
+    republished: list[int] = []
+
+    async def _busy(task: str, payload: dict) -> None:  # noqa: ARG001
+        raise TaskLeaseBusy()
+
+    async def _republish(message, task: str, *, retry_count: int) -> None:  # noqa: ARG001
+        republished.append(retry_count)
+
+    async def _fast_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(worker_mod, "dispatch_task", _busy)
+    monkeypatch.setattr(worker_mod, "_republish_task", _republish)
+    monkeypatch.setattr(worker_mod.asyncio, "sleep", _fast_sleep)
+    await worker_mod._run_one(msg)
+    assert msg.acked is True
+    assert republished == [2]
 
 
 async def test_consume_sets_prefetch_and_dispatches_concurrently(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- 消费侧用 x-retry-count 计数，超过 worker_max_redeliveries(默认5) 写入 gameforge.worker.dlq
- TaskLeaseBusy 不计入毒消息，原计数重投
- 避免无限 requeue 饿死 prefetch 槽位

## Test plan
- [x] pytest tests/test_worker_concurrency.py

Closes #56

Made with [Cursor](https://cursor.com)