### PR TITLE
feat: CodeQaLoop Playwright hard-gate with bounded verify-fix

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -84,6 +84,10 @@ MAX_PUBLISHED_PER_USER=50
 SYSTEM_DAILY_TOKEN_ALERT=5000000
 # 美术方向/详细设计稿的 LLM 尝试次数，耗尽后自动使用内置素材库
 ART_MAX_RETRIES=2
+# CodeQaLoop 总 attempt（含首次 generate）；默认 3
+CODE_QA_MAX_ATTEMPTS=3
+# QA 通过后是否截取游戏卡片封面（需 Worker 已装 Chromium）
+THUMBNAIL_ENABLED=true
 
 # langfuse（可选，trace 上报）
 LANGFUSE_PUBLIC_KEY=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -95,11 +95,14 @@ class Settings(BaseSettings):
     max_drafts_per_user: int = 20  # 每用户草稿游戏数上限
     max_published_per_user: int = 50  # 每用户已发布游戏数上限
     system_daily_token_alert: int = 5_000_000  # 系统日用量告警阈值
-    code_max_retries: int = 3  # code/qa 失败重试上限（docs/03）
-    qa_max_retries: int = 2  # QA 试玩失败回退 code 重试上限
+    # CodeQaLoop 总 attempt（含首次 generate）；infra/product/build 共用此预算。
+    code_qa_max_attempts: int = 3
+    # 已弃用：外层双预算由 code_qa_max_attempts 取代；保留字段避免旧 .env 炸导入。
+    code_max_retries: int = 3
+    qa_max_retries: int = 2
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
-    # 封面截图开关：QA 通过后用 Playwright 截当前版本画面当封面。
-    # 实际是否产出还依赖 PLAYTEST_USE_PLAYWRIGHT=1 且 worker 装了 chromium；否则降级无封面。
+    # 封面截图开关：QA 通过后用 Playwright 截当前 candidate 画面当封面。
+    # 需 worker 已安装 Chromium；Playwright 不可用时 playtest 记 infra 失败，无封面。
     thumbnail_enabled: bool = True
     models_cache_ttl_s: int = 600  # /models 短期缓存（docs/05）
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,12 +97,8 @@ class Settings(BaseSettings):
     system_daily_token_alert: int = 5_000_000  # 系统日用量告警阈值
     # CodeQaLoop 总 attempt（含首次 generate）；infra/product/build 共用此预算。
     code_qa_max_attempts: int = 3
-    # 已弃用：外层双预算由 code_qa_max_attempts 取代；保留字段避免旧 .env 炸导入。
-    code_max_retries: int = 3
-    qa_max_retries: int = 2
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
-    # 封面截图开关：QA 通过后用 Playwright 截当前 candidate 画面当封面。
-    # 需 worker 已安装 Chromium；Playwright 不可用时 playtest 记 infra 失败，无封面。
+    # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。
     thumbnail_enabled: bool = True
     models_cache_ttl_s: int = 600  # /models 短期缓存（docs/05）
 

--- a/backend/app/forge/code_candidate.py
+++ b/backend/app/forge/code_candidate.py
@@ -1,0 +1,44 @@
+"""Candidate 版本分配与 promote（仅 qa_ok 后提升为 current_version）。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game import Game
+from app.models.game_version import GameVersion
+
+CandidateKind = Literal["single-html", "project"]
+
+# 单次 attempt 内 LLM 输出解析小重试（与 CodeQaLoop 外层 attempt 正交）
+CODE_OUTPUT_PARSE_MAX_ATTEMPTS = 2
+
+
+@dataclass
+class CandidateResult:
+    """单次 generate/repair + build 的结果。"""
+
+    candidate_ready: bool
+    candidate_version: int | None = None
+    candidate_kind: CandidateKind | None = None
+    failure_kind: Literal["build"] | None = None
+    errors: list[str] = field(default_factory=list)
+    extra_state: dict[str, Any] = field(default_factory=dict)
+
+
+async def next_candidate_version(session: AsyncSession, game: Game) -> int:
+    """分配下一个版本号，不修改 game.current_version。"""
+    max_stored = await session.scalar(
+        select(func.max(GameVersion.version)).where(GameVersion.game_id == game.id)
+    )
+    return max(int(max_stored or 0), int(game.current_version or 0)) + 1
+
+
+def promote_candidate(game: Game, version: int) -> None:
+    """仅在 qa_ok 后调用：把通过试玩的 candidate 提升为交付版。"""
+    if version < 1:
+        raise ValueError("promote_candidate requires version >= 1")
+    game.current_version = version

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -1,0 +1,601 @@
+"""CodeQaLoop 节点执行体：generate/repair、playtest、diagnose（无 run.status 副作用）。"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from app.core.config import settings
+from app.enums import RunPhase, RunStatus, WSEventType
+from app.forge.assets.picker import format_assets_for_prompt
+from app.forge.build.code_output import ParsedCodeOutput
+from app.forge.build.integration import (
+    format_project_repair_input,
+    load_stored_project_source,
+    parse_llm_code_output,
+    run_project_build_loop,
+    with_design_routing,
+)
+from app.forge.build.routing import routing_from_design_doc, should_use_vite_pipeline
+from app.forge.code_candidate import next_candidate_version
+from app.forge.design_doc import coerce_design_doc, design_doc_to_text
+from app.forge.engine_router import engine_scaffold
+from app.forge.events import publish_event
+from app.forge.prompts import (
+    build_code_prompt,
+    build_project_prompt,
+    build_project_repair_prompt,
+    build_repair_prompt,
+)
+from app.forge.qa.diagnose import diagnose_playtest_failure
+from app.hosting import serve, store
+from app.models.game_version import GameVersion
+from app.sandbox import get_sandbox
+from app.sandbox.playtest import run_playtest, run_playtest_dist
+
+
+def _read_html(path: Any) -> str:
+    data = path.read_bytes()
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("gbk", errors="replace")
+
+
+def _mask_data_uris(source: str) -> tuple[str, dict[str, str]]:
+    replacements: dict[str, str] = {}
+
+    def replace(match: re.Match[str]) -> str:
+        token = f"__FORGE_DATA_URI_{len(replacements):04d}__"
+        replacements[token] = match.group(0)
+        return token
+
+    masked = re.sub(
+        r"data:[^;\"'\s]+;base64,[A-Za-z0-9+/=]+",
+        replace,
+        source,
+    )
+    return masked, replacements
+
+
+def _omit_data_uris(html: str) -> str:
+    return re.sub(
+        r"data:[^;\"'\s]+;base64,[A-Za-z0-9+/=]+",
+        "__DATA_URI_OMITTED_FOR_QA__",
+        html,
+    )[:60000]
+
+
+async def execute_code_or_repair(
+    ctx: Any,
+    state: dict[str, Any],
+    *,
+    streamed_llm: Any,
+    set_phase: Any,
+    check_ctrl: Any,
+    normalize_html: Any,
+    commit_project_build: Any,
+    run_finalized_exc: type[BaseException],
+) -> dict[str, Any]:
+    """单次 CodeQa attempt：generate 或 repair，成功则写入 candidate（不 promote）。"""
+    from app.games import services as game_services
+    from app.forge.assets.picker import PickedAsset
+    from app.forge.tracing import observe_phase
+
+    with observe_phase("code"):
+        design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
+        design_text = design_doc_to_text(design_doc)
+        entry_req = state.get("entry_requirement")
+        artifacts = state.get("artifacts") or []
+        art_direction = state.get("art_direction") or {}
+        assets_block = ""
+        if artifacts:
+            picked = [
+                PickedAsset(
+                    asset_id=a["asset_id"],
+                    filename=a["filename"],
+                    kind=a["kind"],
+                    description=a.get("description", a["filename"]),
+                    data_uri=a["data_uri"],
+                )
+                for a in artifacts
+            ]
+            assets_block = "\n\n" + format_assets_for_prompt(picked)
+
+        qa_errors = state.get("playtest_errors") or []
+        qa_diagnosis = state.get("qa_diagnosis") or ""
+        attempt = int(state.get("attempt") or 0) + 1
+
+        base_user_msg = f"【已确认设计稿 JSON】\n{design_text}"
+        if art_direction:
+            base_user_msg += (
+                "\n\n【已确认美术实现设计稿 JSON】\n"
+                + json.dumps(art_direction, ensure_ascii=False, indent=2)
+            )
+        if entry_req:
+            base_user_msg += f"\n\n【本次实现变更要求】\n{entry_req}"
+        generation_user_msg = base_user_msg
+        if assets_block:
+            generation_user_msg += f"\n\n【可用内置素材】{assets_block}"
+        scaffold = engine_scaffold(design_doc["engine"]["id"])
+        if scaffold:
+            generation_user_msg += (
+                "\n\n【所选引擎最小可运行骨架（参考起点，在此基础上实现设计稿，"
+                "不要照搬玩法，须替换为设计稿的实体/关卡/规则）】\n"
+                f"{scaffold}"
+            )
+
+        baseline_version = state.get("candidate_version")
+        if baseline_version is None and ctx.game.current_version > 0:
+            baseline_version = ctx.game.current_version
+        use_baseline = attempt > 1 or bool(entry_req)
+
+        previous_html = ""
+        if use_baseline and baseline_version and int(baseline_version) > 0:
+            current_path = store.index_path(ctx.game.id, int(baseline_version))
+            if current_path is not None and current_path.exists():
+                previous_html = _read_html(current_path)
+
+        await set_phase(ctx, RunPhase.CODE)
+        last_error = "; ".join(qa_errors)
+        design_routing = routing_from_design_doc(design_doc)
+        engine_id = design_doc["engine"]["id"]
+        use_vite = should_use_vite_pipeline(
+            design_routing, enabled=settings.build_pipeline_enabled
+        )
+
+        ctrl = await check_ctrl(ctx, design_doc)
+        if ctrl != "ok":
+            return {
+                "attempt": attempt,
+                "design_doc": design_doc,
+                "artifacts": artifacts,
+                "art_direction": art_direction,
+                "paused": ctrl == "pause",
+                "failed": ctrl == "cancel",
+                "candidate_ready": False,
+                "code_ok": False,
+            }
+
+        stored_project: dict[str, str] | None = None
+        if use_vite and previous_html and baseline_version:
+            loaded = await load_stored_project_source(ctx.game.id, int(baseline_version))
+            if loaded:
+                stored_project = loaded
+
+        raw_output = ""
+        data_uris: dict[str, str] = {}
+
+        if use_vite and stored_project:
+            parsed_retry = ParsedCodeOutput(
+                format="project",
+                files=stored_project,
+                routing=design_routing,
+            )
+            if last_error or qa_diagnosis:
+                repair_parts = [base_user_msg]
+                if last_error:
+                    repair_parts.append(f"【自动试玩/构建错误】\n{last_error}")
+                if qa_diagnosis:
+                    repair_parts.append(f"【QA 根因分析】\n{qa_diagnosis}")
+                repair_user = format_project_repair_input(
+                    "\n\n".join(repair_parts),
+                    parsed_retry,
+                    last_error or qa_diagnosis,
+                )
+                repair_raw = await streamed_llm(
+                    ctx,
+                    build_project_repair_prompt(
+                        engine_id, list(design_routing.dependencies)
+                    ),
+                    repair_user,
+                    "code",
+                    emit_delta=False,
+                )
+                parsed_retry = with_design_routing(
+                    parse_llm_code_output(repair_raw, engine_id=engine_id),
+                    design_routing,
+                )
+            raw_output = json.dumps(
+                {
+                    "format": "project",
+                    **design_routing.to_dict(),
+                    "files": parsed_retry.files,
+                },
+                ensure_ascii=False,
+            )
+        elif previous_html:
+            masked_html, data_uris = _mask_data_uris(previous_html)
+            repair_parts = [base_user_msg]
+            if last_error:
+                repair_parts.append(f"【自动试玩/构建错误】\n{last_error}")
+            if qa_diagnosis:
+                repair_parts.append(f"【QA 根因分析】\n{qa_diagnosis}")
+            repair_parts.append(f"【当前完整 index.html】\n{masked_html}")
+            user_msg = "\n\n".join(repair_parts)
+            system_prompt = build_repair_prompt(design_doc["engine"]["id"])
+            raw_output = await streamed_llm(
+                ctx, system_prompt, user_msg, "code", emit_delta=False
+            )
+        else:
+            user_msg = generation_user_msg
+            if last_error:
+                user_msg += f"\n\n【上次构建错误】\n{last_error}"
+            if use_vite:
+                system_prompt = build_project_prompt(
+                    engine_id,
+                    list(design_routing.dependencies),
+                )
+            else:
+                system_prompt = build_code_prompt(engine_id)
+            raw_output = await streamed_llm(
+                ctx, system_prompt, user_msg, "code", emit_delta=False
+            )
+
+        for token, data_uri in data_uris.items():
+            raw_output = raw_output.replace(token, data_uri)
+
+        if use_vite and (stored_project or not previous_html):
+            parsed = with_design_routing(
+                parse_llm_code_output(raw_output, engine_id=engine_id),
+                design_routing,
+            )
+            if parsed.format == "project":
+
+                async def _repair_project(
+                    current: ParsedCodeOutput, build_error: str
+                ) -> ParsedCodeOutput:
+                    repair_user = format_project_repair_input(
+                        base_user_msg, current, build_error
+                    )
+                    repair_raw = await streamed_llm(
+                        ctx,
+                        build_project_repair_prompt(
+                            engine_id, list(design_routing.dependencies)
+                        ),
+                        repair_user,
+                        "code",
+                        emit_delta=False,
+                    )
+                    return with_design_routing(
+                        parse_llm_code_output(repair_raw, engine_id=engine_id),
+                        design_routing,
+                    )
+
+                loop_result = await run_project_build_loop(
+                    parsed, repair_fn=_repair_project
+                )
+                if loop_result.ok and loop_result.pipeline_result:
+                    committed = await commit_project_build(
+                        ctx,
+                        project_result=loop_result.pipeline_result,
+                        design_doc=design_doc,
+                        artifacts=artifacts,
+                        art_direction=art_direction,
+                    )
+                    return {
+                        **committed,
+                        "attempt": attempt,
+                        "qa_ok": False,
+                        "exhausted": False,
+                    }
+                # Vite 内环耗尽：failure_kind=build，禁止降级 single-html
+                fail_logs = ""
+                if loop_result.pipeline_result:
+                    fail_logs = (
+                        loop_result.pipeline_result.error
+                        or loop_result.pipeline_result.logs
+                        or ""
+                    )
+                await publish_event(
+                    ctx.run.id,
+                    WSEventType.TOOL_CALL,
+                    {
+                        "phase": "code",
+                        "tool": "build_exhausted",
+                        "args": {
+                            "attempt": loop_result.build_attempts,
+                            "code_qa_attempt": attempt,
+                        },
+                        "status": "error",
+                        "summary": "Vite 构建耗尽，不降级 single-html",
+                    },
+                )
+                return {
+                    "attempt": attempt,
+                    "candidate_ready": False,
+                    "code_ok": False,
+                    "qa_ok": False,
+                    "failure_kind": "build",
+                    "playtest_errors": [
+                        fail_logs or last_error or "Vite 构建失败"
+                    ],
+                    "qa_diagnosis": qa_diagnosis,
+                    "design_doc": design_doc,
+                    "artifacts": artifacts,
+                    "art_direction": art_direction,
+                    "exhausted": False,
+                }
+            elif not previous_html and not stored_project:
+                await publish_event(
+                    ctx.run.id,
+                    WSEventType.TOOL_CALL,
+                    {
+                        "phase": "code",
+                        "tool": "build_format_mismatch",
+                        "args": {
+                            "expected": "project",
+                            "got": parsed.format,
+                            "errors": list(parsed.errors),
+                        },
+                        "status": "warn",
+                        "summary": (
+                            "build=vite 但 LLM 未返回 project JSON，"
+                            "本 attempt 按 build 失败处理"
+                        ),
+                    },
+                )
+                return {
+                    "attempt": attempt,
+                    "candidate_ready": False,
+                    "code_ok": False,
+                    "qa_ok": False,
+                    "failure_kind": "build",
+                    "playtest_errors": list(parsed.errors)
+                    or ["LLM 未返回 project JSON"],
+                    "qa_diagnosis": qa_diagnosis,
+                    "design_doc": design_doc,
+                    "artifacts": artifacts,
+                    "art_direction": art_direction,
+                    "exhausted": False,
+                }
+
+        html = normalize_html(raw_output)
+        result = await get_sandbox().execute(source={"index.html": html})
+        if result.ok:
+            await ctx.s.refresh(ctx.run)
+            if (
+                ctx.run.status != RunStatus.RUNNING.value
+                or ctx.run.ended_at is not None
+            ):
+                raise run_finalized_exc
+
+            version = await next_candidate_version(ctx.s, ctx.game)
+            artifact = f"{ctx.game.id}/{version}/index.html"
+            await store.write_artifact(ctx.game.id, version, result.files)
+            ctx.s.add(
+                GameVersion(
+                    game_id=ctx.game.id,
+                    version=version,
+                    artifact_path=artifact,
+                    design_doc=design_doc,
+                )
+            )
+            await ctx.s.commit()
+            await game_services.prune_old_versions(ctx.s, ctx.game)
+            await publish_event(
+                ctx.run.id,
+                WSEventType.BUILD_DONE,
+                {
+                    "version": version,
+                    "artifact_path": artifact,
+                    "preview_url": f"/draft/{ctx.game.id}/{version}",
+                },
+            )
+            return {
+                "attempt": attempt,
+                "code_ok": True,
+                "candidate_ready": True,
+                "candidate_version": version,
+                "candidate_kind": "single-html",
+                "qa_ok": False,
+                "exhausted": False,
+                "failure_kind": None,
+                "playtest_errors": [],
+                "qa_diagnosis": "",
+                "failed": False,
+                "design_doc": design_doc,
+                "artifacts": artifacts,
+                "art_direction": art_direction,
+            }
+
+        last_error = result.error or "构建失败"
+        await publish_event(
+            ctx.run.id,
+            WSEventType.TOOL_CALL,
+            {
+                "phase": "code",
+                "tool": "execute_code",
+                "args": {"attempt": attempt},
+                "status": "error",
+                "summary": last_error,
+            },
+        )
+        return {
+            "attempt": attempt,
+            "candidate_ready": False,
+            "code_ok": False,
+            "qa_ok": False,
+            "failure_kind": "build",
+            "playtest_errors": [last_error],
+            "qa_diagnosis": qa_diagnosis,
+            "design_doc": design_doc,
+            "artifacts": artifacts,
+            "art_direction": art_direction,
+            "exhausted": False,
+        }
+
+
+async def execute_playtest(
+    ctx: Any,
+    state: dict[str, Any],
+    *,
+    set_phase: Any,
+    save_thumbnail: Any,
+) -> dict[str, Any]:
+    """对当前 candidate 跑 B 档 playtest；不写 run.status。"""
+    from app.forge.tracing import observe_phase
+
+    with observe_phase("qa"):
+        design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
+        attempt = int(state.get("attempt") or 0)
+        candidate_version = state.get("candidate_version")
+        await set_phase(ctx, RunPhase.QA)
+
+        if not state.get("candidate_ready") or not candidate_version:
+            errors = ["无可用 candidate，跳过试玩"]
+            await publish_event(
+                ctx.run.id,
+                WSEventType.QA_REPORT,
+                {
+                    "passed": False,
+                    "issues": errors,
+                    "log_excerpt": "",
+                    "console_logs": [],
+                    "playtest_mode": "playwright",
+                    "attempt": attempt,
+                    "failure_kind": "build",
+                    "motion_signal": None,
+                },
+            )
+            return {
+                "qa_ok": False,
+                "candidate_ready": False,
+                "failure_kind": "build",
+                "playtest_errors": errors,
+                "console_logs": [],
+                "motion_signal": None,
+                "design_doc": design_doc,
+                "attempt": attempt,
+            }
+
+        version = int(candidate_version)
+        html_path = store.index_path(ctx.game.id, version)
+        html = ""
+        pt = None
+        if html_path is None or not html_path.exists():
+            errors = ["产物 index.html 不存在，无法试玩"]
+            result_ok = False
+            console_logs: list[str] = []
+            failure_kind: str | None = "build"
+            motion_signal = None
+        elif serve.is_project_artifact(ctx.game.id, version):
+            artifact_dir = store.artifact_dir(ctx.game.id, version)
+            pt = await run_playtest_dist(
+                artifact_dir, want_thumb=settings.thumbnail_enabled
+            )
+            result_ok = pt.ok
+            errors = pt.errors
+            console_logs = pt.console_logs
+            failure_kind = pt.failure_kind
+            motion_signal = pt.motion_signal
+            html_path = artifact_dir / "index.html"
+            html = _read_html(html_path) if html_path.is_file() else ""
+        else:
+            html = _read_html(html_path)
+            pt = await run_playtest(html, want_thumb=settings.thumbnail_enabled)
+            result_ok = pt.ok
+            errors = pt.errors
+            console_logs = pt.console_logs
+            failure_kind = pt.failure_kind
+            motion_signal = pt.motion_signal
+
+        if not result_ok and failure_kind is None:
+            failure_kind = "product"
+
+        log_excerpt = "\n".join(console_logs[:5]) if console_logs else ""
+        await publish_event(
+            ctx.run.id,
+            WSEventType.QA_REPORT,
+            {
+                "passed": result_ok,
+                "issues": [] if result_ok else errors,
+                "log_excerpt": log_excerpt,
+                "console_logs": console_logs,
+                "playtest_mode": "playwright",
+                "attempt": attempt,
+                "failure_kind": None if result_ok else failure_kind,
+                "motion_signal": motion_signal,
+            },
+        )
+
+        if result_ok:
+            if pt and pt.thumbnail:
+                await save_thumbnail(ctx.s, ctx.game, version, pt.thumbnail)
+            return {
+                "qa_ok": True,
+                "playtest_errors": [],
+                "console_logs": console_logs,
+                "failure_kind": None,
+                "motion_signal": motion_signal,
+                "qa_diagnosis": "",
+                "failed": False,
+                "design_doc": design_doc,
+                "attempt": attempt,
+                "candidate_version": version,
+                "candidate_ready": True,
+            }
+
+        return {
+            "qa_ok": False,
+            "playtest_errors": errors,
+            "console_logs": console_logs,
+            "failure_kind": failure_kind,
+            "motion_signal": motion_signal,
+            "failed": False,
+            "design_doc": design_doc,
+            "attempt": attempt,
+            "candidate_version": version,
+            "candidate_ready": True,
+            "artifacts": state.get("artifacts") or [],
+            "art_direction": state.get("art_direction") or {},
+            "_qa_html": html,
+        }
+
+
+async def execute_diagnose(
+    ctx: Any,
+    state: dict[str, Any],
+    *,
+    llm: Any,
+) -> dict[str, Any]:
+    """对 product/build 失败做诊断；infra 不得进入本节点（由子图路由保证）。"""
+    from app.forge.tracing import observe_phase
+
+    with observe_phase("qa"):
+        design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
+        errors = list(state.get("playtest_errors") or [])
+        console_logs = list(state.get("console_logs") or [])
+        html = state.get("_qa_html") or ""
+        if not html:
+            version = state.get("candidate_version")
+            if version:
+                path = store.index_path(ctx.game.id, int(version))
+                if path is not None and path.exists():
+                    html = _read_html(path)
+        qa_source = _omit_data_uris(html)
+
+        async def _call(system: str, user_msg: str) -> str:
+            return await llm(ctx, system, user_msg)
+
+        diagnosis = await diagnose_playtest_failure(
+            llm=_call,
+            design_doc=design_doc,
+            errors=errors,
+            console_logs=console_logs,
+            source_excerpt=qa_source,
+        )
+        return {
+            "qa_ok": False,
+            "qa_diagnosis": diagnosis,
+            "playtest_errors": errors,
+            "console_logs": console_logs,
+            "failure_kind": state.get("failure_kind") or "product",
+            "design_doc": design_doc,
+            "artifacts": state.get("artifacts") or [],
+            "art_direction": state.get("art_direction") or {},
+            "candidate_ready": False,
+            "attempt": state.get("attempt"),
+            "candidate_version": state.get("candidate_version"),
+        }

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -79,9 +79,9 @@ async def execute_code_or_repair(
     run_finalized_exc: type[BaseException],
 ) -> dict[str, Any]:
     """单次 CodeQa attempt：generate 或 repair，成功则写入 candidate（不 promote）。"""
