### PR TITLE
fix(#58): HIL 等待超时自动释放并发额度

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,6 +67,8 @@ BUILDER_TIMEOUT_S=300
 DEFAULT_DAILY_TOKEN_LIMIT=500000
 DEFAULT_RATE_LIMIT_PER_MIN=30
 MAX_CONCURRENT_RUNS=3
+# HIL/暂停等待超时（秒）：默认 48h，超时后自动 FAILED 释放并发额度
+HIL_WAIT_TIMEOUT_S=172800
 # worker 进程内同时处理的任务数（RabbitMQ prefetch_count）；慢 LLM 不再阻塞消费。
 # 扩容再多开 worker 进程：docker compose up -d --scale worker=N（或设 WORKER_REPLICAS）
 MAX_CONCURRENT_TASKS=3

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,6 +79,8 @@ class Settings(BaseSettings):
     create_run_idempotency_ttl: int = 86_400
     max_concurrent_runs: int = 3  # 每用户同时进行中的 run 上限（docs/05）
     max_concurrent_tasks: int = 3  # worker 进程内同时处理的任务数（RabbitMQ prefetch_count）
+    # HIL / 用户暂停等待超时：PAUSED 超过此时长自动 FAILED，释放并发额度
+    hil_wait_timeout_s: int = 172_800  # 默认 48h
     max_versions_per_game: int = 20  # 版本保留上限（docs/04），超出删最旧
     max_drafts_per_user: int = 20  # 每用户草稿游戏数上限
     max_published_per_user: int = 50  # 每用户已发布游戏数上限

--- a/backend/app/messaging/handlers.py
+++ b/backend/app/messaging/handlers.py
@@ -109,11 +109,12 @@ async def dispatch_task(task: str, payload: dict) -> None:
         # 扫描定时任务（如游戏定时下架）
         case _ if task == TASK_SCAN_SCHEDULES:
             from app.core import db as dbmod
-            from app.scheduler.services import scan_scheduled
+            from app.scheduler.services import expire_stale_paused_runs, scan_scheduled
 
             # 创建数据库会话，执行定时扫描
             async with dbmod.SessionLocal() as s:
                 await scan_scheduled(s)
+                await expire_stale_paused_runs(s, _worker_redis())
         
         # 未知任务类型：抛出异常（Worker 会 nack 并重新入队）
         case _:

--- a/backend/app/messaging/worker.py
+++ b/backend/app/messaging/worker.py
@@ -69,16 +69,15 @@ def _worker_loop_exception_handler(
 async def _scheduler_loop() -> None:
     """
     定时任务调度循环（后台协程）。
-    
+
     功能：每分钟执行一次定时扫描
     用途：
         - 检查并处理到期的游戏下架任务（B8 功能）
-        - 类似 cron 的定时任务
-    
-    注意：这是一个独立的协程，和消息消费并行运行
+        - 回收超时仍 PAUSED 的 HIL/暂停 run，释放并发额度
     """
     from app.core import db as dbmod
-    from app.scheduler.services import scan_scheduled
+    from app.messaging.handlers import _worker_redis
+    from app.scheduler.services import expire_stale_paused_runs, scan_scheduled
 
     while True:
         await asyncio.sleep(60)  # 每分钟执行一次
@@ -89,6 +88,13 @@ async def _scheduler_loop() -> None:
                     log.info("scheduled take_down count=%s", n)
         except Exception:
             log.exception("scheduler scan failed")  # 出错时记录日志，不影响主循环
+        try:
+            async with dbmod.SessionLocal() as s:
+                n = await expire_stale_paused_runs(s, _worker_redis())
+                if n:
+                    log.info("hil wait timeout expired count=%s", n)
+        except Exception:
+            log.exception("hil wait timeout scan failed")
 
 
 async def _outbox_loop() -> None:

--- a/backend/app/scheduler/services.py
+++ b/backend/app/scheduler/services.py
@@ -1,14 +1,21 @@
-"""定时上下架扫描（B8）。"""
+"""定时上下架扫描（B8）+ HIL/暂停等待超时回收。"""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
+import redis.asyncio as redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.enums import GameStatus, Role
+from app.core.config import settings
+from app.enums import GameStatus, Role, RunStatus, WSEventType
+from app.forge import state as ckpt
+from app.forge.events import publish_event
+from app.forge.messages import add_message
+from app.messaging.outbox import cancel_run_tasks
 from app.models.game import Game
+from app.models.generation_run import GenerationRun
 from app.models.user import User
 from app.publish import services as publish_services
 
@@ -28,6 +35,62 @@ async def scan_scheduled(db: AsyncSession) -> int:
     if count:
         await db.commit()
     return count
+
+
+async def expire_stale_paused_runs(
+    db: AsyncSession, r: redis.Redis | None = None
+) -> int:
+    """将超过 hil_wait_timeout_s 仍处于 PAUSED 的 run 置为 FAILED，释放并发额度。
+
+    判定依据：status=paused 且 updated_at 早于 cutoff（暂停写入时会刷新 updated_at）。
+    """
+    cutoff = datetime.now(UTC) - timedelta(seconds=settings.hil_wait_timeout_s)
+    rows = (
+        await db.scalars(
+            select(GenerationRun).where(
+                GenerationRun.status == RunStatus.PAUSED.value,
+                GenerationRun.ended_at.is_(None),
+                GenerationRun.updated_at <= cutoff,
+            )
+        )
+    ).all()
+    if not rows:
+        return 0
+
+    now = datetime.now(UTC)
+    if (
+        settings.hil_wait_timeout_s >= 3600
+        and settings.hil_wait_timeout_s % 3600 == 0
+    ):
+        wait_label = f"{settings.hil_wait_timeout_s // 3600} 小时"
+    else:
+        wait_label = f"{settings.hil_wait_timeout_s} 秒"
+    msg = f"等待确认已超过 {wait_label}，本轮生成已自动结束以释放并发额度。"
+    for run in rows:
+        run.status = RunStatus.FAILED.value
+        run.ended_at = now
+        await add_message(
+            db,
+            game_id=run.game_id,
+            run_id=run.id,
+            user_id=run.user_id,
+            role="system",
+            kind="failed",
+            content=msg,
+            metadata={"code": "HIL_TIMEOUT"},
+            dedupe_key=f"{run.id}:failed:HIL_TIMEOUT",
+        )
+        await cancel_run_tasks(db, run.id)
+        if r is not None:
+            await ckpt.clear_state(r, run.id, db)
+            await r.delete(f"run:hitl:{run.id}")
+        await publish_event(
+            run.id,
+            WSEventType.ERROR,
+            {"code": "HIL_TIMEOUT", "message": msg, "fatal": True},
+        )
+    await db.commit()
+    return len(rows)
 
 
 async def _run_take_downs(db: AsyncSession, admin: User, now: datetime) -> int:

--- a/backend/tests/test_hil_timeout.py
+++ b/backend/tests/test_hil_timeout.py
@@ -1,0 +1,68 @@
+"""HIL / 用户暂停等待超时：过期 PAUSED run 自动 FAILED。"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.enums import RunStatus
+from app.models.game import Game
+from app.models.generation_run import GenerationRun
+from app.scheduler.services import expire_stale_paused_runs
+
+
+@pytest.mark.asyncio
+async def test_expire_stale_paused_runs(
+    verified_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    redis_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "hil_wait_timeout_s", 60)
+
+    game_resp = await verified_client.post(
+        "/api/v1/games", json={"title": "hil-timeout", "requirement": "stub"}
+    )
+    game_id = uuid.UUID(game_resp.json()["data"]["game_id"])
+    game = await db_session.get(Game, game_id)
+    assert game is not None
+
+    stale_id = uuid.uuid4()
+    fresh_id = uuid.uuid4()
+    old = datetime.now(UTC) - timedelta(hours=2)
+    recent = datetime.now(UTC)
+    db_session.add_all(
+        [
+            GenerationRun(
+                id=stale_id,
+                game_id=game_id,
+                user_id=game.owner_id,
+                requirement="stub",
+                status=RunStatus.PAUSED.value,
+                updated_at=old,
+            ),
+            GenerationRun(
+                id=fresh_id,
+                game_id=game_id,
+                user_id=game.owner_id,
+                requirement="stub",
+                status=RunStatus.PAUSED.value,
+                updated_at=recent,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    n = await expire_stale_paused_runs(db_session, redis_client)
+    assert n == 1
+
+    stale = await db_session.get(GenerationRun, stale_id)
+    fresh = await db_session.get(GenerationRun, fresh_id)
+    assert stale is not None and stale.status == RunStatus.FAILED.value
+    assert stale.ended_at is not None
+    assert fresh is not None and fresh.status == RunStatus.PAUSED.value


### PR DESCRIPTION
## Summary
- 周期扫描 PAUSED 且 updated_at 超过 HIL_WAIT_TIMEOUT_S（默认 48h）的 run
- 置 FAILED + 通知事件，清理 checkpoint / hitl 锁 / outbox，释放 max_concurrent_runs 额度

## Test plan
- [x] pytest tests/test_hil_timeout.py

Closes #58

Made with [Cursor](https://cursor.com)