-    from app.games import services as game_services
     from app.forge.assets.picker import PickedAsset
     from app.forge.tracing import observe_phase
+    from app.games import services as game_services
 
     with observe_phase("code"):
         design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -26,16 +26,7 @@ from app.enums import RunPhase, RunStatus, WSEventType
 from app.forge import control as run_ctrl
 from app.forge import state as ckpt
 from app.forge.art_direction import parse_art_detail, parse_art_options
-from app.forge.assets.picker import asset_pick, format_assets_for_prompt
-from app.forge.build.code_output import ParsedCodeOutput
-from app.forge.build.integration import (
-    format_project_repair_input,
-    load_stored_project_source,
-    parse_llm_code_output,
-    run_project_build_loop,
-    with_design_routing,
-)
-from app.forge.build.routing import routing_from_design_doc, should_use_vite_pipeline
+from app.forge.assets.picker import asset_pick
 from app.forge.code_candidate import next_candidate_version, promote_candidate
 from app.forge.design_doc import (
     coerce_design_doc,
@@ -43,7 +34,6 @@ from app.forge.design_doc import (
     parse_design_doc,
     validate_design_doc,
 )
-from app.forge.engine_router import engine_scaffold
 from app.forge.events import publish_event
 from app.forge.guard import ContentAttacked, run_streamed_llm
 from app.forge.messages import add_message, design_message_content, stable_design_key
@@ -54,21 +44,16 @@ from app.forge.prompts import (
     ART_OPTIONS_REVISE_PROMPT,
     PLAN_PROMPT,
     PLAN_REVISE_PROMPT,
-    build_code_prompt,
-    build_project_prompt,
-    build_project_repair_prompt,
-    build_repair_prompt,
 )
-from app.forge.qa.diagnose import diagnose_playtest_failure
 from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
 from app.forge.tracing import observe_phase, observe_run
 from app.hosting import preview_token as preview_token_svc
-from app.hosting import serve, store
+from app.hosting import store
 from app.llm import client as llm_client
 from app.models.game import Game
 from app.models.game_version import GameVersion
 from app.models.generation_run import GenerationRun
-from app.sandbox import get_sandbox
+
 # run_playtest 由 code_qa_exec 调用；此处保留 re-export 供旧 monkeypatch 路径兼容
 from app.sandbox.playtest import run_playtest, run_playtest_dist  # noqa: F401
 

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -1,7 +1,7 @@
-"""生成主图：plan→确认→美术方向→确认→详细美术稿→code↔qa→done。
+"""生成主图：plan→确认→美术方向→确认→详细美术稿→CodeQaLoop→done。
 
 支持：策划修订与美术方向重做、节点间 pause/cancel、美术失败素材兜底、
-code/qa 自动诊断重试，以及 skills 约定注入。
+CodeQaLoop 有界 code/playtest/diagnose，以及 skills 约定注入。
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ from app.forge.build.integration import (
     with_design_routing,
 )
 from app.forge.build.routing import routing_from_design_doc, should_use_vite_pipeline
+from app.forge.code_candidate import next_candidate_version, promote_candidate
 from app.forge.design_doc import (
     coerce_design_doc,
     design_doc_to_text,
@@ -53,12 +54,13 @@ from app.forge.prompts import (
     ART_OPTIONS_REVISE_PROMPT,
     PLAN_PROMPT,
     PLAN_REVISE_PROMPT,
-    QA_PROMPT,
     build_code_prompt,
     build_project_prompt,
     build_project_repair_prompt,
     build_repair_prompt,
 )
+from app.forge.qa.diagnose import diagnose_playtest_failure
+from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
 from app.forge.tracing import observe_phase, observe_run
 from app.hosting import preview_token as preview_token_svc
 from app.hosting import serve, store
@@ -67,7 +69,8 @@ from app.models.game import Game
 from app.models.game_version import GameVersion
 from app.models.generation_run import GenerationRun
 from app.sandbox import get_sandbox
-from app.sandbox.playtest import run_playtest, run_playtest_dist
+# run_playtest 由 code_qa_exec 调用；此处保留 re-export 供旧 monkeypatch 路径兼容
+from app.sandbox.playtest import run_playtest, run_playtest_dist  # noqa: F401
 
 PLAN_MAX_ATTEMPTS = 3
 
@@ -127,15 +130,14 @@ async def _commit_project_build(
     artifacts: list[Any],
     art_direction: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    """Vite 多文件构建成功后落盘、发事件并返回 code_node 状态。"""
+    """Vite 多文件构建成功后落盘为 candidate（不 promote current_version）。"""
     from app.games import services as game_services
 
     await ctx.s.refresh(ctx.run)
     if ctx.run.status != RunStatus.RUNNING.value or ctx.run.ended_at is not None:
         raise RunFinalized
 
-    ctx.game.current_version += 1
-    version = ctx.game.current_version
+    version = await next_candidate_version(ctx.s, ctx.game)
     artifact = f"{ctx.game.id}/{version}/index.html"
     await store.write_version_layers(
         ctx.game.id,
@@ -176,6 +178,10 @@ async def _commit_project_build(
         "artifacts": artifacts,
         "art_direction": art_direction,
         "code_ok": True,
+        "candidate_ready": True,
+        "candidate_version": version,
+        "candidate_kind": "project",
+        "failure_kind": None,
         "playtest_errors": [],
         "qa_diagnosis": "",
     }
@@ -235,10 +241,17 @@ class ForgeState(TypedDict, total=False):
     artifacts: list[dict[str, str]]
     code_ok: bool
     qa_ok: bool
-    qa_attempt: int
-    qa_retry: bool
+    attempt: int
+    exhausted: bool
+    candidate_version: int | None
+    candidate_ready: bool
+    candidate_kind: str | None
     playtest_errors: list[str]
+    console_logs: list[str]
+    failure_kind: str | None
+    motion_signal: str | None
     qa_diagnosis: str
+    code_qa_reset: bool
     failed: bool
     error: str
     hitl_stop: bool
@@ -454,11 +467,16 @@ def _build_graph(ctx: _Ctx) -> Any:
     async def route_start(
         state: ForgeState,
     ) -> Literal[
-        "plan", "revise_plan", "art_options", "revise_art_options", "art_detail", "code"
+        "plan",
+        "revise_plan",
+        "art_options",
+        "revise_art_options",
+        "art_detail",
+        "code_qa_loop",
     ]:
         if not state.get("resume"):
             if state.get("entry_phase") == "code":
-                return "code"
+                return "code_qa_loop"
             return "plan"
 
         st = await ckpt.load_state(ctx.r, ctx.run.id, ctx.s) or {}
@@ -471,10 +489,11 @@ def _build_graph(ctx: _Ctx) -> Any:
             if state.get("decision") == "modify" and state.get("modify_text"):
                 return "revise_art_options"
             return "art_detail"
-        # 兼容升级前已经停在 sandbox/qa HITL 的历史任务；新任务在策划确认后
-        # 不再请求人工介入，而是在预算内自动修复，耗尽后直接报告失败。
-        if st.get("phase") in ("sandbox_failed", "qa_failed", "user_pause"):
-            return "code" if st.get("phase") != "user_pause" else "art_options"
+        # qa_failed / sandbox_failed：HITL 恢复后重新进入 CodeQaLoop（attempt 重置）
+        if st.get("phase") in ("sandbox_failed", "qa_failed"):
+            return "code_qa_loop"
+        if st.get("phase") == "user_pause":
+            return "art_options"
         return "art_options"
 
     async def plan_node(state: ForgeState) -> dict:
@@ -777,472 +796,97 @@ def _build_graph(ctx: _Ctx) -> Any:
                     )
             return await fallback_art(design_doc, last_error)
 
-    async def code_node(state: ForgeState) -> dict:
-        with observe_phase("code"):
-            design_doc = coerce_design_doc(
-                state.get("design_doc") or {}, ctx.game.title
-            )
-            design_text = design_doc_to_text(design_doc)
-            entry_req = state.get("entry_requirement")
-            assets_block = ""
-            artifacts = state.get("artifacts") or []
-            art_direction = state.get("art_direction") or {}
-            if artifacts:
-                from app.forge.assets.picker import PickedAsset
+    async def code_or_repair_node(state: ForgeState) -> dict:
+        from app.forge import code_qa_exec as cqe
 
-                picked = [
-                    PickedAsset(
-                        asset_id=a["asset_id"],
-                        filename=a["filename"],
-                        kind=a["kind"],
-                        description=a.get("description", a["filename"]),
-                        data_uri=a["data_uri"],
-                    )
-                    for a in artifacts
-                ]
-                assets_block = "\n\n" + format_assets_for_prompt(picked)
+        return await cqe.execute_code_or_repair(
+            ctx,
+            dict(state),
+            streamed_llm=_streamed_llm_or_fallback,
+            set_phase=_set_phase,
+            check_ctrl=_check_ctrl,
+            normalize_html=normalize_html,
+            commit_project_build=_commit_project_build,
+            run_finalized_exc=RunFinalized,
+        )
 
-            qa_errors = state.get("playtest_errors") or []
-            qa_diagnosis = state.get("qa_diagnosis") or ""
-            base_user_msg = f"【已确认设计稿 JSON】\n{design_text}"
-            if art_direction:
-                base_user_msg += (
-                    "\n\n【已确认美术实现设计稿 JSON】\n"
-                    + json.dumps(art_direction, ensure_ascii=False, indent=2)
-                )
-            if entry_req:
-                base_user_msg += f"\n\n【本次实现变更要求】\n{entry_req}"
-            generation_user_msg = base_user_msg
-            if assets_block:
-                generation_user_msg += f"\n\n【可用内置素材】{assets_block}"
-            # 引擎最小骨架作为参考起点（仅首次生成；修复分支走 previous_html 基线）。
-            # canvas 无骨架；phaser3/pixijs 注入以降低 Scene/Application 结构出错率。
-            scaffold = engine_scaffold(design_doc["engine"]["id"])
-            if scaffold:
-                generation_user_msg += (
-                    "\n\n【所选引擎最小可运行骨架（参考起点，在此基础上实现设计稿，"
-                    "不要照搬玩法，须替换为设计稿的实体/关卡/规则）】\n"
-                    f"{scaffold}"
-                )
+    async def playtest_node(state: ForgeState) -> dict:
+        from app.forge import code_qa_exec as cqe
 
-            # QA 失败或对已有版本做修改时，以当前可运行版本为修复基线，避免每次
-            # 都从零生成造成已通过功能回归。首次构建则仍走完整生成提示词。
-            previous_html = ""
-            if (qa_errors or entry_req) and ctx.game.current_version > 0:
-                current_path = store.index_path(
-                    ctx.game.id, ctx.game.current_version
-                )
-                if current_path is not None and current_path.exists():
-                    previous_html = _read_html(current_path)
+        return await cqe.execute_playtest(
+            ctx,
+            dict(state),
+            set_phase=_set_phase,
+            save_thumbnail=_save_thumbnail,
+        )
 
-            def mask_data_uris(source: str) -> tuple[str, dict[str, str]]:
-                replacements: dict[str, str] = {}
+    async def diagnose_node(state: ForgeState) -> dict:
+        from app.forge import code_qa_exec as cqe
 
-                def replace(match: re.Match[str]) -> str:
-                    token = f"__FORGE_DATA_URI_{len(replacements):04d}__"
-                    replacements[token] = match.group(0)
-                    return token
+        return await cqe.execute_diagnose(ctx, dict(state), llm=_llm)
 
-                masked = re.sub(
-                    r"data:[^;\"'\s]+;base64,[A-Za-z0-9+/=]+",
-                    replace,
-                    source,
-                )
-                return masked, replacements
+    async def code_qa_loop_node(state: ForgeState) -> dict:
+        """主图包装：调用子图；ok 则 promote，exhausted 则 PAUSED HITL。"""
+        design_doc = coerce_design_doc(
+            state.get("design_doc") or {}, ctx.game.title
+        )
+        loop_in: dict[str, Any] = {
+            "design_doc": design_doc,
+            "artifacts": state.get("artifacts") or [],
+            "art_direction": state.get("art_direction") or {},
+            "entry_requirement": state.get("entry_requirement"),
+            "candidate_version": state.get("candidate_version"),
+            "qa_diagnosis": state.get("qa_diagnosis") or "",
+            "playtest_errors": state.get("playtest_errors") or [],
+        }
+        if state.get("code_qa_reset"):
+            loop_in["attempt"] = 0
+            loop_in["qa_diagnosis"] = ""
+            loop_in["playtest_errors"] = []
+            loop_in["candidate_ready"] = False
+            loop_in["failure_kind"] = None
+            loop_in["code_qa_reset"] = False
+        else:
+            loop_in["attempt"] = int(state.get("attempt") or 0)
 
-            await _set_phase(ctx, RunPhase.CODE)
-            last_error = "; ".join(qa_errors)
-            design_routing = routing_from_design_doc(design_doc)
-            engine_id = design_doc["engine"]["id"]
-            use_vite = should_use_vite_pipeline(
-                design_routing, enabled=settings.build_pipeline_enabled
-            )
-            for attempt in range(1, settings.code_max_retries + 1):
-                ctrl = await _check_ctrl(ctx, design_doc)
-                if ctrl != "ok":
-                    return {
-                        "design_doc": design_doc,
-                        "artifacts": artifacts,
-                        "art_direction": art_direction,
-                        "paused": ctrl == "pause",
-                        "failed": ctrl == "cancel",
-                        "code_ok": False,
-                    }
+        subgraph = build_code_qa_loop(
+            code_or_repair=code_or_repair_node,
+            playtest=playtest_node,
+            diagnose=diagnose_node,
+        )
+        result = await subgraph.ainvoke(loop_in)
 
-                stored_project: dict[str, str] | None = None
-                if use_vite and previous_html and ctx.game.current_version > 0:
-                    loaded = await load_stored_project_source(
-                        ctx.game.id, ctx.game.current_version
-                    )
-                    if loaded:
-                        stored_project = loaded
-
-                raw_output = ""
-                data_uris: dict[str, str] = {}
-
-                if use_vite and stored_project:
-                    parsed_retry = ParsedCodeOutput(
-                        format="project",
-                        files=stored_project,
-                        routing=design_routing,
-                    )
-                    if last_error or qa_diagnosis:
-                        repair_parts = [base_user_msg]
-                        if last_error:
-                            repair_parts.append(f"【自动试玩/构建错误】\n{last_error}")
-                        if qa_diagnosis:
-                            repair_parts.append(f"【QA 根因分析】\n{qa_diagnosis}")
-                        repair_user = format_project_repair_input(
-                            "\n\n".join(repair_parts),
-                            parsed_retry,
-                            last_error or qa_diagnosis,
-                        )
-                        repair_raw = await _streamed_llm_or_fallback(
-                            ctx,
-                            build_project_repair_prompt(
-                                engine_id, list(design_routing.dependencies)
-                            ),
-                            repair_user,
-                            "code",
-                            emit_delta=False,
-                        )
-                        parsed_retry = with_design_routing(
-                            parse_llm_code_output(repair_raw, engine_id=engine_id),
-                            design_routing,
-                        )
-                    raw_output = json.dumps(
-                        {
-                            "format": "project",
-                            **design_routing.to_dict(),
-                            "files": parsed_retry.files,
-                        },
-                        ensure_ascii=False,
-                    )
-                elif previous_html:
-                    masked_html, data_uris = mask_data_uris(previous_html)
-                    repair_parts = [base_user_msg]
-                    if last_error:
-                        repair_parts.append(f"【自动试玩/构建错误】\n{last_error}")
-                    if qa_diagnosis:
-                        repair_parts.append(f"【QA 根因分析】\n{qa_diagnosis}")
-                    repair_parts.append(
-                        f"【当前完整 index.html】\n{masked_html}"
-                    )
-                    user_msg = "\n\n".join(repair_parts)
-                    system_prompt = build_repair_prompt(design_doc["engine"]["id"])
-                    raw_output = await _streamed_llm_or_fallback(
-                        ctx, system_prompt, user_msg, "code", emit_delta=False
-                    )
-                else:
-                    user_msg = generation_user_msg
-                    if last_error:
-                        user_msg += f"\n\n【上次构建错误】\n{last_error}"
-                    if use_vite:
-                        system_prompt = build_project_prompt(
-                            engine_id,
-                            list(design_routing.dependencies),
-                        )
-                    else:
-                        system_prompt = build_code_prompt(engine_id)
-                    raw_output = await _streamed_llm_or_fallback(
-                        ctx, system_prompt, user_msg, "code", emit_delta=False
-                    )
-
-                for token, data_uri in data_uris.items():
-                    raw_output = raw_output.replace(token, data_uri)
-
-                if use_vite and (stored_project or not previous_html):
-                    parsed = with_design_routing(
-                        parse_llm_code_output(raw_output, engine_id=engine_id),
-                        design_routing,
-                    )
-                    if parsed.format == "project":
-
-                        async def _repair_project(
-                            current: ParsedCodeOutput, build_error: str
-                        ) -> ParsedCodeOutput:
-                            repair_user = format_project_repair_input(
-                                base_user_msg, current, build_error
-                            )
-                            repair_raw = await _streamed_llm_or_fallback(
-                                ctx,
-                                build_project_repair_prompt(
-                                    engine_id, list(design_routing.dependencies)
-                                ),
-                                repair_user,
-                                "code",
-                                emit_delta=False,
-                            )
-                            return with_design_routing(
-                                parse_llm_code_output(repair_raw, engine_id=engine_id),
-                                design_routing,
-                            )
-
-                        loop_result = await run_project_build_loop(
-                            parsed, repair_fn=_repair_project
-                        )
-                        if loop_result.ok and loop_result.pipeline_result:
-                            return await _commit_project_build(
-                                ctx,
-                                project_result=loop_result.pipeline_result,
-                                design_doc=design_doc,
-                                artifacts=artifacts,
-                                art_direction=art_direction,
-                            )
-                        if loop_result.fallback_required:
-                            fail_logs = ""
-                            if loop_result.pipeline_result:
-                                fail_logs = (
-                                    loop_result.pipeline_result.error
-                                    or loop_result.pipeline_result.logs
-                                    or ""
-                                )
-                            await publish_event(
-                                ctx.run.id,
-                                WSEventType.TOOL_CALL,
-                                {
-                                    "phase": "code",
-                                    "tool": "build_fallback",
-                                    "args": {
-                                        "attempt": loop_result.build_attempts,
-                                        "from": "vite",
-                                        "to": "single-html",
-                                    },
-                                    "status": "warn",
-                                    "summary": "Vite 构建失败，降级 single-html",
-                                },
-                            )
-                            fallback_msg = (
-                                f"{base_user_msg}\n\n"
-                                f"【Vite 多文件构建 {loop_result.build_attempts} 次失败，"
-                                "请按设计稿重新交付 single-html 可运行版本】\n"
-                                f"{fail_logs or last_error}"
-                            )
-                            raw_output = await _streamed_llm_or_fallback(
-                                ctx,
-                                build_code_prompt(engine_id),
-                                fallback_msg,
-                                "code",
-                                emit_delta=False,
-                            )
-                    elif not previous_html and not stored_project:
-                        await publish_event(
-                            ctx.run.id,
-                            WSEventType.TOOL_CALL,
-                            {
-                                "phase": "code",
-                                "tool": "build_format_mismatch",
-                                "args": {
-                                    "expected": "project",
-                                    "got": parsed.format,
-                                    "errors": list(parsed.errors),
-                                },
-                                "status": "warn",
-                                "summary": (
-                                    "build=vite 但 LLM 未返回 project JSON，"
-                                    "降级 single-html"
-                                ),
-                            },
-                        )
-
-                html = normalize_html(raw_output)
-                result = await get_sandbox().execute(source={"index.html": html})
-                if result.ok:
-                    from app.games import services as game_services
-
-                    await ctx.s.refresh(ctx.run)
-                    if (
-                        ctx.run.status != RunStatus.RUNNING.value
-                        or ctx.run.ended_at is not None
-                    ):
-                        raise RunFinalized
-
-                    ctx.game.current_version += 1
-                    version = ctx.game.current_version
-                    artifact = f"{ctx.game.id}/{version}/index.html"
-                    await store.write_artifact(ctx.game.id, version, result.files)
-                    ctx.s.add(
-                        GameVersion(
-                            game_id=ctx.game.id,
-                            version=version,
-                            artifact_path=artifact,
-                            design_doc=design_doc,
-                        )
-                    )
-                    await ctx.s.commit()
-                    await game_services.prune_old_versions(ctx.s, ctx.game)
-                    await publish_event(
-                        ctx.run.id,
-                        WSEventType.BUILD_DONE,
-                        {
-                            "version": version,
-                            "artifact_path": artifact,
-                            "preview_url": f"/draft/{ctx.game.id}/{version}",
-                        },
-                    )
-                    return {
-                        "code_ok": True,
-                        "qa_ok": False,
-                        "qa_retry": False,
-                        "playtest_errors": [],
-                        "qa_diagnosis": "",
-                        "failed": False,
-                        "design_doc": design_doc,
-                        "artifacts": artifacts,
-                        "art_direction": art_direction,
-                    }
-
-                last_error = result.error or "构建失败"
-                previous_html = html
-                await publish_event(
-                    ctx.run.id,
-                    WSEventType.TOOL_CALL,
-                    {
-                        "phase": "code",
-                        "tool": "execute_code",
-                        "args": {"attempt": attempt},
-                        "status": "error",
-                        "summary": last_error,
-                    },
-                )
-
-            # 策划确认后不再增加人工确认点；自动修复预算耗尽即明确结束任务。
-            await ckpt.save_state(
-                ctx.r,
-                ctx.run.id,
-                {
-                    "phase": "sandbox_failed",
-                    "design_doc": design_doc,
-                    "error": last_error,
-                },
-                ctx.s,
-            )
-            await _fail(
-                ctx,
-                f"代码构建自动修复 {settings.code_max_retries} 次后仍失败：{last_error}",
-                code="CODE_RETRY_EXHAUSTED",
-            )
+        if result.get("paused") or result.get("failed") or result.get("hitl_stop"):
             return {
-                "code_ok": False,
-                "failed": True,
-                "design_doc": design_doc,
-                "error": last_error,
-                "artifacts": artifacts,
+                **result,
+                "design_doc": result.get("design_doc") or design_doc,
+                "code_qa_reset": False,
             }
 
-    async def qa_node(state: ForgeState) -> dict:
-        with observe_phase("qa"):
-            design_doc = coerce_design_doc(
-                state.get("design_doc") or {}, ctx.game.title
-            )
-            qa_attempt = state.get("qa_attempt", 0) + 1
-            await _set_phase(ctx, RunPhase.QA)
-
-            html_path = store.index_path(ctx.game.id, ctx.game.current_version)
-            html = ""
-            pt = None
-            if html_path is None or not html_path.exists():
-                errors = ["产物 index.html 不存在，无法试玩"]
-                result_ok = False
-                console_logs: list[str] = []
-            elif serve.is_project_artifact(ctx.game.id, ctx.game.current_version):
-                artifact_dir = store.artifact_dir(ctx.game.id, ctx.game.current_version)
-                pt = await run_playtest_dist(
-                    artifact_dir, want_thumb=settings.thumbnail_enabled
-                )
-                result_ok = pt.ok
-                errors = pt.errors
-                console_logs = pt.console_logs
-                html_path = artifact_dir / "index.html"
-                html = _read_html(html_path) if html_path.is_file() else ""
-            else:
-                html = _read_html(html_path)
-                pt = await run_playtest(html, want_thumb=settings.thumbnail_enabled)
-                result_ok = pt.ok
-                errors = pt.errors
-                console_logs = pt.console_logs
-
-            log_excerpt = "\n".join(console_logs[:5]) if console_logs else ""
-            await publish_event(
-                ctx.run.id,
-                WSEventType.QA_REPORT,
-                {
-                    "passed": result_ok,
-                    "issues": [] if result_ok else errors,
-                    "log_excerpt": log_excerpt,
-                    "console_logs": console_logs,
-                    "playtest_mode": "sandbox",
-                },
-            )
-
-            if result_ok:
-                # 自动试玩已给出确定性通过结果，无需再调用 LLM 做无效摘要。
-                # 通过分支顺带把截好的封面落盘（复用刚才浏览器会话截的图）。
-                if pt and pt.thumbnail:
-                    await _save_thumbnail(
-                        ctx.s, ctx.game, ctx.game.current_version, pt.thumbnail
-                    )
-                return {
-                    "qa_ok": True,
-                    "qa_retry": False,
-                    "playtest_errors": [],
-                    "qa_diagnosis": "",
-                    "failed": False,
-                    "design_doc": design_doc,
-                    "qa_attempt": qa_attempt,
-                }
-
-            if qa_attempt < settings.qa_max_retries:
-                qa_source = re.sub(
-                    r"data:[^;\"'\s]+;base64,[A-Za-z0-9+/=]+",
-                    "__DATA_URI_OMITTED_FOR_QA__",
-                    html,
-                )[:60000]
-                diagnosis_input = (
-                    "【已确认设计稿 JSON】\n"
-                    f"{design_doc_to_text(design_doc)}\n\n"
-                    "【自动试玩错误】\n"
-                    f"{json.dumps(errors, ensure_ascii=False, indent=2)}\n\n"
-                    "【控制台日志】\n"
-                    f"{chr(10).join(console_logs[:20])[:6000] or '无控制台日志'}\n\n"
-                    "【当前 HTML 源码（data URI 已省略）】\n"
-                    f"{qa_source or '源码不可用'}"
-                )
-                try:
-                    diagnosis = await _llm(ctx, QA_PROMPT, diagnosis_input)
-                except Exception:
-                    # QA 诊断是修复增强项，不应因诊断模型偶发失败而阻断确定性的
-                    # 自动重试。降级为包含原始证据的结构化诊断继续修复。
-                    diagnosis = json.dumps(
-                        {
-                            "summary": "QA 诊断调用失败，依据自动试玩原始错误继续修复",
-                            "root_causes": errors,
-                            "required_fixes": [
-                                {
-                                    "priority": "P0",
-                                    "location": "根据自动试玩错误定位",
-                                    "change": "逐项修复错误并保持完整游戏状态闭环",
-                                    "expected_result": "自动试玩不再出现上述错误",
-                                }
-                            ],
-                            "regression_checks": [
-                                "重新验证菜单、核心操作、关卡推进、胜负与重开"
-                            ],
-                        },
-                        ensure_ascii=False,
-                    )
+        if result.get("qa_ok"):
+            version = result.get("candidate_version")
+            if not version:
                 return {
                     "qa_ok": False,
-                    "qa_attempt": qa_attempt,
-                    "qa_retry": True,
-                    "playtest_errors": errors,
-                    "qa_diagnosis": diagnosis,
-                    "failed": False,
+                    "exhausted": True,
+                    "paused": True,
+                    "hitl_stop": True,
                     "design_doc": design_doc,
-                    "artifacts": state.get("artifacts") or [],
-                    "art_direction": state.get("art_direction") or {},
+                    "playtest_errors": ["qa_ok 但缺少 candidate_version"],
                 }
+            promote_candidate(ctx.game, int(version))
+            await ctx.s.commit()
+            return {
+                **result,
+                "qa_ok": True,
+                "exhausted": False,
+                "code_ok": True,
+                "code_qa_reset": False,
+                "design_doc": design_doc,
+            }
 
+        if result.get("exhausted"):
+            errors = list(result.get("playtest_errors") or [])
             await ckpt.save_state(
                 ctx.r,
                 ctx.run.id,
@@ -1250,23 +894,41 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "phase": "qa_failed",
                     "design_doc": design_doc,
                     "qa": "; ".join(errors),
+                    "code_qa_reset": True,
+                    "art_direction": result.get("art_direction")
+                    or state.get("art_direction")
+                    or {},
+                    "artifacts": result.get("artifacts")
+                    or state.get("artifacts")
+                    or [],
                 },
                 ctx.s,
             )
-            await _fail(
+            await _pause_hitl(
                 ctx,
-                f"自动试玩修复 {settings.qa_max_retries} 轮后仍未通过：{'; '.join(errors)}",
-                code="QA_RETRY_EXHAUSTED",
+                "qa_failed",
+                design_doc,
+                extra={
+                    "issues": errors,
+                    "attempt": result.get("attempt"),
+                    "failure_kind": result.get("failure_kind"),
+                },
             )
             return {
+                **result,
                 "qa_ok": False,
-                "qa_retry": False,
-                "failed": True,
+                "exhausted": True,
+                "paused": True,
+                "hitl_stop": True,
                 "design_doc": design_doc,
-                "qa_attempt": qa_attempt,
-                "playtest_errors": errors,
-                "qa_diagnosis": state.get("qa_diagnosis") or "",
+                "code_qa_reset": False,
             }
+
+        return {
+            **result,
+            "design_doc": result.get("design_doc") or design_doc,
+            "code_qa_reset": False,
+        }
 
     async def done_node(state: ForgeState) -> dict:
         with observe_phase("done"):
@@ -1309,21 +971,16 @@ def _build_graph(ctx: _Ctx) -> Any:
     def after_plan(state: ForgeState) -> Literal["__end__"]:
         return END
 
-    def after_art(state: ForgeState) -> Literal["code", "__end__"]:
+    def after_art(state: ForgeState) -> Literal["code_qa_loop", "__end__"]:
         if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
             return END
-        return "code"
+        return "code_qa_loop"
 
-    def after_code(state: ForgeState) -> Literal["qa", "__end__"]:
-        if state.get("code_ok"):
-            return "qa"
-        return END
-
-    def after_qa(state: ForgeState) -> Literal["done", "code", "__end__"]:
+    def after_code_qa(
+        state: ForgeState,
+    ) -> Literal["done", "__end__"]:
         if state.get("qa_ok"):
             return "done"
-        if state.get("qa_retry"):
-            return "code"
         return END
 
     g = StateGraph(ForgeState)
@@ -1332,8 +989,7 @@ def _build_graph(ctx: _Ctx) -> Any:
     g.add_node("art_options", art_options_node)
     g.add_node("revise_art_options", revise_art_options_node)
     g.add_node("art_detail", art_detail_node)
-    g.add_node("code", code_node)
-    g.add_node("qa", qa_node)
+    g.add_node("code_qa_loop", code_qa_loop_node)
     g.add_node("done", done_node)
     g.add_conditional_edges(
         START,
@@ -1344,18 +1000,23 @@ def _build_graph(ctx: _Ctx) -> Any:
             "art_options": "art_options",
             "revise_art_options": "revise_art_options",
             "art_detail": "art_detail",
-            "code": "code",
+            "code_qa_loop": "code_qa_loop",
         },
     )
     g.add_conditional_edges("plan", after_plan, {END: END})
     g.add_conditional_edges("revise_plan", after_plan, {END: END})
-    g.add_conditional_edges("art_options", after_art, {"code": "code", END: END})
     g.add_conditional_edges(
-        "revise_art_options", after_art, {"code": "code", END: END}
+        "art_options", after_art, {"code_qa_loop": "code_qa_loop", END: END}
     )
-    g.add_conditional_edges("art_detail", after_art, {"code": "code", END: END})
-    g.add_conditional_edges("code", after_code, {"qa": "qa", END: END})
-    g.add_conditional_edges("qa", after_qa, {"done": "done", "code": "code", END: END})
+    g.add_conditional_edges(
+        "revise_art_options", after_art, {"code_qa_loop": "code_qa_loop", END: END}
+    )
+    g.add_conditional_edges(
+        "art_detail", after_art, {"code_qa_loop": "code_qa_loop", END: END}
+    )
+    g.add_conditional_edges(
+        "code_qa_loop", after_code_qa, {"done": "done", END: END}
+    )
     g.add_edge("done", END)
     return g.compile()
 
@@ -1482,6 +1143,7 @@ async def _run_body(
     art_options: dict[str, Any] = {}
     entry_phase = getattr(run, "entry_phase", "plan") or "plan"
     entry_requirement: str | None = None
+    code_qa_reset = False
     if resume:
         st = await ckpt.load_state(r, run_id, s) or {}
         # 一次性推进凭据：只有 resolve_hitl / resume_run_control / retry_run /
@@ -1499,6 +1161,11 @@ async def _run_body(
         if grant:
             decision = grant.get("decision") or decision
             modify_text = grant.get("modify_text")
+        # qa_failed / sandbox_failed 恢复：下一轮 CodeQaLoop 从 attempt==1 开始
+        code_qa_reset = bool(st.pop("code_qa_reset", False)) or phase in (
+            "qa_failed",
+            "sandbox_failed",
+        )
         await ckpt.save_state(r, run_id, st, s)
         design_doc = st.get("design_doc") or run.requirement
         art_options = st.get("art_options") or {}
@@ -1526,5 +1193,7 @@ async def _run_body(
         "art_options": art_options,
         "entry_phase": entry_phase,
         "entry_requirement": entry_requirement,
+        "code_qa_reset": code_qa_reset,
+        "attempt": 0 if code_qa_reset else 0,
     }
     await graph.ainvoke(initial)

--- a/backend/app/forge/qa/__init__.py
+++ b/backend/app/forge/qa/__init__.py
@@ -1,0 +1,5 @@
+"""QA helpers for CodeQaLoop (diagnose, etc.)."""
+
+from app.forge.qa.diagnose import diagnose_playtest_failure, fallback_diagnosis
+
+__all__ = ["diagnose_playtest_failure", "fallback_diagnosis"]

--- a/backend/app/forge/qa/diagnose.py
+++ b/backend/app/forge/qa/diagnose.py
@@ -1,0 +1,62 @@
+"""Playtest 失败诊断：调用 QA_PROMPT，失败时回落结构化 JSON（规格 §5.3）。"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.forge.design_doc import design_doc_to_text
+from app.forge.prompts import QA_PROMPT
+
+LlmCall = Callable[[str, str], Awaitable[str]]
+
+
+def fallback_diagnosis(errors: list[str]) -> str:
+    """LLM 不可用时的确定性诊断，禁止夹带 C 档玩法文案。"""
+    return json.dumps(
+        {
+            "summary": "QA 诊断模型调用失败，依据确定性运行证据继续修复",
+            "root_causes": list(errors) or ["自动试玩未通过"],
+            "required_fixes": [
+                {
+                    "priority": "P0",
+                    "location": "根据运行时错误定位",
+                    "change": "修复上述加载/运行/交互错误",
+                    "expected_result": "B 档冒烟通过",
+                }
+            ],
+            "regression_checks": [
+                "页面成功加载",
+                "ArrowRight / Space 注入不崩溃",
+                "无 pageerror",
+                "存在运行弱信号",
+            ],
+        },
+        ensure_ascii=False,
+    )
+
+
+async def diagnose_playtest_failure(
+    *,
+    llm: LlmCall,
+    design_doc: dict[str, Any],
+    errors: list[str],
+    console_logs: list[str],
+    source_excerpt: str,
+) -> str:
+    """根据试玩证据生成修复诊断；LLM 异常时返回 fallback JSON。"""
+    diagnosis_input = (
+        "【已确认设计稿 JSON】\n"
+        f"{design_doc_to_text(design_doc)}\n\n"
+        "【自动试玩错误】\n"
+        f"{json.dumps(errors, ensure_ascii=False, indent=2)}\n\n"
+        "【控制台日志】\n"
+        f"{chr(10).join(console_logs[:20])[:6000] or '无控制台日志'}\n\n"
+        "【当前 HTML 源码（data URI 已省略）】\n"
+        f"{source_excerpt or '源码不可用'}"
+    )
+    try:
+        return await llm(QA_PROMPT, diagnosis_input)
+    except Exception:  # noqa: BLE001 诊断为增强项，不得阻断确定性重试
+        return fallback_diagnosis(errors)

--- a/backend/app/forge/skills/playtest.md
+++ b/backend/app/forge/skills/playtest.md
@@ -1,22 +1,24 @@
-# QA 试玩约定（B1）
+# QA 试玩约定（CodeQaLoop · B 档硬门禁）
 
-生成完成后，QA 阶段在沙箱内对 `index.html` 做**真实试玩**，不靠 LLM 自评。
+生成后由 **CodeQaLoop** 对当前 candidate 做 **Playwright 可交互冒烟**，不靠 LLM 自评，也不允许静态 DOM 检测冒充通过。
 
-## 试玩检查项
+## 试玩检查项（须全部满足）
 
-1. **无 JS 运行时错误**（pageerror / console error）
-2. **可玩元素存在**：`<canvas>` 或 button/input/onclick 等交互控件
-3. **模拟输入**：发送 `ArrowRight`、`Space` keydown，不得抛异常
+1. **Playwright + Chromium 可用**（否则 `failure_kind=infra`）
+2. **页面加载成功**，无未捕获 `pageerror`
+3. **模拟输入**：`ArrowRight` / `Space`（及可见按钮 click）不得崩溃
+4. **运行弱信号**至少一种：`raf` / `canvas_diff` / `engine_runtime`
 
 ## 失败处理
 
-- 试玩结果写入 `qa_report` WS 事件（含 `errors[]`、`console_logs[]`）
-- 在 `qa_max_retries` 内：先由 QA 负责人做根因诊断，再以当前可运行版本为基线
-  回退 `code_node` 做定向修复（而非从零重生成）
-- 重试耗尽后直接判定失败（FAILED，code=`QA_RETRY_EXHAUSTED`），不再进入人工
-  确认 HITL；用户可经 `/retry` 重投，或修改需求后重新发起
+- 每轮结果写入 `qa_report`（`passed`、`attempt`、`issues`、`console_logs`、`failure_kind`、`motion_signal`、`playtest_mode=playwright`）
+- 在 `code_qa_max_attempts`（默认 3，含首次 generate）内：
+  - `product` / `build` → diagnose → repair → 再测
+  - `infra` → **不**修源码，仅重测同一 candidate
+- 耗尽后进入 **`qa_failed` HITL**（`status=PAUSED`），用户可通过 `hitl/resolve` 或 `/retry` 恢复；resume 后 attempt 从 1 重新计数
 
 ## 实现
 
-- `app.sandbox.playtest.run_playtest(html)` → `{ ok, errors[], console_logs[] }`
-- 默认静态 DOM 检测；生产可设 `PLAYTEST_USE_PLAYWRIGHT=1` 启用 Chromium
+- `app.sandbox.playtest.run_playtest` / `run_playtest_dist`
+- 子图：`app.forge.subgraphs.code_qa_loop`
+- 静态检查仅作诊断 helper，**不得**作为生产 `qa_ok=true` 路径

--- a/backend/app/forge/subgraphs/__init__.py
+++ b/backend/app/forge/subgraphs/__init__.py
@@ -1,0 +1,5 @@
+"""Forge LangGraph subgraphs."""
+
+from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
+
+__all__ = ["build_code_qa_loop"]

--- a/backend/app/forge/subgraphs/code_qa_loop.py
+++ b/backend/app/forge/subgraphs/code_qa_loop.py
@@ -1,0 +1,143 @@
+"""CodeQaLoop：code ↔ playtest ↔ diagnose 有界子图。"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+from app.core.config import settings
+
+NodeFn = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+class CodeQaLoopState(TypedDict, total=False):
+    design_doc: dict[str, Any] | str
+    art_options: dict[str, Any]
+    art_direction: dict[str, Any]
+    artifacts: list[dict[str, str]]
+    entry_requirement: str | None
+    attempt: int
+    qa_ok: bool
+    exhausted: bool
+    candidate_version: int | None
+    candidate_ready: bool
+    candidate_kind: str | None
+    playtest_errors: list[str]
+    console_logs: list[str]
+    failure_kind: str | None
+    qa_diagnosis: str
+    motion_signal: str | None
+    paused: bool
+    failed: bool
+    hitl_stop: bool
+    code_qa_reset: bool
+
+
+def _max_attempts() -> int:
+    return int(settings.code_qa_max_attempts)
+
+
+def after_code_or_repair(
+    state: CodeQaLoopState,
+) -> Literal["playtest", "diagnose", "exhausted", "__end__"]:
+    if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
+        return END
+    if state.get("candidate_ready"):
+        return "playtest"
+    attempt = int(state.get("attempt") or 0)
+    if attempt >= _max_attempts():
+        return "exhausted"
+    # build fail → diagnose（infra 不会从 code_or_repair 产生）
+    return "diagnose"
+
+
+def after_playtest(
+    state: CodeQaLoopState,
+) -> Literal["ok", "exhausted", "replay", "diagnose", "__end__"]:
+    if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
+        return END
+    if state.get("qa_ok"):
+        return "ok"
+    attempt = int(state.get("attempt") or 0)
+    if attempt >= _max_attempts():
+        return "exhausted"
+    if state.get("failure_kind") == "infra":
+        return "replay"
+    return "diagnose"
+
+
+def after_diagnose(
+    state: CodeQaLoopState,
+) -> Literal["code_or_repair", "__end__"]:
+    if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
+        return END
+    return "code_or_repair"
+
+
+def build_code_qa_loop(
+    *,
+    code_or_repair: NodeFn,
+    playtest: NodeFn,
+    diagnose: NodeFn,
+) -> Any:
+    """编译 CodeQaLoop 子图。节点禁止写 run.status / 调用 _fail。"""
+
+    async def infra_replay(state: CodeQaLoopState) -> dict[str, Any]:
+        """infra：只加 attempt，保持同一 candidate，回到 playtest。"""
+        return {
+            "attempt": int(state.get("attempt") or 0) + 1,
+            "qa_ok": False,
+            "exhausted": False,
+        }
+
+    async def mark_ok(state: CodeQaLoopState) -> dict[str, Any]:
+        return {"qa_ok": True, "exhausted": False}
+
+    async def mark_exhausted(state: CodeQaLoopState) -> dict[str, Any]:
+        return {
+            "qa_ok": False,
+            "exhausted": True,
+            "candidate_ready": False,
+        }
+
+    g = StateGraph(CodeQaLoopState)
+    g.add_node("code_or_repair", code_or_repair)
+    g.add_node("playtest", playtest)
+    g.add_node("diagnose", diagnose)
+    g.add_node("infra_replay", infra_replay)
+    g.add_node("mark_ok", mark_ok)
+    g.add_node("mark_exhausted", mark_exhausted)
+
+    g.add_edge(START, "code_or_repair")
+    g.add_conditional_edges(
+        "code_or_repair",
+        after_code_or_repair,
+        {
+            "playtest": "playtest",
+            "diagnose": "diagnose",
+            "exhausted": "mark_exhausted",
+            END: END,
+        },
+    )
+    g.add_conditional_edges(
+        "playtest",
+        after_playtest,
+        {
+            "ok": "mark_ok",
+            "exhausted": "mark_exhausted",
+            "replay": "infra_replay",
+            "diagnose": "diagnose",
+            END: END,
+        },
+    )
+    g.add_edge("infra_replay", "playtest")
+    g.add_conditional_edges(
+        "diagnose",
+        after_diagnose,
+        {"code_or_repair": "code_or_repair", END: END},
+    )
+    g.add_edge("mark_ok", END)
+    g.add_edge("mark_exhausted", END)
+    return g.compile()

--- a/backend/app/games/services.py
+++ b/backend/app/games/services.py
@@ -565,6 +565,9 @@ async def retry_run(
     run.status = RunStatus.RUNNING.value
     run.phase = RunPhase.CODE.value
     run.ended_at = None
+    # 下一轮 CodeQaLoop 从 attempt==1 开始
+    st = {**st, "code_qa_reset": True}
+    await ckpt.save_state(r, run_id, st, db)
     await add_message(
         db,
         game_id=run.game_id,

--- a/backend/app/sandbox/motion.py
+++ b/backend/app/sandbox/motion.py
@@ -1,0 +1,109 @@
+"""B 档运行弱信号：rAF / canvas 帧差 / 已知引擎 runtime。
+
+QA 不得用自有 requestAnimationFrame 观察循环制造自证信号；
+仅统计页面业务代码触发的 rAF callback。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+# 在业务脚本之前注入：统计页面自己请求并执行的 rAF 次数。
+RAF_INIT_SCRIPT = """
+(() => {
+  if (window.__gfRafHooked) return;
+  window.__gfRafHooked = true;
+  window.__gfRafCount = 0;
+  const orig = window.requestAnimationFrame.bind(window);
+  window.requestAnimationFrame = (cb) =>
+    orig((t) => {
+      window.__gfRafCount = (window.__gfRafCount || 0) + 1;
+      return cb(t);
+    });
+})();
+"""
+
+_RAF_MIN_DELTA = 2
+_CANVAS_DIFF_SAMPLE_STEP = 17
+_CANVAS_DIFF_MIN_HITS = 8
+
+
+class _PageLike(Protocol):
+    async def evaluate(self, expression: str) -> Any: ...
+
+    async def wait_for_timeout(self, timeout: float) -> None: ...
+
+    def locator(self, selector: str) -> Any: ...
+
+
+def png_frames_differ(a: bytes, b: bytes) -> bool:
+    """两帧 PNG 是否有可观测差异（稀疏采样，避免抗锯齿噪声误杀）。"""
+    if a == b:
+        return False
+    if abs(len(a) - len(b)) >= 64:
+        return True
+    n = min(len(a), len(b))
+    hits = 0
+    for i in range(0, n, _CANVAS_DIFF_SAMPLE_STEP):
+        if a[i] != b[i]:
+            hits += 1
+            if hits >= _CANVAS_DIFF_MIN_HITS:
+                return True
+    return False
+
+
+async def probe_raf_activity(page: _PageLike, *, window_ms: int = 400) -> bool:
+    before = int(await page.evaluate("() => window.__gfRafCount || 0") or 0)
+    await page.wait_for_timeout(window_ms)
+    after = int(await page.evaluate("() => window.__gfRafCount || 0") or 0)
+    return after - before >= _RAF_MIN_DELTA
+
+
+async def probe_canvas_frame_diff(page: _PageLike, *, window_ms: int = 400) -> bool:
+    canvases = page.locator("canvas")
+    if await canvases.count() <= 0:
+        return False
+    canvas = canvases.first
+    try:
+        if not await canvas.is_visible():
+            return False
+        shot_a = await canvas.screenshot(type="png")
+        await page.wait_for_timeout(window_ms)
+        shot_b = await canvas.screenshot(type="png")
+    except Exception:  # noqa: BLE001 截图失败不算 motion
+        return False
+    return png_frames_differ(shot_a, shot_b)
+
+
+async def probe_engine_runtime(page: _PageLike) -> bool:
+    """已知引擎已真实挂载；空 #game/#app 根节点不算。"""
+    return bool(
+        await page.evaluate(
+            """() => {
+  const hasPhaser =
+    typeof Phaser !== 'undefined' &&
+    Array.isArray(Phaser.GAMES) &&
+    Phaser.GAMES.length > 0;
+  if (hasPhaser) return true;
+  if (typeof PIXI !== 'undefined') {
+    const c = document.querySelector('canvas');
+    if (c && c.width > 0 && c.height > 0) return true;
+  }
+  const mounted = document.querySelector(
+    '#game canvas, #app canvas, [data-game-root] canvas'
+  );
+  return !!(mounted && mounted.width > 0 && mounted.height > 0);
+}"""
+        )
+    )
+
+
+async def evaluate_motion_signal(page: _PageLike) -> str | None:
+    """返回 raf | canvas_diff | engine_runtime；全无则 None。"""
+    if await probe_raf_activity(page):
+        return "raf"
+    if await probe_canvas_frame_diff(page):
+        return "canvas_diff"
+    if await probe_engine_runtime(page):
+        return "engine_runtime"
+    return None

--- a/backend/app/sandbox/playtest.py
+++ b/backend/app/sandbox/playtest.py
@@ -291,7 +291,9 @@ async def _session_playtest(
     )
 
 
-async def _with_browser(url: str, want_thumb: bool, mode_label: str, timeout: int) -> PlaytestResult:
+async def _with_browser(
+    url: str, want_thumb: bool, mode_label: str, timeout: int
+) -> PlaytestResult:
     from playwright.async_api import async_playwright
 
     try:

--- a/backend/app/sandbox/playtest.py
+++ b/backend/app/sandbox/playtest.py
@@ -1,13 +1,12 @@
-"""Headless playtest for generated HTML games (B1).
+"""Headless playtest：生产路径强制 Playwright 可交互冒烟（B 档硬门禁）。
 
-MVP: static DOM checks + optional Playwright when installed (PLAYTEST_USE_PLAYWRIGHT=1).
-Tests mock this module; production may enable Playwright for real JS execution.
+静态 DOM 检查仅作诊断 helper（`static_playtest_diagnostic`），不得作为生产 QA 通过路径。
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
+import logging
 import re
 import socket
 import sys
@@ -17,6 +16,7 @@ from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any, Literal
 
 from app.core.cdn_policy import (
     extract_external_refs,
@@ -24,6 +24,12 @@ from app.core.cdn_policy import (
     validate_dist_self_contained,
     validate_refs,
 )
+from app.sandbox.motion import RAF_INIT_SCRIPT, evaluate_motion_signal
+
+log = logging.getLogger(__name__)
+
+FailureKind = Literal["product", "build", "infra"]
+MotionSignal = Literal["raf", "canvas_diff", "engine_runtime"]
 
 
 @dataclass
@@ -31,8 +37,75 @@ class PlaytestResult:
     ok: bool
     errors: list[str] = field(default_factory=list)
     console_logs: list[str] = field(default_factory=list)
-    # QA 通过分支顺带截的封面图（PNG bytes）。want_thumb=False / 静态模式 / 截图失败时均为 None。
     thumbnail: bytes | None = None
+    failure_kind: FailureKind | None = None
+    motion_signal: MotionSignal | None = None
+
+    def __post_init__(self) -> None:
+        if self.ok and self.errors:
+            raise ValueError("PlaytestResult invariant: ok=True requires errors==[]")
+        if self.ok and self.failure_kind is not None:
+            raise ValueError("PlaytestResult invariant: ok=True requires failure_kind=None")
+        if self.ok and self.motion_signal is None:
+            raise ValueError(
+                "PlaytestResult invariant: ok=True requires motion_signal"
+            )
+
+
+def make_playtest_result(
+    *,
+    errors: list[str] | None = None,
+    console_logs: list[str] | None = None,
+    thumbnail: bytes | None = None,
+    failure_kind: FailureKind | None = None,
+    motion_signal: MotionSignal | None = None,
+) -> PlaytestResult:
+    """统一派生 ok，避免多分支手改 result.ok 破坏不变量。"""
+    errs = list(errors or [])
+    logs = list(console_logs or [])
+    ok = (not errs) and failure_kind is None and motion_signal is not None
+    return PlaytestResult(
+        ok=ok,
+        errors=errs,
+        console_logs=logs,
+        thumbnail=thumbnail if ok else None,
+        failure_kind=None if ok else (failure_kind or ("product" if errs else "product")),
+        motion_signal=motion_signal if ok else None,
+    )
+
+
+def _infra_result(code: str, detail: str, logs: list[str] | None = None) -> PlaytestResult:
+    return make_playtest_result(
+        errors=[f"{code}: {detail}"],
+        console_logs=logs or ["playtest: infra failure"],
+        failure_kind="infra",
+    )
+
+
+def playwright_import_available() -> bool:
+    try:
+        import playwright  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _check_playwright_available() -> PlaytestResult | None:
+    if not playwright_import_available():
+        return _infra_result(
+            "PLAYWRIGHT_UNAVAILABLE", "playwright package is not installed"
+        )
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(headless=True)
+            browser.close()
+    except Exception as exc:  # noqa: BLE001
+        return _infra_result(
+            "CHROMIUM_UNAVAILABLE", f"chromium launch failed: {exc}"
+        )
+    return None
 
 
 class _DomScanner(HTMLParser):
@@ -40,7 +113,6 @@ class _DomScanner(HTMLParser):
         super().__init__()
         self.has_canvas = False
         self.has_interactive = False
-        self.script_blocks: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         t = tag.lower()
@@ -64,12 +136,6 @@ def _extract_scripts(html: str) -> list[str]:
 
 
 def _declares_engine(html: str) -> bool:
-    """HTML 是否引用了受控游戏引擎 CDN（Phaser/PixiJS）。
-
-    引擎产物的 <canvas> 由运行时注入到挂载点，源码里没有裸 <canvas>。静态模式不执行
-    JS，无法证明 canvas 已挂载，因此对声明了引擎的产物跳过 canvas 存在性检查——
-    这项交给运行时/Playwright/人工试玩，而非用「源码无 canvas」错判可玩性。
-    """
     from app.forge.engine_router import SUPPORTED_ENGINES, recommended_cdn_url
 
     engine_urls = {
@@ -79,15 +145,11 @@ def _declares_engine(html: str) -> bool:
 
 
 def _screen_target_errors(html: str, scripts: list[str]) -> list[str]:
-    """Detect the generated-game convention where state targets have no matching screen DOM."""
     source = "\n".join(scripts)
     if not re.search(r"screen-\$\{[^}]+\}", source):
         return []
-
     screen_ids = set(re.findall(r'id=["\']screen-([^"\']+)["\']', html, flags=re.I))
-    targets = set(
-        re.findall(r"\bsetScreen\(\s*[\"']([^\"']+)[\"']\s*\)", source)
-    )
+    targets = set(re.findall(r"\bsetScreen\(\s*[\"']([^\"']+)[\"']\s*\)", source))
     missing = sorted(targets - screen_ids)
     if not missing:
         return []
@@ -97,170 +159,180 @@ def _screen_target_errors(html: str, scripts: list[str]) -> list[str]:
     ]
 
 
-def _static_playtest(html: str) -> PlaytestResult:
-    """Fast checks without a browser: structure + basic script sanity."""
+def static_playtest_diagnostic(html: str) -> PlaytestResult:
+    """诊断用静态检查。永不作为生产 QA 通过（成功结构检查仍 ok=False）。"""
     errors: list[str] = []
-    logs: list[str] = ["playtest: static mode"]
-
+    logs: list[str] = ["playtest: static diagnostic (not a QA pass path)"]
     scanner = _DomScanner()
     try:
         scanner.feed(html)
-    except Exception as e:  # noqa: BLE001 HTML parse
+    except Exception as e:  # noqa: BLE001
         errors.append(f"HTML 解析失败: {e}")
-        return PlaytestResult(ok=False, errors=errors, console_logs=logs)
+        return make_playtest_result(
+            errors=errors, console_logs=logs, failure_kind="product"
+        )
 
-    # 引擎产物 canvas 由运行时注入，静态模式无法验证其存在；对声明了引擎的产物
-    # 跳过 canvas 存在性检查，交给运行时/Playwright/人工。仍保留花括号/screen/白名单等检查。
     missing_interactive = not scanner.has_canvas and not scanner.has_interactive
     if missing_interactive and not _declares_engine(html):
         errors.append("缺少 canvas 或可交互元素（button/input/onclick）")
-
     scripts = _extract_scripts(html)
     errors.extend(_screen_target_errors(html, scripts))
     for i, block in enumerate(scripts, start=1):
         src = block.strip()
         if not src:
             continue
-        # 常见未闭合括号/引号
         if src.count("{") != src.count("}"):
             errors.append(f"script#{i} 花括号可能未闭合")
-        if "addEventListener" in src and "keydown" not in src and "click" not in src:
-            logs.append(f"script#{i}: addEventListener without keydown/click")
-
-    # 模拟 keydown：静态模式下仅记录
-    logs.append("playtest: simulated keydown ArrowRight (static, no runtime)")
-
-    return PlaytestResult(ok=not errors, errors=errors, console_logs=logs)
-
-
-async def _playwright_playtest_url(base_url: str, want_thumb: bool = False) -> PlaytestResult:
-    from playwright.async_api import async_playwright
-
-    errors: list[str] = []
-    logs: list[str] = ["playtest: playwright dist mode"]
-    thumbnail: bytes | None = None
-    url = base_url if base_url.endswith("/") else f"{base_url}/"
-
-    async with async_playwright() as pw:
-        browser = await pw.chromium.launch(headless=True)
-        page = await browser.new_page()
-
-        def _on_page_error(exc: Exception) -> None:
-            errors.append(f"pageerror: {exc}")
-
-        page.on("pageerror", _on_page_error)
-
-        def _on_console(msg) -> None:
-            if msg.type in ("error", "warning"):
-                logs.append(f"console:{msg.type}:{msg.text}")
-
-        page.on("console", _on_console)
-        await page.goto(url, wait_until="networkidle", timeout=20_000)
-
-        has_canvas = await page.locator("canvas").count() > 0
-        has_root = await page.locator("#app, #game, [data-game-root]").count() > 0
-        has_interactive = (
-            await page.locator("button, input, select, textarea, [onclick]").count() > 0
+    if not errors:
+        errors.append(
+            "STATIC_DIAGNOSTIC_ONLY: structural checks passed (not runtime QA)"
         )
-        if not has_canvas and not has_interactive and not has_root:
-            errors.append("缺少 canvas、游戏根节点或可交互元素")
-
-        try:
-            await page.keyboard.press("ArrowRight")
-            await page.keyboard.press("Space")
-            logs.append("playtest: keydown ArrowRight + Space ok")
-        except Exception as e:  # noqa: BLE001 input sim
-            errors.append(f"模拟按键失败: {e}")
-
-        if want_thumb and not errors:
-            try:
-                await page.set_viewport_size({"width": 1024, "height": 576})
-                await page.wait_for_timeout(500)
-                thumbnail = await page.screenshot(type="png", full_page=False)
-            except Exception as e:  # noqa: BLE001 playwright screenshot
-                logs.append(f"thumbnail: 截图失败，已降级无封面: {e}")
-                thumbnail = None
-
-        await browser.close()
-
-    return PlaytestResult(
-        ok=not errors, errors=errors, console_logs=logs, thumbnail=thumbnail
+    return make_playtest_result(
+        errors=errors, console_logs=logs, failure_kind="product"
     )
 
 
-async def _playwright_playtest(html_path: Path, want_thumb: bool = False) -> PlaytestResult:
-    from playwright.async_api import async_playwright
+_static_playtest = static_playtest_diagnostic
 
+
+async def _inject_inputs(page: Any, logs: list[str], errors: list[str]) -> None:
+    try:
+        await page.keyboard.press("ArrowRight")
+        await page.keyboard.press("Space")
+        logs.append("playtest: keydown ArrowRight + Space ok")
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"INPUT_INJECTION_FAILED: {e}")
+        return
+    btn = page.locator(
+        "button:visible, input[type=button]:visible, [role=button]:visible"
+    )
+    try:
+        if await btn.count() > 0:
+            first = btn.first
+            if await first.is_enabled():
+                await first.click(timeout=3_000)
+                logs.append("playtest: button click ok")
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"INPUT_INJECTION_FAILED: click: {e}")
+
+
+async def _session_playtest(
+    page: Any,
+    *,
+    url: str,
+    want_thumb: bool,
+    mode_label: str,
+    goto_timeout_ms: int,
+) -> PlaytestResult:
     errors: list[str] = []
-    logs: list[str] = ["playtest: playwright mode"]
-    thumbnail: bytes | None = None
+    logs: list[str] = [f"playtest: {mode_label}"]
 
-    async with async_playwright() as pw:
-        browser = await pw.chromium.launch(headless=True)
-        page = await browser.new_page()
+    def _on_page_error(exc: Exception) -> None:
+        errors.append(f"PAGE_ERROR: {exc}")
 
-        def _on_page_error(exc: Exception) -> None:
-            errors.append(f"pageerror: {exc}")
+    page.on("pageerror", _on_page_error)
+    page.on(
+        "console",
+        lambda msg: logs.append(f"console:{msg.type}:{msg.text}")
+        if msg.type in ("error", "warning", "log")
+        else None,
+    )
+    await page.add_init_script(RAF_INIT_SCRIPT)
 
-        page.on("pageerror", _on_page_error)
-        page.on("console", lambda msg: logs.append(f"console:{msg.type}:{msg.text}"))
-
-        await page.goto(html_path.as_uri(), wait_until="domcontentloaded", timeout=15_000)
-
-        has_canvas = await page.locator("canvas").count() > 0
-        has_interactive = (
-            await page.locator("button, input, select, textarea, [onclick]").count() > 0
+    try:
+        await page.goto(url, wait_until="domcontentloaded", timeout=goto_timeout_ms)
+        await page.wait_for_timeout(300)
+    except Exception as e:  # noqa: BLE001
+        return make_playtest_result(
+            errors=[f"PAGE_LOAD_FAILED: {e}"],
+            console_logs=logs,
+            failure_kind="product",
         )
-        if not has_canvas and not has_interactive:
-            errors.append("缺少 canvas 或可交互元素")
 
+    if errors:
+        return make_playtest_result(
+            errors=errors, console_logs=logs, failure_kind="product"
+        )
+
+    await _inject_inputs(page, logs, errors)
+    await page.wait_for_timeout(200)
+    if errors:
+        return make_playtest_result(
+            errors=errors, console_logs=logs, failure_kind="product"
+        )
+
+    motion = await evaluate_motion_signal(page)
+    if motion is None:
+        errors.append("NO_RUNTIME_SIGNAL: no raf/canvas_diff/engine_runtime")
+        return make_playtest_result(
+            errors=errors, console_logs=logs, failure_kind="product"
+        )
+
+    if errors:
+        return make_playtest_result(
+            errors=errors, console_logs=logs, failure_kind="product"
+        )
+
+    thumbnail: bytes | None = None
+    if want_thumb:
         try:
-            await page.keyboard.press("ArrowRight")
-            await page.keyboard.press("Space")
-            logs.append("playtest: keydown ArrowRight + Space ok")
-        except Exception as e:  # noqa: BLE001 input sim
-            errors.append(f"模拟按键失败: {e}")
+            await page.set_viewport_size({"width": 1024, "height": 576})
+            await page.wait_for_timeout(300)
+            thumbnail = await page.screenshot(type="png", full_page=False)
+        except Exception as e:  # noqa: BLE001
+            logs.append(f"thumbnail: 截图失败，已降级无封面: {e}")
+            thumbnail = None
 
-        # 封面截图：仅在本次校验通过且调用方需要时截。复用已 warm 的浏览器会话，
-        # 不二次冷启。16:9 视口对齐卡片比例；full_page=False 避免截到滚动区。
-        # 截图是封面增强项，任何异常都降级为 None，不影响 QA 结论。
-        if want_thumb and not errors:
-            try:
-                await page.set_viewport_size({"width": 1024, "height": 576})
-                # 给 canvas/外部 CDN（tailwind/three.js）一点渲染时间；外网受限时画面可能不全，
-                # 由调用方接受白屏降级。
-                await page.wait_for_timeout(500)
-                thumbnail = await page.screenshot(type="png", full_page=False)
-            except Exception as e:  # noqa: BLE001 playwright screenshot
-                logs.append(f"thumbnail: 截图失败，已降级无封面: {e}")
-                thumbnail = None
-
-        await browser.close()
-
-    return PlaytestResult(
-        ok=not errors, errors=errors, console_logs=logs, thumbnail=thumbnail
+    return make_playtest_result(
+        errors=[],
+        console_logs=logs,
+        thumbnail=thumbnail,
+        motion_signal=motion,  # type: ignore[arg-type]
     )
 
 
-def _static_playtest_dist(dist_dir: Path) -> PlaytestResult:
+async def _with_browser(url: str, want_thumb: bool, mode_label: str, timeout: int) -> PlaytestResult:
+    from playwright.async_api import async_playwright
+
+    try:
+        async with async_playwright() as pw:
+            browser = await pw.chromium.launch(headless=True)
+            try:
+                page = await browser.new_page()
+                return await _session_playtest(
+                    page,
+                    url=url,
+                    want_thumb=want_thumb,
+                    mode_label=mode_label,
+                    goto_timeout_ms=timeout,
+                )
+            finally:
+                await browser.close()
+    except Exception as e:  # noqa: BLE001
+        msg = str(e).lower()
+        if any(k in msg for k in ("executable", "chromium", "browser", "playwright")):
+            return _infra_result("BROWSER_LAUNCH_FAILED", str(e))
+        return make_playtest_result(
+            errors=[f"PAGE_LOAD_FAILED: {e}"],
+            console_logs=[f"playtest: {mode_label}"],
+            failure_kind="product",
+        )
+
+
+def _dist_asset_errors(dist_dir: Path) -> list[str]:
     index = dist_dir / "index.html"
     if not index.is_file():
-        return PlaytestResult(ok=False, errors=["dist/index.html 不存在"])
+        return ["dist/index.html 不存在"]
     html = index.read_text(encoding="utf-8")
     errors: list[str] = []
-    logs: list[str] = ["playtest: static dist mode"]
     for match in re.finditer(r"""(?:src|href)\s*=\s*["']([^"']+)["']""", html, re.I):
         ref = match.group(1).strip()
-        if ref.startswith(("http://", "https://", "data:", "blob:")):
+        if ref.startswith(("http://", "https://", "data:", "blob:", "#")):
             continue
         target = (dist_dir / ref.removeprefix("./")).resolve()
         if not target.is_file():
             errors.append(f"dist 资源缺失: {ref}")
-    result = _static_playtest(html)
-    result.console_logs = logs + result.console_logs
-    result.errors = errors + result.errors
-    result.ok = not result.errors
-    return result
+    return errors
 
 
 def _free_port() -> int:
@@ -269,97 +341,86 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
+def _serve(directory: Path) -> tuple[ThreadingHTTPServer, threading.Thread, str]:
+    port = _free_port()
+    handler = lambda *args, **kwargs: SimpleHTTPRequestHandler(  # noqa: E731
+        *args, directory=str(directory.resolve()), **kwargs
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, f"http://127.0.0.1:{port}"
+
+
+def _stop_server(server: ThreadingHTTPServer, thread: threading.Thread) -> None:
+    server.shutdown()
+    thread.join(timeout=2)
+    server.server_close()
+
+
 async def run_playtest_dist(dist_dir: Path, want_thumb: bool = False) -> PlaytestResult:
-    """对 dist/ 目录启动临时静态 HTTP Server 做试玩（§17 project/vite）。"""
     refs = scan_dist_external_refs(dist_dir)
     ok, violations = validate_dist_self_contained(refs)
     if not ok:
-        return PlaytestResult(
-            ok=False,
+        return make_playtest_result(
             errors=[f"dist 含外链（应自包含）：{v}" for v in violations],
             console_logs=["playtest: dist external ref check failed"],
+            failure_kind="product",
         )
 
-    use_pw = os.environ.get("PLAYTEST_USE_PLAYWRIGHT", "").lower() in ("1", "true", "yes")
-    if use_pw:
-        try:
-            import playwright  # noqa: F401
-        except ImportError:
-            use_pw = False
+    asset_errors = _dist_asset_errors(dist_dir)
+    if asset_errors:
+        return make_playtest_result(
+            errors=asset_errors,
+            console_logs=["playtest: dist asset check"],
+            failure_kind="product",
+        )
 
-    if not use_pw:
-        return _static_playtest_dist(dist_dir)
+    unavailable = await asyncio.to_thread(_check_playwright_available)
+    if unavailable is not None:
+        return unavailable
 
-    port = _free_port()
-    handler = lambda *args, **kwargs: SimpleHTTPRequestHandler(  # noqa: E731
-        *args, directory=str(dist_dir.resolve()), **kwargs
-    )
-    server = ThreadingHTTPServer(("127.0.0.1", port), handler)
-    base_url = f"http://127.0.0.1:{port}"
-
-    serve_thread = threading.Thread(target=server.serve_forever, daemon=True)
-    serve_thread.start()
+    server, thread, base = _serve(dist_dir)
     try:
-        return await _playwright_playtest_url(base_url, want_thumb=want_thumb)
-    except Exception as e:  # noqa: BLE001 playwright runtime
-        fallback = _static_playtest_dist(dist_dir)
-        fallback.errors.insert(0, f"Playwright dist 失败，已降级静态检测: {e}")
-        fallback.ok = False
-        return fallback
+        return await _with_browser(
+            f"{base}/", want_thumb, "playwright dist mode", 20_000
+        )
     finally:
-        server.shutdown()
-        serve_thread.join(timeout=2)
-        server.server_close()
+        _stop_server(server, thread)
 
 
 async def run_playtest(html: str, want_thumb: bool = False) -> PlaytestResult:
-    """加载 index.html 做可玩性校验，并独立检查 CDN 白名单。
+    unavailable = await asyncio.to_thread(_check_playwright_available)
+    if unavailable is not None:
+        return _with_cdn_check(html, unavailable)
 
-    want_thumb=True 时，在浏览器模式下校验通过分支顺带截封面图（见 _playwright_playtest）；
-    静态模式或截图失败返回 thumbnail=None。
-
-    CDN 校验与浏览器/静态检测分离：CSP 收紧后，非白名单 CDN 会被浏览器拦截，
-    在此提前抓出并置顶报错，触发 QA 修复，避免产物上线后白屏。
-    """
-    result = await _browser_playtest(html, want_thumb=want_thumb)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        path = root / "index.html"
+        path.write_text(html, encoding="utf-8")
+        server, thread, base = _serve(root)
+        try:
+            result = await _with_browser(
+                f"{base}/index.html", want_thumb, "playwright mode", 15_000
+            )
+        finally:
+            _stop_server(server, thread)
     return _with_cdn_check(html, result)
 
 
-async def _browser_playtest(html: str, want_thumb: bool = False) -> PlaytestResult:
-    use_pw = os.environ.get("PLAYTEST_USE_PLAYWRIGHT", "").lower() in ("1", "true", "yes")
-    if use_pw:
-        try:
-            import playwright  # noqa: F401
-        except ImportError:
-            use_pw = False
-
-    if not use_pw:
-        return _static_playtest(html)
-
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "index.html"
-        path.write_text(html, encoding="utf-8")
-        try:
-            return await _playwright_playtest(path, want_thumb=want_thumb)
-        except Exception as e:  # noqa: BLE001 playwright runtime
-            fallback = _static_playtest(html)
-            fallback.errors.insert(0, f"Playwright 失败，已降级静态检测: {e}")
-            return fallback
-
-
 def _with_cdn_check(html: str, result: PlaytestResult) -> PlaytestResult:
-    """把非白名单 CDN 引用合并为 P0 错误，排在校验结果最前。"""
     ok, violations = validate_refs(extract_external_refs(html))
     if ok:
         return result
     cdn_errors = [f"引用非白名单 CDN（将被 CSP 拦截）：{v}" for v in violations]
-    result.errors = cdn_errors + result.errors
-    result.ok = False
-    return result
+    return make_playtest_result(
+        errors=cdn_errors + result.errors,
+        console_logs=result.console_logs,
+        failure_kind=result.failure_kind or "product",
+    )
 
 
 def main() -> None:
-    """CLI entry: python -m app.sandbox.playtest /path/to/index.html"""
     if len(sys.argv) < 2:
         print("usage: playtest <html-file>", file=sys.stderr)
         sys.exit(2)
@@ -368,6 +429,8 @@ def main() -> None:
     print("OK" if result.ok else "FAIL")
     for err in result.errors:
         print(f"ERR: {err}")
+    if result.failure_kind:
+        print(f"KIND: {result.failure_kind}")
     sys.exit(0 if result.ok else 1)
 
 

--- a/backend/app/schemas/ws.py
+++ b/backend/app/schemas/ws.py
@@ -48,7 +48,10 @@ class QaReportPayload(BaseModel):
     issues: list[str]
     log_excerpt: str
     console_logs: list[str] = []
-    playtest_mode: str = "sandbox"
+    playtest_mode: str = "playwright"
+    attempt: int = 1
+    failure_kind: str | None = None
+    motion_signal: str | None = None
 
 
 class DesignDoc(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -64,8 +64,13 @@ def _playtest_ok(monkeypatch: pytest.MonkeyPatch) -> None:
             motion_signal="raf",
         )
 
-    monkeypatch.setattr("app.forge.graph.run_playtest", _ok)
-    monkeypatch.setattr("app.forge.graph.run_playtest_dist", _ok)
+    for target in (
+        "app.forge.graph.run_playtest",
+        "app.forge.graph.run_playtest_dist",
+        "app.forge.code_qa_exec.run_playtest",
+        "app.forge.code_qa_exec.run_playtest_dist",
+    ):
+        monkeypatch.setattr(target, _ok)
 
 
 def _valid_design_doc_json() -> str:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -57,9 +57,15 @@ def _playtest_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     from app.sandbox.playtest import PlaytestResult
 
     async def _ok(_html: str, **_kwargs: object) -> PlaytestResult:
-        return PlaytestResult(ok=True, errors=[], console_logs=["mock playtest ok"])
+        return PlaytestResult(
+            ok=True,
+            errors=[],
+            console_logs=["mock playtest ok"],
+            motion_signal="raf",
+        )
 
     monkeypatch.setattr("app.forge.graph.run_playtest", _ok)
+    monkeypatch.setattr("app.forge.graph.run_playtest_dist", _ok)
 
 
 def _valid_design_doc_json() -> str:

--- a/backend/tests/test_code_qa_loop.py
+++ b/backend/tests/test_code_qa_loop.py
@@ -1,0 +1,182 @@
+"""CodeQaLoop 子图路由单测（全 mock）。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from app.forge.subgraphs.code_qa_loop import (
+    after_code_or_repair,
+    after_playtest,
+    build_code_qa_loop,
+)
+
+
+@pytest.mark.asyncio
+async def test_infra_failure_retries_same_candidate_without_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 3)
+    repair_calls = {"n": 0}
+    playtest_calls = {"n": 0}
+    candidate_versions: list[int | None] = []
+
+    async def code_or_repair(state: dict[str, Any]) -> dict[str, Any]:
+        repair_calls["n"] += 1
+        attempt = int(state.get("attempt") or 0) + 1
+        return {
+            "attempt": attempt,
+            "candidate_ready": True,
+            "candidate_version": 10,
+            "failure_kind": None,
+            "qa_ok": False,
+        }
+
+    async def playtest(state: dict[str, Any]) -> dict[str, Any]:
+        playtest_calls["n"] += 1
+        candidate_versions.append(state.get("candidate_version"))
+        return {
+            "qa_ok": False,
+            "failure_kind": "infra",
+            "playtest_errors": ["PLAYWRIGHT_UNAVAILABLE"],
+            "attempt": state.get("attempt"),
+            "candidate_version": state.get("candidate_version"),
+            "candidate_ready": True,
+        }
+
+    async def diagnose(state: dict[str, Any]) -> dict[str, Any]:
+        raise AssertionError("infra must not diagnose")
+
+    graph = build_code_qa_loop(
+        code_or_repair=code_or_repair,
+        playtest=playtest,
+        diagnose=diagnose,
+    )
+    result = await graph.ainvoke({"attempt": 0, "design_doc": {}})
+
+    assert result.get("exhausted") is True
+    assert result.get("qa_ok") is False
+    assert repair_calls["n"] == 1
+    assert playtest_calls["n"] == 3
+    assert candidate_versions == [10, 10, 10]
+
+
+@pytest.mark.asyncio
+async def test_product_fail_diagnose_then_repair_then_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 3)
+    steps: list[str] = []
+
+    async def code_or_repair(state: dict[str, Any]) -> dict[str, Any]:
+        steps.append("code")
+        attempt = int(state.get("attempt") or 0) + 1
+        return {
+            "attempt": attempt,
+            "candidate_ready": True,
+            "candidate_version": attempt,
+            "qa_ok": False,
+        }
+
+    async def playtest(state: dict[str, Any]) -> dict[str, Any]:
+        steps.append("playtest")
+        attempt = int(state.get("attempt") or 0)
+        if attempt >= 2:
+            return {
+                "qa_ok": True,
+                "attempt": attempt,
+                "candidate_version": state.get("candidate_version"),
+                "candidate_ready": True,
+                "failure_kind": None,
+                "motion_signal": "raf",
+            }
+        return {
+            "qa_ok": False,
+            "failure_kind": "product",
+            "playtest_errors": ["pageerror"],
+            "attempt": attempt,
+            "candidate_version": state.get("candidate_version"),
+            "candidate_ready": True,
+        }
+
+    async def diagnose(state: dict[str, Any]) -> dict[str, Any]:
+        steps.append("diagnose")
+        return {
+            "qa_diagnosis": '{"summary":"fix"}',
+            "candidate_ready": False,
+            "attempt": state.get("attempt"),
+            "playtest_errors": state.get("playtest_errors") or [],
+        }
+
+    graph = build_code_qa_loop(
+        code_or_repair=code_or_repair,
+        playtest=playtest,
+        diagnose=diagnose,
+    )
+    result = await graph.ainvoke({"attempt": 0})
+
+    assert result.get("qa_ok") is True
+    assert result.get("exhausted") is False
+    assert steps == ["code", "playtest", "diagnose", "code", "playtest"]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_after_three_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 3)
+
+    async def code_or_repair(state: dict[str, Any]) -> dict[str, Any]:
+        attempt = int(state.get("attempt") or 0) + 1
+        return {
+            "attempt": attempt,
+            "candidate_ready": True,
+            "candidate_version": attempt,
+            "qa_ok": False,
+        }
+
+    async def playtest(state: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "qa_ok": False,
+            "failure_kind": "product",
+            "playtest_errors": ["still broken"],
+            "attempt": state.get("attempt"),
+            "candidate_version": state.get("candidate_version"),
+            "candidate_ready": True,
+        }
+
+    async def diagnose(state: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "qa_diagnosis": "x",
+            "candidate_ready": False,
+            "attempt": state.get("attempt"),
+        }
+
+    graph = build_code_qa_loop(
+        code_or_repair=code_or_repair,
+        playtest=playtest,
+        diagnose=diagnose,
+    )
+    result = await graph.ainvoke({"attempt": 0})
+    assert result.get("exhausted") is True
+    assert result.get("qa_ok") is False
+    assert int(result.get("attempt") or 0) == 3
+
+
+def test_after_playtest_routing_helpers() -> None:
+    assert after_playtest({"qa_ok": True}) == "ok"
+    assert after_playtest({"qa_ok": False, "attempt": 3}) == "exhausted"
+    assert (
+        after_playtest({"qa_ok": False, "attempt": 1, "failure_kind": "infra"})
+        == "replay"
+    )
+    assert (
+        after_playtest({"qa_ok": False, "attempt": 1, "failure_kind": "product"})
+        == "diagnose"
+    )
+    assert after_code_or_repair({"candidate_ready": True}) == "playtest"
+    assert (
+        after_code_or_repair({"candidate_ready": False, "attempt": 1}) == "diagnose"
+    )

--- a/backend/tests/test_motion.py
+++ b/backend/tests/test_motion.py
@@ -1,0 +1,15 @@
+"""Motion probe helpers."""
+
+from app.sandbox.motion import png_frames_differ
+
+
+def test_identical_png_bytes_not_motion() -> None:
+    assert not png_frames_differ(b"\x89PNG\r\n", b"\x89PNG\r\n")
+
+
+def test_sparse_diff_detects_change() -> None:
+    a = bytes([0] * 500)
+    b = bytearray([0] * 500)
+    for i in range(0, 500, 17):
+        b[i] = 1
+    assert png_frames_differ(a, bytes(b))

--- a/backend/tests/test_playtest.py
+++ b/backend/tests/test_playtest.py
@@ -1,103 +1,77 @@
-"""B1: sandbox playtest unit tests."""
+"""Playtest hard-gate and B-tier motion unit tests."""
+
+from __future__ import annotations
 
 import pytest
 
-from app.sandbox.playtest import run_playtest
-
-
-def _chromium_available() -> bool:
-    """探测 playwright + chromium 是否可用（封面截图的前提）。"""
-    try:
-        from playwright.sync_api import sync_playwright
-    except ImportError:
-        return False
-    try:
-        with sync_playwright() as pw:
-            pw.chromium.launch(headless=True).close()
-        return True
-    except Exception:  # noqa: BLE001 未装 chromium / 缺系统依赖均视为不可用
-        return False
-
-
-_NEED_CHROMIUM = pytest.mark.skipif(
-    not _chromium_available(), reason="封面截图需 playwright + chromium（worker 可选依赖）"
+from app.sandbox.motion import png_frames_differ
+from app.sandbox.playtest import (
+    PlaytestResult,
+    make_playtest_result,
+    run_playtest,
+    static_playtest_diagnostic,
 )
 
 
-@pytest.mark.asyncio
-async def test_playtest_passes_with_canvas_and_script() -> None:
+def test_playtest_result_rejects_ok_with_errors() -> None:
+    with pytest.raises(ValueError):
+        PlaytestResult(ok=True, errors=["x"], console_logs=[], motion_signal="raf")
+
+
+def test_playtest_result_rejects_ok_without_motion() -> None:
+    with pytest.raises(ValueError):
+        PlaytestResult(ok=True, errors=[], console_logs=[])
+
+
+def test_make_playtest_result_ok_requires_motion() -> None:
+    r = make_playtest_result(errors=[], motion_signal="raf")
+    assert r.ok
+    assert r.failure_kind is None
+    assert r.motion_signal == "raf"
+
+
+def test_make_playtest_result_errors_force_not_ok() -> None:
+    r = make_playtest_result(errors=["boom"], motion_signal="raf")
+    assert not r.ok
+    assert r.motion_signal is None
+    assert r.failure_kind == "product"
+
+
+def test_png_frames_differ() -> None:
+    assert not png_frames_differ(b"abc", b"abc")
+    assert png_frames_differ(b"a" * 200, b"b" * 200)
+
+
+def test_static_diagnostic_never_ok() -> None:
     html = """
     <html><body>
     <canvas id="game"></canvas>
-    <script>
-    document.addEventListener('keydown', function(e) {});
-    </script>
+    <script>document.addEventListener('keydown', function(e) {});</script>
     </body></html>
     """
-    r = await run_playtest(html)
-    assert r.ok, r.errors
-    assert r.console_logs
+    r = static_playtest_diagnostic(html)
+    assert not r.ok
+    assert r.failure_kind == "product"
 
 
-@pytest.mark.asyncio
-async def test_playtest_fails_without_interactive() -> None:
-    html = "<html><body><h1>hello</h1></body></html>"
-    r = await run_playtest(html)
+def test_static_diagnostic_flags_missing_interactive() -> None:
+    r = static_playtest_diagnostic("<html><body><h1>hello</h1></body></html>")
     assert not r.ok
     assert any("canvas" in e or "交互" in e for e in r.errors)
 
 
-@pytest.mark.asyncio
-async def test_playtest_fails_unbalanced_braces() -> None:
+def test_static_diagnostic_unbalanced_braces() -> None:
     html = """
     <html><body><canvas></canvas>
     <script>function f() { console.log(1); </script>
     </body></html>
     """
-    r = await run_playtest(html)
+    r = static_playtest_diagnostic(html)
     assert not r.ok
     assert any("花括号" in e for e in r.errors)
 
 
-@pytest.mark.asyncio
-async def test_playtest_fails_when_screen_state_has_no_matching_dom() -> None:
-    html = """
-    <html><body>
-    <div id="screen-menu"><button>开始</button></div>
-    <div id="screen-game"></div>
-    <script>
-    function setScreen(next) {
-      document.getElementById(`screen-${next}`);
-    }
-    setScreen('playing');
-    </script>
-    </body></html>
-    """
-    r = await run_playtest(html)
-    assert not r.ok
-    assert any("#screen-playing" in e for e in r.errors)
-
-
-@pytest.mark.asyncio
-async def test_playtest_accepts_matching_screen_state_dom() -> None:
-    html = """
-    <html><body>
-    <div id="screen-menu"><button>开始</button></div>
-    <div id="screen-playing"></div>
-    <script>
-    function setScreen(next) {
-      document.getElementById(`screen-${next}`);
-    }
-    setScreen('playing');
-    </script>
-    </body></html>
-    """
-    r = await run_playtest(html)
-    assert r.ok, r.errors
-
-
 def test_cdn_whitelist_accepts_engine_scripts() -> None:
-    """Phaser/PixiJS 走 jsdelivr/unpkg CDN，已在白名单内，validate_refs 不得误杀。"""
     from app.core.cdn_policy import extract_external_refs, validate_refs
 
     html = (
@@ -109,88 +83,37 @@ def test_cdn_whitelist_accepts_engine_scripts() -> None:
 
 
 @pytest.mark.asyncio
-async def test_playtest_passes_with_engine_cdn_and_canvas() -> None:
-    """含 Phaser CDN 脚本 + canvas 的产物应通过试玩（CDN 在白名单）。"""
-    html = """
-    <html><body>
-    <canvas id="game"></canvas>
-    <script src="https://cdn.jsdelivr.net/npm/phaser@3.80.1/dist/phaser.min.js"></script>
-    <script>document.addEventListener('keydown', function(e) {});</script>
-    </body></html>
-    """
-    r = await run_playtest(html)
-    assert r.ok, r.errors
-
-
-@pytest.mark.asyncio
-async def test_playtest_accepts_engine_mounted_canvas() -> None:
-    """引擎产物 canvas 由运行时注入挂载点，源码无裸 <canvas>；静态模式不得误判。
-
-    静态模式不执行 JS，无法验证引擎是否真的挂上了 canvas；此项交给运行时/Playwright/
-    人工，而非用「源码无 canvas」错判可玩性。
-    """
-    html = """
-    <html><body>
-    <div id="game"></div>
-    <script src="https://cdn.jsdelivr.net/npm/phaser@3.80.1/dist/phaser.min.js"></script>
-    <script>document.addEventListener('keydown', function(e) {});</script>
-    </body></html>
-    """
-    r = await run_playtest(html)
-    assert r.ok, r.errors
-
-
-@pytest.mark.asyncio
-async def test_playtest_still_rejects_bare_page_without_engine() -> None:
-    """无 canvas 且无引擎声明的纯静态页仍应被拒（引擎兼容不得放宽通用保护）。"""
-    html = "<html><body><h1>no game</h1></body></html>"
-    r = await run_playtest(html)
-    assert not r.ok
-    assert any("canvas" in e or "交互" in e for e in r.errors)
-
-
-@pytest.mark.asyncio
-async def test_static_mode_never_returns_thumbnail(monkeypatch: pytest.MonkeyPatch) -> None:
-    """默认无 PLAYTEST_USE_PLAYWRIGHT → 静态模式，want_thumb 也无法截图，thumbnail 恒 None。
-
-    静态模式没有浏览器会话，截图能力只在 playwright 模式下具备（见 integration 标记的用例）。
-    """
-    monkeypatch.delenv("PLAYTEST_USE_PLAYWRIGHT", raising=False)
-    html = (
-        "<html><body><canvas id='game'></canvas>"
-        "<script>document.addEventListener('keydown',e=>{})</script></body></html>"
+async def test_run_playtest_without_playwright_is_infra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.sandbox.playtest.playwright_import_available", lambda: False
     )
+    r = await run_playtest("<html><body><canvas></canvas></body></html>")
+    assert not r.ok
+    assert r.failure_kind == "infra"
+    assert any("PLAYWRIGHT_UNAVAILABLE" in e for e in r.errors)
+
+
+@pytest.mark.asyncio
+async def test_run_playtest_mock_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_check() -> None:
+        return None
+
+    async def _fake_browser(*_a: object, **_k: object) -> PlaytestResult:
+        return make_playtest_result(
+            errors=[],
+            console_logs=["mock"],
+            motion_signal="raf",
+            thumbnail=b"\x89PNG",
+        )
+
+    monkeypatch.setattr(
+        "app.sandbox.playtest._check_playwright_available", lambda: None
+    )
+    monkeypatch.setattr("app.sandbox.playtest._with_browser", _fake_browser)
+    html = "<html><body><canvas id='game'></canvas></body></html>"
     r = await run_playtest(html, want_thumb=True)
     assert r.ok
-    assert r.thumbnail is None
-
-
-@pytest.mark.asyncio
-@_NEED_CHROMIUM
-async def test_playwright_mode_returns_thumbnail_on_pass(monkeypatch: pytest.MonkeyPatch) -> None:
-    """真实 chromium 模式：通过 HTML + want_thumb=True 应返回非空 PNG。
-
-    需 worker 装好 chromium 且 PLAYTEST_USE_PLAYWRIGHT=1；无 chromium 环境自动跳过。
-    """
-    monkeypatch.setenv("PLAYTEST_USE_PLAYWRIGHT", "1")
-    html = """
-    <html><body>
-    <canvas id="game" width="100" height="100"></canvas>
-    <script>document.addEventListener('keydown', function(e) {});</script>
-    </body></html>
-    """
-    r = await run_playtest(html, want_thumb=True)
-    assert r.ok, r.errors
-    assert r.thumbnail is not None
-    assert r.thumbnail.startswith(b"\x89PNG")
-
-
-@pytest.mark.asyncio
-@_NEED_CHROMIUM
-async def test_playwright_mode_no_thumbnail_when_failed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """真实 chromium 模式：QA 不通过（缺交互元素）时不截图，thumbnail=None 且 ok=False。"""
-    monkeypatch.setenv("PLAYTEST_USE_PLAYWRIGHT", "1")
-    html = "<html><body><h1>no game here</h1></body></html>"
-    r = await run_playtest(html, want_thumb=True)
-    assert not r.ok
-    assert r.thumbnail is None
+    assert r.motion_signal == "raf"
+    assert r.thumbnail == b"\x89PNG"

--- a/backend/tests/test_playtest_dist.py
+++ b/backend/tests/test_playtest_dist.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from app.sandbox.playtest import run_playtest_dist
+from app.sandbox.playtest import make_playtest_result, run_playtest_dist
+
 
 _CANVAS_HTML = """<!doctype html><html><body>
 <canvas id="game"></canvas>
@@ -13,13 +14,28 @@ _CANVAS_HTML = """<!doctype html><html><body>
 
 
 @pytest.mark.asyncio
-async def test_run_playtest_dist_static_ok(tmp_path: Path) -> None:
+async def test_run_playtest_dist_ok_with_mock_browser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     dist = tmp_path / "dist"
     dist.mkdir()
     (dist / "index.html").write_text(_CANVAS_HTML, encoding="utf-8")
     assets = dist / "assets"
     assets.mkdir()
-    (assets / "app.js").write_text("console.log(1)", encoding="utf-8")
+    (assets / "app.js").write_text(
+        "function tick(){requestAnimationFrame(tick)};tick();", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(
+        "app.sandbox.playtest._check_playwright_available", lambda: None
+    )
+
+    async def _ok(*_a: object, **_k: object):
+        return make_playtest_result(
+            errors=[], console_logs=["mock dist"], motion_signal="raf"
+        )
+
+    monkeypatch.setattr("app.sandbox.playtest._with_browser", _ok)
     result = await run_playtest_dist(dist)
     assert result.ok, result.errors
 
@@ -47,3 +63,21 @@ async def test_run_playtest_dist_missing_asset(tmp_path: Path) -> None:
     result = await run_playtest_dist(dist)
     assert not result.ok
     assert any("缺失" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_run_playtest_dist_infra_without_playwright(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text(_CANVAS_HTML, encoding="utf-8")
+    assets = dist / "assets"
+    assets.mkdir()
+    (assets / "app.js").write_text("console.log(1)", encoding="utf-8")
+    monkeypatch.setattr(
+        "app.sandbox.playtest.playwright_import_available", lambda: False
+    )
+    result = await run_playtest_dist(dist)
+    assert not result.ok
+    assert result.failure_kind == "infra"

--- a/backend/tests/test_playtest_dist.py
+++ b/backend/tests/test_playtest_dist.py
@@ -6,7 +6,6 @@ import pytest
 
 from app.sandbox.playtest import make_playtest_result, run_playtest_dist
 
-
 _CANVAS_HTML = """<!doctype html><html><body>
 <canvas id="game"></canvas>
 <script src="./assets/app.js"></script>

--- a/backend/tests/test_retry_run.py
+++ b/backend/tests/test_retry_run.py
@@ -45,12 +45,14 @@ async def test_retry_run_from_qa_failed(
     from app.sandbox.playtest import PlaytestResult
 
     async def _fail(_html: str, **_kwargs: object) -> PlaytestResult:
-        return PlaytestResult(ok=False, errors=["mock"], console_logs=[])
+        return PlaytestResult(
+            ok=False, errors=["mock"], console_logs=[], failure_kind="product"
+        )
 
-    monkeypatch.setattr("app.forge.graph.run_playtest", _fail)
+    monkeypatch.setattr("app.forge.code_qa_exec.run_playtest", _fail)
     from app.core.config import settings
 
-    monkeypatch.setattr(settings, "qa_max_retries", 0)
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 1)
 
     gid = await _make_game(verified_client)
     rid = uuid.UUID(
@@ -71,10 +73,17 @@ async def test_retry_run_from_qa_failed(
     assert st is not None
     assert st.get("phase") == "qa_failed"
 
+    r = await verified_client.get(f"/api/v1/runs/{rid}")
+    assert r.json()["data"]["status"] == "paused"
+
     r = await verified_client.post(f"/api/v1/runs/{rid}/retry")
     assert r.status_code == 200, r.text
     assert r.json()["data"]["status"] == "running"
     assert r.json()["data"]["phase"] == "code"
+
+    st2 = await ckpt.load_state(redis_client, rid)
+    assert st2 is not None
+    assert st2.get("code_qa_reset") is True
 
 
 async def test_retry_run_invalid_state(

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -204,30 +204,30 @@ async def test_grant_consumed_after_done_prevents_replay(
     assert r.json()["data"] == versions_after_done
 
 
-async def test_qa_playtest_failure_retries_then_fails(
+async def test_qa_playtest_failure_retries_then_pauses(
     verified_client: httpx.AsyncClient,
     redis_client: fakeredis.aioredis.FakeRedis,
     _fake_llm,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """QA 试玩失败 → 自动回退 code 修复；预算耗尽后直接 FAILED（不再进 HITL）。
-
-    新版流程在策划确认后不再为 sandbox/qa 失败插入人工确认点：重试耗尽即终态
-    失败，但 checkpoint 仍写 qa_failed，便于 /retry 重投。failed run 不再暴露
-    可点击的 current_hitl。
-    """
+    """QA 试玩失败 → CodeQaLoop 修复；预算耗尽后 PAUSED（qa_failed HITL）。"""
     from app.sandbox.playtest import PlaytestResult
 
     calls = {"n": 0}
 
     async def _fail_playtest(_html: str, **_kwargs: object) -> PlaytestResult:
         calls["n"] += 1
-        return PlaytestResult(ok=False, errors=["mock js error"], console_logs=["err"])
+        return PlaytestResult(
+            ok=False,
+            errors=["mock js error"],
+            console_logs=["err"],
+            failure_kind="product",
+        )
 
-    monkeypatch.setattr("app.forge.graph.run_playtest", _fail_playtest)
+    monkeypatch.setattr("app.forge.code_qa_exec.run_playtest", _fail_playtest)
     from app.core.config import settings
 
-    monkeypatch.setattr(settings, "qa_max_retries", 1)
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 1)
 
     gid = await _make_game(verified_client)
     rid = await _make_run(verified_client, gid)
@@ -239,8 +239,9 @@ async def test_qa_playtest_failure_retries_then_fails(
     await run_generation(ctx, rid, resume=True, decision="select_a")
 
     r = await verified_client.get(f"/api/v1/runs/{rid}")
-    assert r.json()["data"]["status"] == "failed"
-    assert r.json()["data"]["current_hitl"] is None
+    assert r.json()["data"]["status"] == "paused"
+    assert r.json()["data"]["current_hitl"] is not None
+    assert r.json()["data"]["current_hitl"]["node"] == "qa_failed"
     assert calls["n"] >= 1
 
 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,4 +1,5 @@
 # gameforge/worker：RabbitMQ consumer。build context = 仓库根目录
+# CodeQaLoop 硬门禁要求本镜像具备 Playwright + Chromium。
 FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1 \
@@ -8,8 +9,14 @@ WORKDIR /app
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# Chromium 系统依赖（playwright install --with-deps 需要 root）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY backend/pyproject.toml backend/uv.lock ./
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --extra playwright \
+    && uv run playwright install --with-deps chromium
 
 COPY backend/app ./app
 COPY backend/alembic ./alembic

--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -34,7 +34,7 @@
 * 提示词输出契约：`prompts.py:326`「只输出完整 HTML 源码，首字符必须是 `<!DOCTYPE html>`，以 `</html>` 结束」；`_CODE_COMMON`（`prompts.py:55`）「只生成一个自包含 index.html，JS/CSS 一律内联」。
 * 代码节点：`graph.py:794` `execute(source={"index.html": html})`，source 只有一个 key。
 * 沙箱：`docker.py:64` 无 `build_cmd` 时仅 `test -f /workspace/index.html`；`graph.py:794` 调用根本没传 `build_cmd`。**当前 HTML 不在沙箱里构建/执行，沙箱只做写盘 + 文件存在性检查。**
-* 试玩：`playtest.py` 默认走 `_static_playtest`（`playtest.py:203`），纯 Python 正则扫描，不执行 JS；仅 `PLAYTEST_USE_PLAYWRIGHT=1` 时用真浏览器。
+* 试玩：`playtest.py` 对产物做 Playwright 可交互冒烟（CodeQaLoop 硬门禁）；静态 DOM 检查仅作诊断，不得冒充 QA 通过。
 * 托管：`hosting/local.py:59`、`hosting/routes.py:43` 固定读写单个 `index.html`。
 
 已支持三个 CDN-UMD 引擎 `canvas` / `phaser3` / `pixijs`（`engine_router.py:19`）。**框架层面已具备中等能力，真正瓶颈不是渲染框架，而是：游戏必须压成单 HTML，且没有 npm / TypeScript / Vite 标准前端构建链。** 这限制了 LLM 使用 npm 生态（物理/动画/声音/3D 库）、代码模块化、TypeScript、代码分包，以及 React 等 UI 框架。

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,8 @@ The default values are suitable for local Docker-backed dependencies. Do not com
 | `backend/.env` | `RABBITMQ_URL` | `amqp://gameforge:gameforge@localhost:5672/` | Worker queue and real-time events |
 | `backend/.env` | `CORS_ORIGINS` | `http://127.0.0.1:5173,...` | browser origins allowed by the API |
 | `backend/.env` | `SANDBOX_BACKEND` | `local` | local development build backend; use `docker` only after building the sandbox image |
-| `backend/.env` | `THUMBNAIL_ENABLED` | `true` | allows optional game-cover capture after a successful browser playtest |
+| `backend/.env` | `THUMBNAIL_ENABLED` | `true` | after a successful Playwright QA pass, optionally capture a game-card cover |
+| `backend/.env` | `CODE_QA_MAX_ATTEMPTS` | `3` | CodeQaLoop attempts (generate + repair), including the first generate |
 | `frontend/.env` | `VITE_API_BASE_URL` | `http://127.0.0.1:8000/api/v1` | REST API base URL |
 | `frontend/.env` | `VITE_HOSTING_BASE_URL` | optional | hosting root for `/play` and `/draft` pages |
 | `frontend/.env` | `VITE_WS_BASE_URL` | optional | WebSocket root; inferred when omitted |
@@ -143,32 +144,28 @@ docker compose exec backend uv run python -m scripts.seed_official_games
 
 The frontend is normally run locally with `pnpm run dev` during development.
 
-## Optional Browser Playtest and Generated Covers
+## Required Browser Playtest (CodeQaLoop)
 
-The default Worker performs static checks on generated HTML. A Worker can additionally run a real Chromium playtest and capture the first viewport as a game-card cover. This is optional: without Chromium or with either setting disabled, generation continues normally and cards use their gradient fallback.
+Generation Workers **must** run real Chromium playtests. Static DOM checks are diagnostics only and cannot mark QA as passed. Without Playwright/Chromium, CodeQaLoop records `failure_kind=infra` and cannot reach `done`.
 
-Both controls must be enabled for cover capture:
-
-- `THUMBNAIL_ENABLED=true` in `backend/.env` (the runtime switch; it defaults to `true`).
-- `PLAYTEST_USE_PLAYWRIGHT=1` in the environment of the Worker process.
-
-Install the optional dependency and Chromium on the machine that runs the Worker:
+Install Playwright + Chromium on every Worker host:
 
 ```bash
 cd backend
 uv sync --extra playwright
 uv run playwright install chromium
-export PLAYTEST_USE_PLAYWRIGHT=1
 ```
 
-In Windows PowerShell, set the Worker environment variable for the current terminal before starting the Worker:
+Windows PowerShell:
 
 ```powershell
-$env:PLAYTEST_USE_PLAYWRIGHT = "1"
+cd backend
+uv sync --extra playwright
+uv run playwright install chromium
 uv run python -m app.messaging.worker
 ```
 
-For Linux containers, install the browser dependencies as part of the Worker image or use `uv run playwright install chromium --with-deps` where supported. Browser or screenshot failures fall back without blocking game generation.
+Linux containers should bake browser dependencies into the Worker image (`docker/Dockerfile.worker` installs Chromium via `playwright install --with-deps`). Screenshot failures only affect covers (`THUMBNAIL_ENABLED`); missing Chromium blocks QA pass.
 
 ## Windows Troubleshooting
 
@@ -180,7 +177,7 @@ For Linux containers, install the browser dependencies as part of the Worker ima
 | `/ready` reports an unavailable dependency | Start Docker Desktop, run `docker compose ps`, and verify PostgreSQL, Redis, and RabbitMQ are healthy. |
 | No verification code or a Forge run remains queued | Ensure the Worker terminal is running and connected to RabbitMQ. |
 | Forge generation fails before it begins | Verify the account email, then save and test a working LLM provider configuration in Settings. |
-| A game card has no screenshot cover | This is expected unless the Worker has Playwright and Chromium installed, `PLAYTEST_USE_PLAYWRIGHT=1` is set, and `THUMBNAIL_ENABLED` is enabled. Generation is unaffected. |
+| A game card has no screenshot cover | Expected unless the Worker has Playwright + Chromium and `THUMBNAIL_ENABLED=true`. Missing Chromium also blocks CodeQaLoop from passing. |
 | A local environment has stale schema | Run `cd backend` followed by `uv run alembic upgrade head`. |
 
 ## Ports

--- a/docs/development.zh-CN.md
+++ b/docs/development.zh-CN.md
@@ -34,7 +34,8 @@ cp frontend/.env.example frontend/.env
 | `backend/.env` | `RABBITMQ_URL` | `amqp://gameforge:gameforge@localhost:5672/` | Worker 队列和实时事件 |
 | `backend/.env` | `CORS_ORIGINS` | `http://127.0.0.1:5173,...` | API 允许的浏览器来源 |
 | `backend/.env` | `SANDBOX_BACKEND` | `local` | 本地开发使用的构建后端；仅在构建 Sandbox Image 后使用 `docker` |
-| `backend/.env` | `THUMBNAIL_ENABLED` | `true` | 允许在浏览器试玩成功后，可选地截取游戏卡片封面 |
+| `backend/.env` | `THUMBNAIL_ENABLED` | `true` | Playwright QA 通过后可选截取游戏卡片封面 |
+| `backend/.env` | `CODE_QA_MAX_ATTEMPTS` | `3` | CodeQaLoop 总 attempt（含首次 generate） |
 | `frontend/.env` | `VITE_API_BASE_URL` | `http://127.0.0.1:8000/api/v1` | REST API 基础地址 |
 | `frontend/.env` | `VITE_HOSTING_BASE_URL` | 可选 | `/play` 和 `/draft` 页的托管根地址 |
 | `frontend/.env` | `VITE_WS_BASE_URL` | 可选 | WebSocket 根地址；留空时自动推导 |
@@ -143,32 +144,28 @@ docker compose exec backend uv run python -m scripts.seed_official_games
 
 开发期间前端通常仍在本地通过 `pnpm run dev` 运行。
 
-## 可选浏览器试玩与生成封面
+## 必需的浏览器试玩（CodeQaLoop）
 
-默认 Worker 会对生成的 HTML 做静态检查。Worker 还可以启动真实的 Chromium 浏览器试玩，并把首屏截图保存为游戏卡片封面。这是可选增强：没有 Chromium 或任一开关关闭时，游戏仍会正常生成，卡片会使用渐变回退样式。
+执行生成任务的 Worker **必须**具备 Playwright + Chromium。静态 DOM 检查仅作诊断，不得作为 QA 通过依据。缺少浏览器时 CodeQaLoop 记 `failure_kind=infra`，无法进入 `done`。
 
-要生成封面，以下两个控制项必须同时启用：
-
-- `backend/.env` 中的 `THUMBNAIL_ENABLED=true`（运行时开关，默认值为 `true`）。
-- Worker 进程环境中的 `PLAYTEST_USE_PLAYWRIGHT=1`。
-
-在运行 Worker 的机器上安装可选依赖与 Chromium：
+在 Worker 机器上安装：
 
 ```bash
 cd backend
 uv sync --extra playwright
 uv run playwright install chromium
-export PLAYTEST_USE_PLAYWRIGHT=1
 ```
 
-Windows PowerShell 中，请在启动 Worker 前为当前终端设置环境变量：
+Windows PowerShell：
 
 ```powershell
-$env:PLAYTEST_USE_PLAYWRIGHT = "1"
+cd backend
+uv sync --extra playwright
+uv run playwright install chromium
 uv run python -m app.messaging.worker
 ```
 
-Linux 容器中，应将浏览器依赖安装进 Worker 镜像；在支持的环境可使用 `uv run playwright install chromium --with-deps`。浏览器或截图失败会自动降级，不会阻断游戏生成。
+Linux 容器应将浏览器依赖写入 Worker 镜像（见 `docker/Dockerfile.worker` 的 `playwright install --with-deps`）。截图失败只影响封面（`THUMBNAIL_ENABLED`）；缺少 Chromium 会阻断 QA 通过。
 
 ## Windows 排错
 
@@ -180,7 +177,7 @@ Linux 容器中，应将浏览器依赖安装进 Worker 镜像；在支持的环
 | `/ready` 报依赖不可用 | 打开 Docker Desktop，运行 `docker compose ps`，确认 PostgreSQL、Redis 和 RabbitMQ 均为 healthy。 |
 | 没有验证码或 Forge 一直排队 | 确认 Worker 终端正在运行并且已连接 RabbitMQ。 |
 | Forge 尚未开始就失败 | 检查邮箱是否完成验证，并在设置页保存和测试可用的 LLM Provider 配置。 |
-| 游戏卡片没有截图封面 | 只有 Worker 安装 Playwright 与 Chromium、设置 `PLAYTEST_USE_PLAYWRIGHT=1` 且启用 `THUMBNAIL_ENABLED` 时才会截取封面。不会影响游戏生成。 |
+| 游戏卡片没有截图封面 | 需 Worker 已装 Playwright + Chromium 且 `THUMBNAIL_ENABLED=true`。缺少 Chromium 同时会阻断 CodeQaLoop 通过。 |
 | 本地数据库结构过旧 | 在 `backend/` 中运行 `uv run alembic upgrade head`。 |
 
 ## 端口

--- a/frontend/src/pages/forge/resume.test.ts
+++ b/frontend/src/pages/forge/resume.test.ts
@@ -97,9 +97,6 @@ describe('forge resume helpers', () => {
   })
 
   it('failed 终态即使残留 current_hitl 也不浮出 HITL 卡', () => {
-    // 新版流程：qa_failed/sandbox_failed 重试耗尽即 FAILED，checkpoint 仍写、
-    // get_run 仍返回 current_hitl，但不再是人工确认点。重连到这种 run 必须返回
-    // null，让上层走失败恢复条而非一张点批准必 409 的死卡。
     const failed: RunDetail = {
       run_id: 'r-fail',
       game_id: 'g1',
@@ -110,6 +107,26 @@ describe('forge resume helpers', () => {
       current_hitl: { node: 'qa_failed' },
     }
     expect(buildResumeHitl(failed, '霓虹蛇')).toBeNull()
+  })
+
+  it('paused + qa_failed 可恢复为 HITL', () => {
+    const paused: RunDetail = {
+      run_id: 'r-qa',
+      game_id: 'g1',
+      status: 'paused',
+      phase: 'qa',
+      entry_phase: 'code',
+      ws_url: '/ws/runs/r-qa',
+      current_hitl: { node: 'qa_failed' },
+    }
+    const hitl = buildResumeHitl(paused, '霓虹蛇')
+    expect(hitl?.node).toBe('qa_failed')
+    expect(hitl?.action_url).toContain('/hitl/resolve')
+    const gameplay =
+      typeof hitl?.design_doc === 'object' && hitl.design_doc && 'gameplay' in hitl.design_doc
+        ? String(hitl.design_doc.gameplay)
+        : ''
+    expect(gameplay).toContain('试玩未通过')
   })
 
   it('从 game detail 推导草稿预览 URL', () => {

--- a/frontend/src/pages/forge/resume.ts
+++ b/frontend/src/pages/forge/resume.ts
@@ -41,17 +41,18 @@ export function buildResumeHitl(run: RunDetail, gameTitle: string): HitlWaitPayl
       art_options: hw.art_options,
     }
   }
-  // current_hitl 兜底仅对仍可交互的 paused 态生效。新版流程下
-  // qa_failed/sandbox_failed 是 FAILED 终态（checkpoint 仍写、get_run 仍返回
-  // current_hitl，但 resolve 会 409），failed run 不能再浮出 HITL 卡，否则会显示
-  // 一张点批准必 409 的死卡，掩盖本应出现的失败恢复条。
+  // current_hitl 兜底仅对仍可交互的 paused 态生效。
+  // qa_failed 现为 PAUSED HITL（可 hitl/resolve 重试修复）；failed 终态不浮卡。
   if (run.status !== 'paused') return null
   if (!run.current_hitl) return null
   return {
     node: run.current_hitl.node,
     design_doc: {
       title: `${gameTitle} · 待确认策划`,
-      gameplay: '（重连恢复）请确认或修改策划后继续生成。',
+      gameplay:
+        run.current_hitl.node === 'qa_failed'
+          ? '（重连恢复）自动试玩未通过，可批准重试修复或修改后继续。'
+          : '（重连恢复）请确认或修改策划后继续生成。',
       controls: '',
       levels: [],
     },


### PR DESCRIPTION
## Summary

- Introduce a LangGraph **CodeQaLoop** subgraph that owns generate/repair → Playwright playtest → diagnose within `code_qa_max_attempts` (default 3, including first generate).
- Enforce **B-tier interactive smoke** as a hard gate: Playwright + Chromium required; no static-DOM false pass; `failure_kind` routes product/build to repair and infra to replay-only.
- Promote `candidate_version` to `game.current_version` only after `qa_ok`; exhausted attempts pause as true HITL (`qa_failed` + `PAUSED`), with attempt reset to 1 on resume.
- Require Playwright in the Worker image/docs and drop legacy `PLAYTEST_USE_PLAYWRIGHT` / dual outer retry knobs.

## Motivation

Users were waiting through long generation runs that could still ship unplayable games, because QA often used static checks (or optional Playwright) and could silently pass without executing JS.

## Key behavior

| Case | Behavior |
| --- | --- |
| Product / build fail | diagnose → repair → new candidate → playtest |
| Infra fail (no Chromium, etc.) | no LLM repair; replay same candidate; attempt++ |
| Budget exhausted | `status=PAUSED`, `phase=qa_failed` (not FAILED) |
| Vite build retries exhausted | `failure_kind=build`; no automatic single-html success fallback |
| Thumbnail | optional after pass; screenshot failure does not fail QA |

## Test plan

- [ ] `cd backend && uv run pytest tests/test_playtest.py tests/test_playtest_dist.py tests/test_motion.py tests/test_code_qa_loop.py tests/test_retry_run.py -q`
- [ ] Confirm Worker has Playwright: `uv sync --extra playwright && uv run playwright install chromium` (or rebuild worker image)
- [ ] Forge run with Chromium available: broken HTML fails QA, repair path can recover within 3 attempts
- [ ] Exhaust attempts → UI shows resumable `qa_failed` HITL (`paused`); resume starts at attempt 1
- [ ] Worker without Chromium → infra failures, never `done` via static pass
- [ ] Frontend: `pnpm test -- resume.test.ts` (or project equivalent)
- [ ] Spot-check WS `qa_report`: `playtest_mode=playwright`, plus `attempt` / `failure_kind` / `motion_signal`

## Docs

- Spec: `docs/superpowers/specs/2026-08-15-code-qa-loop-design.md`
- Plan: `docs/superpowers/plans/2026-08-15-code-qa-loop.md`