### PR TITLE
feat(forge): P0 可靠性底座与 ADR-01 产物门禁

### DIFF
--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -22,6 +22,7 @@ from app.models.generation_run import GenerationRun
 from app.schemas.active_run import ActiveRunItem
 from app.schemas.forge_message import ForgeMessageItem
 from app.schemas.run import (
+    ArtifactGateDetail,
     HitlResolveReq,
     HitlResolveResp,
     HitlState,
@@ -195,6 +196,17 @@ async def get_run(
     current_hitl, hitl_wait = _hitl_from_state(run, state)
     pause_reason = None
     recovery = None
+    artifact_gate = None
+    if state and any(
+        k in state
+        for k in ("previewable", "publishable", "qa_ok", "generation_success")
+    ):
+        artifact_gate = ArtifactGateDetail(
+            generation_success=bool(state.get("generation_success", False)),
+            previewable=bool(state.get("previewable", False)),
+            publishable=bool(state.get("publishable", False)),
+            qa_ok=bool(state.get("qa_ok", False)),
+        )
     if run.status == RunStatus.PAUSED.value:
         try:
             reason = pause_reason_from_state(state)
@@ -221,6 +233,7 @@ async def get_run(
             hitl_wait=hitl_wait,
             pause_reason=pause_reason,
             recovery=recovery,
+            artifact_gate=artifact_gate,
         )
     )
 

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -11,11 +11,12 @@ from app.auth.deps import CurrentUser, DbSession, RedisClient
 from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
 from app.core.response import ApiResponse, ErrorResponse
-from app.enums import EntryPhase, RunPhase, RunStatus
+from app.enums import EntryPhase, PauseReason, RunPhase, RunStatus
 from app.forge import state as ckpt
 from app.forge.event_log import list_events
 from app.forge.messages import add_message, list_messages, stable_payload_key
 from app.forge.queue import enqueue_resume
+from app.forge.reliability.pause import pause_reason_from_state, recovery_from_state
 from app.games import services
 from app.models.generation_run import GenerationRun
 from app.schemas.active_run import ActiveRunItem
@@ -25,6 +26,7 @@ from app.schemas.run import (
     HitlResolveResp,
     HitlState,
     HitlWaitDetail,
+    RecoveryDetail,
     RunControlResp,
     RunCreate,
     RunListItem,
@@ -191,6 +193,22 @@ async def get_run(
     run = await services.get_run(db, user, run_id)
     state = await ckpt.load_state(r, run_id, db)
     current_hitl, hitl_wait = _hitl_from_state(run, state)
+    pause_reason = None
+    recovery = None
+    if run.status == RunStatus.PAUSED.value:
+        try:
+            reason = pause_reason_from_state(state)
+            pause_reason = reason.value if reason else None
+        except ValueError:
+            pause_reason = None
+        raw_recovery = recovery_from_state(state)
+        if raw_recovery:
+            recovery = RecoveryDetail(
+                node=str(raw_recovery.get("node") or ""),
+                error_code=str(raw_recovery.get("error_code") or ""),
+                attempts=int(raw_recovery.get("attempts") or 0),
+                can_retry=bool(raw_recovery.get("can_retry", True)),
+            )
     return ApiResponse(
         data=RunStatusResp(
             run_id=run.id,
@@ -201,6 +219,8 @@ async def get_run(
             ws_url=_WS.format(run_id=run.id),
             current_hitl=current_hitl,
             hitl_wait=hitl_wait,
+            pause_reason=pause_reason,
+            recovery=recovery,
         )
     )
 
@@ -310,6 +330,12 @@ async def resolve_hitl(
     ):
         await r.delete(f"run:hitl:{run_id}")
         raise AppError(ErrorCode.INVALID_STATE, "run 不在 HITL 等待态")
+    if state.get("pause_reason") == PauseReason.RECOVERABLE_ERROR.value:
+        await r.delete(f"run:hitl:{run_id}")
+        raise AppError(
+            ErrorCode.INVALID_STATE,
+            "可恢复故障请使用 /retry，而非 HITL resolve",
+        )
     if run.status != RunStatus.PAUSED.value:
         await r.delete(f"run:hitl:{run_id}")
         raise AppError(ErrorCode.INVALID_STATE, "run 已结束")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,6 +97,8 @@ class Settings(BaseSettings):
     system_daily_token_alert: int = 5_000_000  # 系统日用量告警阈值
     # CodeQaLoop 总 attempt（含首次 generate）；infra/product/build 共用此预算。
     code_qa_max_attempts: int = 3
+    # P0 可靠性：为 LangGraph 节点挂 TimeoutPolicy/RetryPolicy；关则保持旧行为便于回滚
+    reliability_node_timeout: bool = True
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
     # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。
     thumbnail_enabled: bool = True

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -99,6 +99,8 @@ class Settings(BaseSettings):
     code_qa_max_attempts: int = 3
     # P0 可靠性：为 LangGraph 节点挂 TimeoutPolicy/RetryPolicy；关则保持旧行为便于回滚
     reliability_node_timeout: bool = True
+    # P0 可靠性：副作用幂等（promote / usage 等）；关则跳过 Redis NX 门闩
+    reliability_idempotent_side_effects: bool = True
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
     # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。
     thumbnail_enabled: bool = True

--- a/backend/app/enums.py
+++ b/backend/app/enums.py
@@ -22,6 +22,15 @@ class RunStatus(StrEnum):
     FAILED = "failed"
 
 
+class PauseReason(StrEnum):
+    """paused 细分原因（ADR-05：不新增 RunStatus）。"""
+
+    WAITING_USER = "waiting_user"
+    RECOVERABLE_ERROR = "recoverable_error"
+    QUOTA_BLOCKED = "quota_blocked"
+    MANUAL_HOLD = "manual_hold"
+
+
 class RunPhase(StrEnum):
     PLAN = "plan"
     ART = "art"

--- a/backend/app/forge/code_candidate.py
+++ b/backend/app/forge/code_candidate.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+import redis.asyncio as redis
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.forge.reliability.idempotency import (
+    get_side_effect_value,
+    side_effect_key,
+    try_begin_side_effect,
+)
 from app.models.game import Game
 from app.models.game_version import GameVersion
 
@@ -35,6 +42,35 @@ async def next_candidate_version(session: AsyncSession, game: Game) -> int:
         select(func.max(GameVersion.version)).where(GameVersion.game_id == game.id)
     )
     return max(int(max_stored or 0), int(game.current_version or 0)) + 1
+
+
+async def claim_candidate_version(
+    r: redis.Redis,
+    session: AsyncSession,
+    game: Game,
+    *,
+    run_id: uuid.UUID,
+    attempt: int,
+) -> tuple[int, bool]:
+    """按 run+attempt 幂等领取 candidate 版本号。
+
+    返回 (version, is_new)。重放同一 attempt 时复用已领取版本，避免重复抬号。
+    """
+    key = side_effect_key(
+        run_id, "code_or_repair", f"attempt-{int(attempt)}", "save_candidate"
+    )
+    existing = await get_side_effect_value(r, key)
+    if existing is not None and str(existing).isdigit():
+        return int(existing), False
+
+    version = await next_candidate_version(session, game)
+    if await try_begin_side_effect(r, key, value=str(version)):
+        return version, True
+
+    claimed = await get_side_effect_value(r, key)
+    if claimed is not None and str(claimed).isdigit():
+        return int(claimed), False
+    return version, True
 
 
 def promote_candidate(game: Game, version: int) -> None:

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -31,6 +31,7 @@ from app.forge.prompts import (
     build_repair_prompt,
 )
 from app.forge.qa.diagnose import diagnose_playtest_failure
+from app.forge.reliability.artifact_gate import derive_artifact_gate
 from app.hosting import serve, store
 from app.models.game_version import GameVersion
 from app.sandbox import get_sandbox
@@ -400,6 +401,7 @@ async def execute_code_or_repair(
                     "version": version,
                     "artifact_path": artifact,
                     "preview_url": f"/draft/{ctx.game.id}/{version}",
+                    **derive_artifact_gate(build_ok=True, qa_ok=False).as_dict(),
                 },
             )
             return {
@@ -417,6 +419,7 @@ async def execute_code_or_repair(
                 "design_doc": design_doc,
                 "artifacts": artifacts,
                 "art_direction": art_direction,
+                **derive_artifact_gate(build_ok=True, qa_ok=False).as_dict(),
             }
 
         last_error = result.error or "构建失败"

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -6,6 +6,8 @@ import json
 import re
 from typing import Any
 
+from sqlalchemy import select
+
 from app.core.config import settings
 from app.enums import RunPhase, RunStatus, WSEventType
 from app.forge.assets.picker import format_assets_for_prompt
@@ -18,7 +20,7 @@ from app.forge.build.integration import (
     with_design_routing,
 )
 from app.forge.build.routing import routing_from_design_doc, should_use_vite_pipeline
-from app.forge.code_candidate import next_candidate_version
+from app.forge.code_candidate import claim_candidate_version
 from app.forge.design_doc import coerce_design_doc, design_doc_to_text
 from app.forge.engine_router import engine_scaffold
 from app.forge.events import publish_event
@@ -273,6 +275,7 @@ async def execute_code_or_repair(
                         design_doc=design_doc,
                         artifacts=artifacts,
                         art_direction=art_direction,
+                        attempt=int(attempt),
                     )
                     return {
                         **committed,
@@ -361,17 +364,33 @@ async def execute_code_or_repair(
             ):
                 raise run_finalized_exc
 
-            version = await next_candidate_version(ctx.s, ctx.game)
+            version, _is_new = await claim_candidate_version(
+                ctx.r,
+                ctx.s,
+                ctx.game,
+                run_id=ctx.run.id,
+                attempt=int(attempt),
+            )
             artifact = f"{ctx.game.id}/{version}/index.html"
             await store.write_artifact(ctx.game.id, version, result.files)
-            ctx.s.add(
-                GameVersion(
-                    game_id=ctx.game.id,
-                    version=version,
-                    artifact_path=artifact,
-                    design_doc=design_doc,
+            existing_gv = await ctx.s.scalar(
+                select(GameVersion).where(
+                    GameVersion.game_id == ctx.game.id,
+                    GameVersion.version == version,
                 )
             )
+            if existing_gv is None:
+                ctx.s.add(
+                    GameVersion(
+                        game_id=ctx.game.id,
+                        version=version,
+                        artifact_path=artifact,
+                        design_doc=design_doc,
+                    )
+                )
+            else:
+                existing_gv.artifact_path = artifact
+                existing_gv.design_doc = design_doc
             await ctx.s.commit()
             await game_services.prune_old_versions(ctx.s, ctx.game)
             await publish_event(

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -54,6 +54,7 @@ from app.forge.reliability import (
     is_fatal,
     is_recoverable,
 )
+from app.forge.reliability.artifact_gate import derive_artifact_gate
 from app.forge.reliability.idempotency import side_effect_key, try_begin_side_effect
 from app.forge.reliability.policy import langgraph_retry_policy, langgraph_timeout_policy
 from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
@@ -184,6 +185,7 @@ async def _commit_project_build(
             "artifact_path": artifact,
             "build": "vite",
             "preview_url": preview_url,
+            **derive_artifact_gate(build_ok=True, qa_ok=False).as_dict(),
         },
     )
     return {
@@ -197,6 +199,7 @@ async def _commit_project_build(
         "failure_kind": None,
         "playtest_errors": [],
         "qa_diagnosis": "",
+        **derive_artifact_gate(build_ok=True, qa_ok=False).as_dict(),
     }
 
 
@@ -254,6 +257,10 @@ class ForgeState(TypedDict, total=False):
     artifacts: list[dict[str, str]]
     code_ok: bool
     qa_ok: bool
+    # ADR-01 产物门禁（与 qa_ok 分立；publishable 仅 qa_ok 时为真）
+    generation_success: bool
+    previewable: bool
+    publishable: bool
     attempt: int
     exhausted: bool
     candidate_version: int | None
@@ -1000,6 +1007,7 @@ def _build_graph(ctx: _Ctx) -> Any:
             else:
                 # 重放：已 promote 过则保持成功语义，避免重复抬版本
                 await ctx.s.refresh(ctx.game)
+            gate = derive_artifact_gate(build_ok=True, qa_ok=True)
             return {
                 **result,
                 "qa_ok": True,
@@ -1007,10 +1015,13 @@ def _build_graph(ctx: _Ctx) -> Any:
                 "code_ok": True,
                 "code_qa_reset": False,
                 "design_doc": design_doc,
+                **gate.as_dict(),
             }
 
         if result.get("exhausted"):
             errors = list(result.get("playtest_errors") or [])
+            has_candidate = bool(result.get("candidate_version"))
+            gate = derive_artifact_gate(build_ok=has_candidate, qa_ok=False)
             await ckpt.save_state(
                 ctx.r,
                 ctx.run.id,
@@ -1025,6 +1036,8 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "artifacts": result.get("artifacts")
                     or state.get("artifacts")
                     or [],
+                    "candidate_version": result.get("candidate_version"),
+                    **gate.as_dict(),
                 },
                 ctx.s,
             )
@@ -1036,6 +1049,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "issues": errors,
                     "attempt": result.get("attempt"),
                     "failure_kind": result.get("failure_kind"),
+                    **gate.as_dict(),
                 },
             )
             return {
@@ -1080,6 +1094,7 @@ def _build_graph(ctx: _Ctx) -> Any:
             await ckpt.clear_state(ctx.r, ctx.run.id, ctx.s)
             await run_ctrl.clear_control(ctx.r, ctx.run.id)
             await ctx.s.commit()
+            gate = derive_artifact_gate(build_ok=True, qa_ok=True)
             await publish_event(
                 ctx.run.id,
                 WSEventType.DONE,
@@ -1088,6 +1103,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "game_id": str(ctx.game.id),
                     "version": ctx.game.current_version,
                     "preview_url": f"/draft/{ctx.game.id}/{ctx.game.current_version}",
+                    **gate.as_dict(),
                 },
             )
             return {}

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -1224,8 +1224,11 @@ async def run_generation(
                         extra={"stage": stage, "duration": duration},
                     )
                 await s.rollback()
-                await s.refresh(run)
-                if run.ended_at is not None:
+                run = await s.get(GenerationRun, run_id)
+                if run is None or run.ended_at is not None:
+                    return
+                game = await s.get(Game, run.game_id)
+                if game is None:
                     return
 
                 # 审核命中 / 明确 Fatal → FAILED；可恢复错误 → paused+recoverable_error
@@ -1258,7 +1261,9 @@ async def run_generation(
                     return
 
                 classified = (
-                    e if isinstance(e, FatalError) or is_recoverable(e) else classify_exception(e)
+                    e
+                    if isinstance(e, FatalError) or is_recoverable(e)
+                    else classify_exception(e)
                 )
                 if is_fatal(classified) or isinstance(e, AppError):
                     fail_code = (

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.errors import AppError
-from app.enums import RunPhase, RunStatus, WSEventType
+from app.enums import PauseReason, RunPhase, RunStatus, WSEventType
 from app.forge import control as run_ctrl
 from app.forge import state as ckpt
 from app.forge.art_direction import parse_art_detail, parse_art_options
@@ -44,6 +44,15 @@ from app.forge.prompts import (
     ART_OPTIONS_REVISE_PROMPT,
     PLAN_PROMPT,
     PLAN_REVISE_PROMPT,
+)
+from app.forge.reliability import (
+    FatalError,
+    RecoveryInfo,
+    apply_paused_metadata,
+    build_pause_checkpoint,
+    classify_exception,
+    is_fatal,
+    is_recoverable,
 )
 from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
 from app.forge.tracing import observe_phase, observe_run
@@ -373,7 +382,22 @@ async def _pause_hitl(
     await ctx.s.refresh(ctx.run)
     if ctx.run.status != RunStatus.RUNNING.value or ctx.run.ended_at is not None:
         raise RunFinalized
-    ctx.run.status = RunStatus.PAUSED.value
+    apply_paused_metadata(ctx.run)
+    existing = await ckpt.load_state(ctx.r, ctx.run.id, ctx.s) or {}
+    checkpoint = build_pause_checkpoint(
+        phase=str(existing.get("phase") or node),
+        pause_reason=PauseReason.WAITING_USER,
+        design_doc=design_doc,
+        extra={
+            **{k: v for k, v in existing.items() if k not in {"recovery", "pause_reason"}},
+            "phase": str(existing.get("phase") or node),
+            "design_doc": design_doc,
+            **(extra or {}),
+        },
+    )
+    # build_pause_checkpoint 已写入 pause_reason；去掉可能被 extra 带入的 recovery
+    checkpoint.pop("recovery", None)
+    await ckpt.save_state(ctx.r, ctx.run.id, checkpoint, ctx.s)
     await add_message(
         ctx.s,
         game_id=ctx.game.id,
@@ -389,11 +413,82 @@ async def _pause_hitl(
     payload = {
         "node": node,
         "design_doc": design_doc,
+        "pause_reason": PauseReason.WAITING_USER.value,
         "action_url": f"/api/v1/games/{ctx.game.id}/runs/{ctx.run.id}/hitl/resolve",
     }
     if extra:
         payload.update(extra)
     await publish_event(ctx.run.id, WSEventType.HITL_WAIT, payload)
+
+
+async def _pause_recoverable(
+    ctx: _Ctx,
+    *,
+    phase: str,
+    error_code: str,
+    message: str,
+    attempts: int = 1,
+) -> None:
+    """可恢复故障：status=paused + pause_reason=recoverable_error（ADR-05）。"""
+    await ctx.s.refresh(ctx.run)
+    if ctx.run.ended_at is not None or ctx.run.status == RunStatus.FAILED.value:
+        raise RunFinalized
+    apply_paused_metadata(ctx.run)
+    existing = await ckpt.load_state(ctx.r, ctx.run.id, ctx.s) or {}
+    recovery = RecoveryInfo(
+        node=phase,
+        error_code=error_code,
+        attempts=attempts,
+        can_retry=True,
+    )
+    checkpoint = build_pause_checkpoint(
+        phase=phase,
+        pause_reason=PauseReason.RECOVERABLE_ERROR,
+        design_doc=existing.get("design_doc"),
+        recovery=recovery,
+        extra={
+            k: v
+            for k, v in existing.items()
+            if k not in {"pause_reason", "recovery", "phase"}
+        },
+    )
+    await ckpt.save_state(ctx.r, ctx.run.id, checkpoint, ctx.s)
+    await add_message(
+        ctx.s,
+        game_id=ctx.game.id,
+        run_id=ctx.run.id,
+        user_id=ctx.run.user_id,
+        role="assistant",
+        kind="paused",
+        content=message,
+        metadata={
+            "pause_reason": PauseReason.RECOVERABLE_ERROR.value,
+            "recovery": {
+                "node": recovery.node,
+                "error_code": recovery.error_code,
+                "attempts": recovery.attempts,
+                "can_retry": recovery.can_retry,
+            },
+        },
+        dedupe_key=f"{ctx.run.id}:paused:{error_code}:{attempts}",
+    )
+    await ctx.s.commit()
+    await publish_event(
+        ctx.run.id,
+        WSEventType.ERROR,
+        {
+            "code": error_code,
+            "message": message,
+            "fatal": False,
+            "pause_reason": PauseReason.RECOVERABLE_ERROR.value,
+            "recovery": {
+                "node": recovery.node,
+                "error_code": recovery.error_code,
+                "attempts": recovery.attempts,
+                "can_retry": recovery.can_retry,
+            },
+        },
+    )
 
 
 async def _check_ctrl(
@@ -406,9 +501,16 @@ async def _check_ctrl(
     if flag == "pause":
         doc = coerce_design_doc(design_doc, ctx.game.title)
         await ckpt.save_state(
-            ctx.r, ctx.run.id, {"phase": "user_pause", "design_doc": doc}, ctx.s
+            ctx.r,
+            ctx.run.id,
+            build_pause_checkpoint(
+                phase="user_pause",
+                pause_reason=PauseReason.MANUAL_HOLD,
+                design_doc=doc,
+            ),
+            ctx.s,
         )
-        ctx.run.status = RunStatus.PAUSED.value
+        apply_paused_metadata(ctx.run)
         await ctx.s.commit()
         await run_ctrl.clear_control(ctx.r, ctx.run.id)
         return "pause"
@@ -476,6 +578,17 @@ def _build_graph(ctx: _Ctx) -> Any:
             return "art_detail"
         # qa_failed / sandbox_failed：HITL 恢复后重新进入 CodeQaLoop（attempt 重置）
         if st.get("phase") in ("sandbox_failed", "qa_failed"):
+            return "code_qa_loop"
+        if st.get("pause_reason") == PauseReason.RECOVERABLE_ERROR.value:
+            node = ""
+            recovery = st.get("recovery")
+            if isinstance(recovery, dict):
+                node = str(recovery.get("node") or "")
+            node = node or str(phase or "")
+            if node in {"plan", "revise_plan"}:
+                return "plan"
+            if node in {"art", "art_options", "art_detail", "revise_art_options"}:
+                return "art_options"
             return "code_qa_loop"
         if st.get("phase") == "user_pause":
             return "art_options"
@@ -1063,7 +1176,6 @@ async def run_generation(
             except Exception as e:
                 duration = round(time.monotonic() - started, 3)
                 if isinstance(e, AppError):
-                    # 业务错（LLM 未配置/apikey 错等）不打整条栈，仅一行 warning
                     log.warning(
                         "request failed (business)",
                         extra={
@@ -1077,7 +1189,12 @@ async def run_generation(
                         "request failed",
                         extra={"stage": stage, "duration": duration},
                     )
-                # 审核命中走 CONTENT_BLOCKED 友好分支；其余通用 RUN_FAILED。
+                await s.rollback()
+                await s.refresh(run)
+                if run.ended_at is not None:
+                    return
+
+                # 审核命中 / 明确 Fatal → FAILED；可恢复错误 → paused+recoverable_error
                 if isinstance(e, ContentAttacked):
                     fail_code = "CONTENT_BLOCKED"
                     fail_msg = (
@@ -1085,12 +1202,6 @@ async def run_generation(
                         if e.side == "output"
                         else f"输入未通过安全审核（{e.category}），已中断。"
                     )
-                else:
-                    fail_code = "RUN_FAILED"
-                    fail_msg = f"本轮生成失败：{e}"
-                await s.rollback()
-                await s.refresh(run)
-                if run.ended_at is None:
                     run.status = RunStatus.FAILED.value
                     run.ended_at = datetime.now(UTC)
                     await add_message(
@@ -1110,6 +1221,68 @@ async def run_generation(
                         WSEventType.ERROR,
                         {"code": fail_code, "message": fail_msg, "fatal": True},
                     )
+                    return
+
+                classified = (
+                    e if isinstance(e, FatalError) or is_recoverable(e) else classify_exception(e)
+                )
+                if is_fatal(classified) or isinstance(e, AppError):
+                    fail_code = (
+                        e.code.value if isinstance(e, AppError) else classified.error_code
+                    )
+                    fail_msg = f"本轮生成失败：{e}"
+                    run.status = RunStatus.FAILED.value
+                    run.ended_at = datetime.now(UTC)
+                    await add_message(
+                        s,
+                        game_id=run.game_id,
+                        run_id=run.id,
+                        user_id=run.user_id,
+                        role="assistant",
+                        kind="failed",
+                        content=fail_msg,
+                        metadata={"code": fail_code, "phase": run.phase},
+                        dedupe_key=f"{run.id}:failed:{fail_code}",
+                    )
+                    await s.commit()
+                    await publish_event(
+                        run_id,
+                        WSEventType.ERROR,
+                        {"code": fail_code, "message": fail_msg, "fatal": True},
+                    )
+                    return
+
+                if is_recoverable(classified):
+                    forge_ctx = _Ctx(s, r, run, game)
+                    await _pause_recoverable(
+                        forge_ctx,
+                        phase=run.phase or "code",
+                        error_code=classified.error_code,
+                        message=f"可恢复故障，已暂停：{classified}",
+                        attempts=1,
+                    )
+                    return
+
+                # 兜底：未知但仍非 fatal 的路径不应静默
+                run.status = RunStatus.FAILED.value
+                run.ended_at = datetime.now(UTC)
+                await add_message(
+                    s,
+                    game_id=run.game_id,
+                    run_id=run.id,
+                    user_id=run.user_id,
+                    role="assistant",
+                    kind="failed",
+                    content=f"本轮生成失败：{e}",
+                    metadata={"code": "RUN_FAILED", "phase": run.phase},
+                    dedupe_key=f"{run.id}:failed:RUN_FAILED",
+                )
+                await s.commit()
+                await publish_event(
+                    run_id,
+                    WSEventType.ERROR,
+                    {"code": "RUN_FAILED", "message": str(e), "fatal": True},
+                )
     finally:
         clear_log_context()
 

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -27,7 +27,7 @@ from app.forge import control as run_ctrl
 from app.forge import state as ckpt
 from app.forge.art_direction import parse_art_detail, parse_art_options
 from app.forge.assets.picker import asset_pick
-from app.forge.code_candidate import next_candidate_version, promote_candidate
+from app.forge.code_candidate import claim_candidate_version, promote_candidate
 from app.forge.design_doc import (
     coerce_design_doc,
     design_doc_to_text,
@@ -125,6 +125,7 @@ async def _commit_project_build(
     design_doc: dict[str, Any],
     artifacts: list[Any],
     art_direction: dict[str, Any] | None,
+    attempt: int = 1,
 ) -> dict[str, Any]:
     """Vite 多文件构建成功后落盘为 candidate（不 promote current_version）。"""
     from app.games import services as game_services
@@ -133,7 +134,13 @@ async def _commit_project_build(
     if ctx.run.status != RunStatus.RUNNING.value or ctx.run.ended_at is not None:
         raise RunFinalized
 
-    version = await next_candidate_version(ctx.s, ctx.game)
+    version, _is_new = await claim_candidate_version(
+        ctx.r,
+        ctx.s,
+        ctx.game,
+        run_id=ctx.run.id,
+        attempt=int(attempt),
+    )
     artifact = f"{ctx.game.id}/{version}/index.html"
     await store.write_version_layers(
         ctx.game.id,
@@ -142,14 +149,24 @@ async def _commit_project_build(
         build_snapshot=project_result.build_snapshot,
         dist=project_result.dist,
     )
-    ctx.s.add(
-        GameVersion(
-            game_id=ctx.game.id,
-            version=version,
-            artifact_path=artifact,
-            design_doc=design_doc,
+    existing_gv = await ctx.s.scalar(
+        select(GameVersion).where(
+            GameVersion.game_id == ctx.game.id,
+            GameVersion.version == version,
         )
     )
+    if existing_gv is None:
+        ctx.s.add(
+            GameVersion(
+                game_id=ctx.game.id,
+                version=version,
+                artifact_path=artifact,
+                design_doc=design_doc,
+            )
+        )
+    else:
+        existing_gv.artifact_path = artifact
+        existing_gv.design_doc = design_doc
     await ctx.s.commit()
     await game_services.prune_old_versions(ctx.s, ctx.game)
     token = await preview_token_svc.mint_preview_token(

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -54,6 +54,7 @@ from app.forge.reliability import (
     is_fatal,
     is_recoverable,
 )
+from app.forge.reliability.policy import langgraph_retry_policy, langgraph_timeout_policy
 from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
 from app.forge.tracing import observe_phase, observe_run
 from app.hosting import preview_token as preview_token_svc
@@ -1081,13 +1082,21 @@ def _build_graph(ctx: _Ctx) -> Any:
             return "done"
         return END
 
+    def _node_kwargs(policy_key: str) -> dict[str, object]:
+        if not settings.reliability_node_timeout:
+            return {}
+        return {
+            "timeout": langgraph_timeout_policy(policy_key),
+            "retry_policy": langgraph_retry_policy(policy_key),
+        }
+
     g = StateGraph(ForgeState)
-    g.add_node("plan", plan_node)
-    g.add_node("revise_plan", revise_plan_node)
-    g.add_node("art_options", art_options_node)
-    g.add_node("revise_art_options", revise_art_options_node)
-    g.add_node("art_detail", art_detail_node)
-    g.add_node("code_qa_loop", code_qa_loop_node)
+    g.add_node("plan", plan_node, **_node_kwargs("plan"))
+    g.add_node("revise_plan", revise_plan_node, **_node_kwargs("plan"))
+    g.add_node("art_options", art_options_node, **_node_kwargs("art"))
+    g.add_node("revise_art_options", revise_art_options_node, **_node_kwargs("art"))
+    g.add_node("art_detail", art_detail_node, **_node_kwargs("art"))
+    g.add_node("code_qa_loop", code_qa_loop_node, **_node_kwargs("code_qa_loop"))
     g.add_node("done", done_node)
     g.add_conditional_edges(
         START,

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -54,6 +54,7 @@ from app.forge.reliability import (
     is_fatal,
     is_recoverable,
 )
+from app.forge.reliability.idempotency import side_effect_key, try_begin_side_effect
 from app.forge.reliability.policy import langgraph_retry_policy, langgraph_timeout_policy
 from app.forge.subgraphs.code_qa_loop import build_code_qa_loop
 from app.forge.tracing import observe_phase, observe_run
@@ -973,8 +974,15 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "design_doc": design_doc,
                     "playtest_errors": ["qa_ok 但缺少 candidate_version"],
                 }
-            promote_candidate(ctx.game, int(version))
-            await ctx.s.commit()
+            key = side_effect_key(
+                ctx.run.id, "code_qa_loop", f"v{int(version)}", "promote"
+            )
+            if await try_begin_side_effect(ctx.r, key):
+                promote_candidate(ctx.game, int(version))
+                await ctx.s.commit()
+            else:
+                # 重放：已 promote 过则保持成功语义，避免重复抬版本
+                await ctx.s.refresh(ctx.game)
             return {
                 **result,
                 "qa_ok": True,

--- a/backend/app/forge/reliability/__init__.py
+++ b/backend/app/forge/reliability/__init__.py
@@ -19,6 +19,13 @@ from app.forge.reliability.errors import (
     is_fatal,
     is_recoverable,
 )
+from app.forge.reliability.pause import (
+    RecoveryInfo,
+    apply_paused_metadata,
+    build_pause_checkpoint,
+    pause_reason_from_state,
+    recovery_from_state,
+)
 
 __all__ = [
     "DataCorruption",
@@ -30,12 +37,17 @@ __all__ = [
     "ProviderRateLimit",
     "ProviderTimeout",
     "RecoverableError",
+    "RecoveryInfo",
     "SandboxOOM",
     "SandboxTimeout",
     "SecurityViolation",
     "UserActionRequired",
     "WorkerInterrupted",
+    "apply_paused_metadata",
+    "build_pause_checkpoint",
     "classify_exception",
     "is_fatal",
     "is_recoverable",
+    "pause_reason_from_state",
+    "recovery_from_state",
 ]

--- a/backend/app/forge/reliability/__init__.py
+++ b/backend/app/forge/reliability/__init__.py
@@ -1,5 +1,6 @@
 """Forge 可靠性子系统（P0）：错误分类、暂停原因、节点策略、幂等。"""
 
+from app.forge.reliability.artifact_gate import ArtifactGate, derive_artifact_gate
 from app.forge.reliability.errors import (
     DataCorruption,
     FatalError,
@@ -40,6 +41,7 @@ from app.forge.reliability.policy import (
 )
 
 __all__ = [
+    "ArtifactGate",
     "DataCorruption",
     "FatalError",
     "ForgeRuntimeError",
@@ -60,6 +62,7 @@ __all__ = [
     "apply_paused_metadata",
     "build_pause_checkpoint",
     "classify_exception",
+    "derive_artifact_gate",
     "get_side_effect_value",
     "is_fatal",
     "is_recoverable",

--- a/backend/app/forge/reliability/__init__.py
+++ b/backend/app/forge/reliability/__init__.py
@@ -1,0 +1,41 @@
+"""Forge 可靠性子系统（P0）：错误分类、暂停原因、节点策略、幂等。"""
+
+from app.forge.reliability.errors import (
+    DataCorruption,
+    FatalError,
+    ForgeRuntimeError,
+    InvalidModelOutput,
+    InvariantViolation,
+    Provider5xx,
+    ProviderRateLimit,
+    ProviderTimeout,
+    RecoverableError,
+    SandboxOOM,
+    SandboxTimeout,
+    SecurityViolation,
+    UserActionRequired,
+    WorkerInterrupted,
+    classify_exception,
+    is_fatal,
+    is_recoverable,
+)
+
+__all__ = [
+    "DataCorruption",
+    "FatalError",
+    "ForgeRuntimeError",
+    "InvalidModelOutput",
+    "InvariantViolation",
+    "Provider5xx",
+    "ProviderRateLimit",
+    "ProviderTimeout",
+    "RecoverableError",
+    "SandboxOOM",
+    "SandboxTimeout",
+    "SecurityViolation",
+    "UserActionRequired",
+    "WorkerInterrupted",
+    "classify_exception",
+    "is_fatal",
+    "is_recoverable",
+]

--- a/backend/app/forge/reliability/__init__.py
+++ b/backend/app/forge/reliability/__init__.py
@@ -21,6 +21,7 @@ from app.forge.reliability.errors import (
 )
 from app.forge.reliability.idempotency import (
     already_applied,
+    get_side_effect_value,
     side_effect_key,
     try_begin_side_effect,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "apply_paused_metadata",
     "build_pause_checkpoint",
     "classify_exception",
+    "get_side_effect_value",
     "is_fatal",
     "is_recoverable",
     "langgraph_retry_policy",

--- a/backend/app/forge/reliability/__init__.py
+++ b/backend/app/forge/reliability/__init__.py
@@ -26,6 +26,12 @@ from app.forge.reliability.pause import (
     pause_reason_from_state,
     recovery_from_state,
 )
+from app.forge.reliability.policy import (
+    NODE_EXECUTION_POLICIES,
+    langgraph_retry_policy,
+    langgraph_timeout_policy,
+    resolve_node_run_timeout,
+)
 
 __all__ = [
     "DataCorruption",
@@ -33,6 +39,7 @@ __all__ = [
     "ForgeRuntimeError",
     "InvalidModelOutput",
     "InvariantViolation",
+    "NODE_EXECUTION_POLICIES",
     "Provider5xx",
     "ProviderRateLimit",
     "ProviderTimeout",
@@ -48,6 +55,9 @@ __all__ = [
     "classify_exception",
     "is_fatal",
     "is_recoverable",
+    "langgraph_retry_policy",
+    "langgraph_timeout_policy",
     "pause_reason_from_state",
     "recovery_from_state",
+    "resolve_node_run_timeout",
 ]

--- a/backend/app/forge/reliability/__init__.py
+++ b/backend/app/forge/reliability/__init__.py
@@ -19,6 +19,11 @@ from app.forge.reliability.errors import (
     is_fatal,
     is_recoverable,
 )
+from app.forge.reliability.idempotency import (
+    already_applied,
+    side_effect_key,
+    try_begin_side_effect,
+)
 from app.forge.reliability.pause import (
     RecoveryInfo,
     apply_paused_metadata,
@@ -50,6 +55,7 @@ __all__ = [
     "SecurityViolation",
     "UserActionRequired",
     "WorkerInterrupted",
+    "already_applied",
     "apply_paused_metadata",
     "build_pause_checkpoint",
     "classify_exception",
@@ -60,4 +66,6 @@ __all__ = [
     "pause_reason_from_state",
     "recovery_from_state",
     "resolve_node_run_timeout",
+    "side_effect_key",
+    "try_begin_side_effect",
 ]

--- a/backend/app/forge/reliability/artifact_gate.py
+++ b/backend/app/forge/reliability/artifact_gate.py
@@ -1,0 +1,39 @@
+"""产物门禁标志（ADR-01）：previewable ≠ publishable，build_ok ≠ qa_ok。"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactGate:
+    generation_success: bool
+    previewable: bool
+    publishable: bool
+    qa_ok: bool
+
+    def __post_init__(self) -> None:
+        if self.publishable and not self.qa_ok:
+            raise ValueError("publishable requires qa_ok=True")
+        if self.qa_ok and not self.previewable:
+            raise ValueError("qa_ok requires previewable=True")
+
+    def as_dict(self) -> dict[str, bool]:
+        return asdict(self)
+
+
+def derive_artifact_gate(*, build_ok: bool, qa_ok: bool) -> ArtifactGate:
+    """由构建与 B 档 QA 结果推导三标志。
+
+    - 构建成功即可预览，但不得自动视为可发布
+    - 仅 qa_ok 时 publishable=True
+    - 禁止用静态检测合成 qa_ok
+    """
+    if qa_ok and not build_ok:
+        raise ValueError("qa_ok requires build_ok=True")
+    return ArtifactGate(
+        generation_success=bool(build_ok),
+        previewable=bool(build_ok),
+        publishable=bool(qa_ok),
+        qa_ok=bool(qa_ok),
+    )

--- a/backend/app/forge/reliability/errors.py
+++ b/backend/app/forge/reliability/errors.py
@@ -1,0 +1,110 @@
+"""Forge 运行时错误分类（P0）。
+
+RecoverableError 不得直接把 Run 打成 FAILED；仅 FatalError（及明确取消）可进不可恢复终态。
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+class ForgeRuntimeError(Exception):
+    """Forge 运行时错误基类。"""
+
+    error_code: str = "forge_runtime_error"
+
+    def __init__(self, message: str = "", *, cause: BaseException | None = None) -> None:
+        super().__init__(message or self.error_code)
+        self.cause = cause
+
+
+class RecoverableError(ForgeRuntimeError):
+    """可恢复：retry / fallback / paused+recoverable_error。"""
+
+    error_code = "recoverable_error"
+
+
+class ProviderTimeout(RecoverableError):
+    error_code = "provider_timeout"
+
+
+class ProviderRateLimit(RecoverableError):
+    error_code = "provider_rate_limit"
+
+
+class Provider5xx(RecoverableError):
+    error_code = "provider_5xx"
+
+
+class InvalidModelOutput(RecoverableError):
+    error_code = "invalid_model_output"
+
+
+class SandboxTimeout(RecoverableError):
+    error_code = "sandbox_timeout"
+
+
+class SandboxOOM(RecoverableError):
+    error_code = "sandbox_oom"
+
+
+class WorkerInterrupted(RecoverableError):
+    error_code = "worker_interrupted"
+
+
+class UserActionRequired(ForgeRuntimeError):
+    """需用户介入（HITL），非 fatal、也非自动 retry 语义。"""
+
+    error_code = "user_action_required"
+
+
+class FatalError(ForgeRuntimeError):
+    """不可恢复：数据损坏 / invariant / 安全。"""
+
+    error_code = "fatal_error"
+
+
+class DataCorruption(FatalError):
+    error_code = "data_corruption"
+
+
+class InvariantViolation(FatalError):
+    error_code = "invariant_violation"
+
+
+class SecurityViolation(FatalError):
+    error_code = "security_violation"
+
+
+def is_recoverable(exc: BaseException) -> bool:
+    return isinstance(exc, RecoverableError)
+
+
+def is_fatal(exc: BaseException) -> bool:
+    return isinstance(exc, FatalError)
+
+
+def classify_exception(exc: BaseException) -> ForgeRuntimeError:
+    """将常见底层异常映射为 Forge 错误分类；已是 Forge 错误则原样返回。"""
+    if isinstance(exc, ForgeRuntimeError):
+        return exc
+
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+        return ProviderTimeout(str(exc) or "provider timeout", cause=exc)
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        if status == 429:
+            return ProviderRateLimit(str(exc) or "rate limited", cause=exc)
+        if 500 <= status <= 599:
+            return Provider5xx(str(exc) or f"provider {status}", cause=exc)
+        return WorkerInterrupted(str(exc) or f"http {status}", cause=exc)
+
+    msg = str(exc).lower()
+    if "out of memory" in msg or "oom" in msg:
+        return SandboxOOM(str(exc) or "sandbox oom", cause=exc)
+    if "构建超时" in str(exc) or "sandbox timeout" in msg:
+        return SandboxTimeout(str(exc) or "sandbox timeout", cause=exc)
+
+    # 未知瞬态默认按可恢复中断，避免误杀整个 Run；真正 invariant 应由调用方显式抛 Fatal。
+    return WorkerInterrupted(str(exc) or "worker interrupted", cause=exc)

--- a/backend/app/forge/reliability/errors.py
+++ b/backend/app/forge/reliability/errors.py
@@ -5,6 +5,8 @@ RecoverableError 不得直接把 Run 打成 FAILED；仅 FatalError（及明确�
 
 from __future__ import annotations
 
+import re
+
 import httpx
 
 
@@ -101,7 +103,7 @@ def classify_exception(exc: BaseException) -> ForgeRuntimeError:
         return WorkerInterrupted(str(exc) or f"http {status}", cause=exc)
 
     msg = str(exc).lower()
-    if "out of memory" in msg or "oom" in msg:
+    if "out of memory" in msg or re.search(r"\boom\b", msg):
         return SandboxOOM(str(exc) or "sandbox oom", cause=exc)
     if "构建超时" in str(exc) or "sandbox timeout" in msg:
         return SandboxTimeout(str(exc) or "sandbox timeout", cause=exc)

--- a/backend/app/forge/reliability/idempotency.py
+++ b/backend/app/forge/reliability/idempotency.py
@@ -1,0 +1,45 @@
+"""副作用幂等：timeout/重放不得重复 promote / billing。"""
+
+from __future__ import annotations
+
+import uuid
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+
+_KEY = "forge:side:{run_id}:{node}:{execution_id}:{operation}"
+
+
+def side_effect_key(
+    run_id: uuid.UUID,
+    node: str,
+    execution_id: str,
+    operation: str,
+) -> str:
+    return _KEY.format(
+        run_id=run_id,
+        node=node,
+        execution_id=execution_id,
+        operation=operation,
+    )
+
+
+async def try_begin_side_effect(
+    r: redis.Redis,
+    key: str,
+    *,
+    ttl_s: int | None = None,
+) -> bool:
+    """首次返回 True；已执行过返回 False。Flag 关闭时始终 True（兼容旧路径）。"""
+    if not settings.reliability_idempotent_side_effects:
+        return True
+    ttl = ttl_s if ttl_s is not None else settings.create_run_idempotency_ttl
+    ok = await r.set(key, "1", nx=True, ex=max(1, ttl))
+    return bool(ok)
+
+
+async def already_applied(r: redis.Redis, key: str) -> bool:
+    if not settings.reliability_idempotent_side_effects:
+        return False
+    return bool(await r.exists(key))

--- a/backend/app/forge/reliability/idempotency.py
+++ b/backend/app/forge/reliability/idempotency.py
@@ -30,13 +30,21 @@ async def try_begin_side_effect(
     key: str,
     *,
     ttl_s: int | None = None,
+    value: str = "1",
 ) -> bool:
-    """首次返回 True；已执行过返回 False。Flag 关闭时始终 True（兼容旧路径）。"""
+    """首次返回 True 并写入 value；已执行过返回 False。Flag 关闭时始终 True。"""
     if not settings.reliability_idempotent_side_effects:
         return True
     ttl = ttl_s if ttl_s is not None else settings.create_run_idempotency_ttl
-    ok = await r.set(key, "1", nx=True, ex=max(1, ttl))
+    ok = await r.set(key, value, nx=True, ex=max(1, ttl))
     return bool(ok)
+
+
+async def get_side_effect_value(r: redis.Redis, key: str) -> str | None:
+    if not settings.reliability_idempotent_side_effects:
+        return None
+    raw = await r.get(key)
+    return str(raw) if raw is not None else None
 
 
 async def already_applied(r: redis.Redis, key: str) -> bool:

--- a/backend/app/forge/reliability/pause.py
+++ b/backend/app/forge/reliability/pause.py
@@ -1,0 +1,62 @@
+"""可恢复暂停：status=paused + pause_reason/recovery（ADR-05）。"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from app.enums import PauseReason, RunStatus
+
+
+class _StatusCarrier(Protocol):
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryInfo:
+    node: str
+    error_code: str
+    attempts: int
+    can_retry: bool = True
+
+
+def apply_paused_metadata(run: _StatusCarrier) -> None:
+    """仅设置 status=paused，不引入新 RunStatus。"""
+    run.status = RunStatus.PAUSED.value
+
+
+def build_pause_checkpoint(
+    *,
+    phase: str,
+    pause_reason: PauseReason,
+    design_doc: dict[str, Any] | str | None = None,
+    recovery: RecoveryInfo | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "phase": phase,
+        "pause_reason": pause_reason.value,
+    }
+    if design_doc is not None:
+        state["design_doc"] = design_doc
+    if recovery is not None:
+        state["recovery"] = asdict(recovery)
+    if extra:
+        state.update(extra)
+    return state
+
+
+def pause_reason_from_state(state: dict[str, Any] | None) -> PauseReason | None:
+    if not state:
+        return None
+    raw = state.get("pause_reason")
+    if raw is None:
+        return None
+    return PauseReason(str(raw))
+
+
+def recovery_from_state(state: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not state:
+        return None
+    recovery = state.get("recovery")
+    return dict(recovery) if isinstance(recovery, dict) else None

--- a/backend/app/forge/reliability/policy.py
+++ b/backend/app/forge/reliability/policy.py
@@ -1,0 +1,69 @@
+"""节点执行策略：统一 timeout / retry 预算（与 CodeQa/Build 预算正交）。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from langgraph.types import RetryPolicy, TimeoutPolicy
+
+from app.core.config import settings
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecutionPolicy:
+    """单节点执行策略。
+
+    run_timeout_margin_s：相对 llm_request_timeout 的额外裕量；
+    若 fixed_run_timeout_s 非空则使用固定墙钟（无 LLM 节点）。
+    """
+
+    max_attempts: int = 2
+    run_timeout_margin_s: float = 60.0
+    fixed_run_timeout_s: float | None = None
+    idle_timeout_s: float | None = None
+
+
+NODE_EXECUTION_POLICIES: dict[str, NodeExecutionPolicy] = {
+    "entry_router": NodeExecutionPolicy(fixed_run_timeout_s=10.0, max_attempts=1),
+    "plan": NodeExecutionPolicy(run_timeout_margin_s=60.0, max_attempts=2),
+    "art": NodeExecutionPolicy(run_timeout_margin_s=60.0, max_attempts=2),
+    "code_or_repair": NodeExecutionPolicy(run_timeout_margin_s=120.0, max_attempts=2),
+    "playtest": NodeExecutionPolicy(fixed_run_timeout_s=90.0, max_attempts=2),
+    "diagnose": NodeExecutionPolicy(run_timeout_margin_s=30.0, max_attempts=2),
+    # 外墙：给满 attempt 预算的粗上限；细粒度 timeout 在子图节点上
+    "code_qa_loop": NodeExecutionPolicy(
+        fixed_run_timeout_s=None,
+        run_timeout_margin_s=0.0,
+        max_attempts=1,
+    ),
+}
+
+
+def resolve_node_run_timeout(node: str) -> float:
+    policy = NODE_EXECUTION_POLICIES[node]
+    if policy.fixed_run_timeout_s is not None:
+        return float(policy.fixed_run_timeout_s)
+    llm = float(settings.llm_request_timeout)
+    if node == "code_qa_loop":
+        # attempt × (code + playtest + diagnose) 粗算，避免外墙先于子步骤超时
+        attempts = max(1, int(settings.code_qa_max_attempts))
+        per = (
+            resolve_node_run_timeout("code_or_repair")
+            + resolve_node_run_timeout("playtest")
+            + resolve_node_run_timeout("diagnose")
+        )
+        return float(attempts * per)
+    return llm + float(policy.run_timeout_margin_s)
+
+
+def langgraph_timeout_policy(node: str) -> TimeoutPolicy:
+    policy = NODE_EXECUTION_POLICIES[node]
+    kwargs: dict[str, float] = {"run_timeout": resolve_node_run_timeout(node)}
+    if policy.idle_timeout_s is not None:
+        kwargs["idle_timeout"] = float(policy.idle_timeout_s)
+    return TimeoutPolicy(**kwargs)
+
+
+def langgraph_retry_policy(node: str) -> RetryPolicy:
+    policy = NODE_EXECUTION_POLICIES[node]
+    return RetryPolicy(max_attempts=max(1, policy.max_attempts))

--- a/backend/app/games/services.py
+++ b/backend/app/games/services.py
@@ -14,12 +14,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.admin import services as admin_services
 from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
-from app.enums import EntryPhase, GameStatus, RunPhase, RunStatus
+from app.enums import EntryPhase, GameStatus, PauseReason, RunPhase, RunStatus
 from app.forge import control as run_ctrl
 from app.forge import state as ckpt
 from app.forge.entry_router import classify_entry_phase
 from app.forge.messages import add_message
 from app.forge.queue import enqueue_resume
+from app.forge.reliability.pause import build_pause_checkpoint
 from app.hosting import store as hosting_store
 from app.messaging.outbox import add_task, cancel_run_tasks
 from app.messaging.tasks import (
@@ -453,6 +454,18 @@ async def pause_run(
         raise AppError(ErrorCode.INVALID_STATE, "仅 running 可暂停")
     await run_ctrl.request_pause(r, run_id)
     run.status = RunStatus.PAUSED.value
+    existing = await ckpt.load_state(r, run_id, db) or {}
+    await ckpt.save_state(
+        r,
+        run_id,
+        build_pause_checkpoint(
+            phase=str(existing.get("phase") or run.phase or "plan"),
+            pause_reason=PauseReason.MANUAL_HOLD,
+            design_doc=existing.get("design_doc"),
+            extra={k: v for k, v in existing.items() if k not in {"pause_reason", "recovery"}},
+        ),
+        db,
+    )
     await db.commit()
     await db.refresh(run)
     return run
@@ -552,21 +565,35 @@ async def activate_version(
 async def retry_run(
     db: AsyncSession, r: redis.Redis, user: User, run_id: UUID
 ) -> GenerationRun:
-    """从失败检查点重试（Batch A · B-A5）。"""
+    """从失败检查点或可恢复暂停重试（Batch A · B-A5 / P0 ADR-05）。"""
     run = await get_run(db, user, run_id)
     st = await ckpt.load_state(r, run_id, db) or {}
     phase = st.get("phase")
-    if phase not in _RETRY_PHASES:
+    pause_reason = st.get("pause_reason")
+    recovery = st.get("recovery") if isinstance(st.get("recovery"), dict) else {}
+    recoverable = (
+        pause_reason == PauseReason.RECOVERABLE_ERROR.value
+        and bool(recovery.get("can_retry", True))
+    )
+    if phase not in _RETRY_PHASES and not recoverable:
         raise AppError(ErrorCode.INVALID_STATE, "当前 run 不可重试")
     if run.status not in (RunStatus.FAILED.value, RunStatus.PAUSED.value):
         raise AppError(ErrorCode.INVALID_STATE, "当前 run 不可重试")
     await run_ctrl.clear_control(r, run_id)
     await r.delete(f"run:hitl:{run_id}")
     run.status = RunStatus.RUNNING.value
-    run.phase = RunPhase.CODE.value
+    if phase in _RETRY_PHASES:
+        run.phase = RunPhase.CODE.value
+    else:
+        run.phase = run.phase or RunPhase.CODE.value
     run.ended_at = None
-    # 下一轮 CodeQaLoop 从 attempt==1 开始
-    st = {**st, "code_qa_reset": True}
+    # 下一轮 CodeQaLoop 从 attempt==1 开始；清掉 recoverable 元数据避免陈旧 UI
+    st = {
+        **st,
+        "code_qa_reset": True,
+    }
+    st.pop("pause_reason", None)
+    st.pop("recovery", None)
     await ckpt.save_state(r, run_id, st, db)
     await add_message(
         db,
@@ -576,7 +603,7 @@ async def retry_run(
         role="system",
         kind="retry",
         content="正在从失败阶段重试本轮生成。",
-        dedupe_key=f"{run.id}:retry:{phase}",
+        dedupe_key=f"{run.id}:retry:{phase or 'recoverable'}",
     )
     await enqueue_resume(db, r, run_id, "approve", None)
     await db.commit()

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -3,6 +3,7 @@
 明文 key 仅内存单次调用生命周期，不落日志（docs/05）。测试 monkeypatch call_llm。
 """
 
+import hashlib
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
@@ -18,6 +19,7 @@ from app.core.errors import AppError, ErrorCode
 from app.core.langfuse import observe_generation
 from app.core.metrics import LLM_CALLS, LLM_TOKENS
 from app.enums import LLMProvider, Role
+from app.forge.reliability.idempotency import side_effect_key
 from app.llm import circuit, crypto, provider
 from app.llm.provider import StreamChunk
 from app.models.llm_config import UserLLMConfig
@@ -25,6 +27,23 @@ from app.models.user import User
 from app.notify import services as notify_services
 from app.usage import quota as quota_mod
 from app.usage.store import get_system_usage, get_user_usage, record_usage
+
+
+def _usage_idem_key(
+    *,
+    user_id: uuid.UUID,
+    run_id: uuid.UUID | None,
+    system: str,
+    user_msg: str,
+    content: str,
+    input_tokens: int,
+    output_tokens: int,
+) -> str:
+    digest = hashlib.sha256(
+        f"{system}\0{user_msg}\0{content}\0{input_tokens}\0{output_tokens}".encode()
+    ).hexdigest()[:24]
+    scope = run_id or user_id
+    return side_effect_key(scope, "llm", digest, "usage")
 
 
 async def _get_config(
@@ -176,6 +195,15 @@ async def call_llm(
         output_tokens=usage.output_tokens,
         game_id=game_id,
         run_id=run_id,
+        idempotency_key=_usage_idem_key(
+            user_id=user_id,
+            run_id=run_id,
+            system=system,
+            user_msg=user_msg,
+            content=content,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+        ),
     )
     await _maybe_quota_alert(db, r, user_id)
     await _maybe_system_alert(db, r)
@@ -249,6 +277,7 @@ async def call_llm_stream(
         LLM_CALLS.labels(prov.value, "ok").inc()
         LLM_TOKENS.labels(prov.value, "input").inc(usage_acc.input_tokens)
         LLM_TOKENS.labels(prov.value, "output").inc(usage_acc.output_tokens)
+        full_text = "".join(accumulated)
         await record_usage(
             r,
             user_id,
@@ -256,6 +285,15 @@ async def call_llm_stream(
             output_tokens=usage_acc.output_tokens,
             game_id=game_id,
             run_id=run_id,
+            idempotency_key=_usage_idem_key(
+                user_id=user_id,
+                run_id=run_id,
+                system=system,
+                user_msg=user_msg,
+                content=full_text,
+                input_tokens=usage_acc.input_tokens,
+                output_tokens=usage_acc.output_tokens,
+            ),
         )
         await _maybe_quota_alert(db, r, user_id)
         await _maybe_system_alert(db, r)

--- a/backend/app/schemas/run.py
+++ b/backend/app/schemas/run.py
@@ -41,6 +41,13 @@ class HitlWaitDetail(BaseModel):
     art_options: dict | None = None
 
 
+class RecoveryDetail(BaseModel):
+    node: str
+    error_code: str
+    attempts: int
+    can_retry: bool = True
+
+
 class RunStatusResp(BaseModel):
     run_id: uuid.UUID
     game_id: uuid.UUID
@@ -50,6 +57,8 @@ class RunStatusResp(BaseModel):
     ws_url: str
     current_hitl: HitlState | None = None
     hitl_wait: HitlWaitDetail | None = None
+    pause_reason: str | None = None
+    recovery: RecoveryDetail | None = None
 
 
 class HitlResolveReq(BaseModel):

--- a/backend/app/schemas/run.py
+++ b/backend/app/schemas/run.py
@@ -48,6 +48,15 @@ class RecoveryDetail(BaseModel):
     can_retry: bool = True
 
 
+class ArtifactGateDetail(BaseModel):
+    """ADR-01：previewable ≠ publishable，build_ok ≠ qa_ok。"""
+
+    generation_success: bool = False
+    previewable: bool = False
+    publishable: bool = False
+    qa_ok: bool = False
+
+
 class RunStatusResp(BaseModel):
     run_id: uuid.UUID
     game_id: uuid.UUID
@@ -59,6 +68,7 @@ class RunStatusResp(BaseModel):
     hitl_wait: HitlWaitDetail | None = None
     pause_reason: str | None = None
     recovery: RecoveryDetail | None = None
+    artifact_gate: ArtifactGateDetail | None = None
 
 
 class HitlResolveReq(BaseModel):

--- a/backend/app/schemas/ws.py
+++ b/backend/app/schemas/ws.py
@@ -41,6 +41,11 @@ class BuildDonePayload(BaseModel):
     version: int
     artifact_path: str
     preview_url: str
+    # ADR-01：三分立；构建成功即可预览，未过 QA 不得 publishable
+    generation_success: bool = True
+    previewable: bool = True
+    publishable: bool = False
+    qa_ok: bool = False
 
 
 class QaReportPayload(BaseModel):
@@ -78,6 +83,10 @@ class DonePayload(BaseModel):
     game_id: uuid.UUID
     version: int
     preview_url: str
+    generation_success: bool = True
+    previewable: bool = True
+    publishable: bool = True
+    qa_ok: bool = True
 
 
 class ErrorPayload(BaseModel):

--- a/backend/app/usage/store.py
+++ b/backend/app/usage/store.py
@@ -75,12 +75,18 @@ async def record_usage(
     calls: int = 1,
     game_id: uuid.UUID | None = None,
     run_id: uuid.UUID | None = None,
-) -> None:
-    """M4 LLM 层调用：累加 user/sys 的 day/month/total + 月榜 ZSET。一次 pipeline。
+    idempotency_key: str | None = None,
+) -> bool:
+    """累加 user/sys 的 day/month/total + 月榜 ZSET。
 
-    day/month key 设 TTL（只增数据不无限堆积），total 不设。
-    可选 game_id/run_id 维度（B3）。
+    若提供 idempotency_key 且已记账，则跳过累加并返回 False；成功记账返回 True。
     """
+    if idempotency_key is not None:
+        from app.forge.reliability.idempotency import try_begin_side_effect
+
+        if not await try_begin_side_effect(r, idempotency_key):
+            return False
+
     total = input_tokens + output_tokens
     uid = str(user_id)
     pipe = r.pipeline()
@@ -116,6 +122,7 @@ async def record_usage(
         pipe.sadd(idx, str(run_id))
         pipe.expire(idx, 40 * 86400)
     await pipe.execute()
+    return True
 
 
 async def _bucket(r: redis.Redis, key: str) -> UsageBucket:

--- a/backend/tests/test_artifact_gate.py
+++ b/backend/tests/test_artifact_gate.py
@@ -1,0 +1,39 @@
+"""ADR-01：previewable / publishable / qa_ok 三分立。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.forge.reliability.artifact_gate import ArtifactGate, derive_artifact_gate
+
+
+def test_build_ok_without_qa_is_previewable_not_publishable() -> None:
+    gate = derive_artifact_gate(build_ok=True, qa_ok=False)
+    assert gate.generation_success is True
+    assert gate.previewable is True
+    assert gate.publishable is False
+    assert gate.qa_ok is False
+
+
+def test_qa_ok_implies_publishable() -> None:
+    gate = derive_artifact_gate(build_ok=True, qa_ok=True)
+    assert gate.previewable is True
+    assert gate.publishable is True
+    assert gate.qa_ok is True
+
+
+def test_cannot_mark_publishable_without_qa() -> None:
+    with pytest.raises(ValueError):
+        ArtifactGate(
+            generation_success=True,
+            previewable=True,
+            publishable=True,
+            qa_ok=False,
+        )
+
+
+def test_build_failed_not_previewable() -> None:
+    gate = derive_artifact_gate(build_ok=False, qa_ok=False)
+    assert gate.generation_success is False
+    assert gate.previewable is False
+    assert gate.publishable is False

--- a/backend/tests/test_claim_candidate_version.py
+++ b/backend/tests/test_claim_candidate_version.py
@@ -1,0 +1,38 @@
+"""claim_candidate_version 幂等领取。"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.forge.code_candidate import claim_candidate_version
+
+
+@pytest.mark.asyncio
+async def test_claim_candidate_version_reuses_same_attempt(redis_client, monkeypatch) -> None:
+    calls = {"n": 0}
+
+    async def fake_next(_session, _game) -> int:
+        calls["n"] += 1
+        return 3 + calls["n"]
+
+    monkeypatch.setattr(
+        "app.forge.code_candidate.next_candidate_version", fake_next
+    )
+    game = SimpleNamespace(id=uuid.uuid4(), current_version=0)
+    run_id = uuid.uuid4()
+    session = AsyncMock()
+
+    v1, new1 = await claim_candidate_version(
+        redis_client, session, game, run_id=run_id, attempt=1
+    )
+    v2, new2 = await claim_candidate_version(
+        redis_client, session, game, run_id=run_id, attempt=1
+    )
+    assert new1 is True
+    assert new2 is False
+    assert v1 == v2 == 4
+    assert calls["n"] == 1

--- a/backend/tests/test_forge_graph_log_level.py
+++ b/backend/tests/test_forge_graph_log_level.py
@@ -1,8 +1,7 @@
 """run_generation 异常日志分级：
 
-AppError（业务错，如 LLM 未配置/apikey 错）→ WARNING 且不带 traceback；
-其他异常（系统/瞬时错）→ ERROR 且带 traceback。
-两种情况都把 run 置 FAILED。验证 worker 进程不再因业务错刷一长串栈。
+AppError（业务错，如 LLM 未配置/apikey 错）→ WARNING 且不带 traceback，run FAILED；
+其他瞬时/系统异常（RuntimeError 等）→ ERROR 且带 traceback，run PAUSED + recoverable_error。
 """
 
 import logging
@@ -71,7 +70,7 @@ async def test_runtime_error_logged_as_exception_with_traceback(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """系统错（RuntimeError）→ error + traceback（保留诊断），run FAILED。"""
+    """系统错（RuntimeError）→ error + traceback；按 P0 进入可恢复暂停。"""
     rid = await _make_run(verified_client)
 
     async def _boom(*_a, **_k):
@@ -91,3 +90,10 @@ async def test_runtime_error_logged_as_exception_with_traceback(
     ]
     assert errs, "RuntimeError 应产生 error 日志"
     assert errs[0].exc_info is not None, "系统错日志应带 traceback"
+
+    r = await verified_client.get(f"/api/v1/runs/{rid}")
+    data = r.json()["data"]
+    assert data["status"] == "paused"
+    assert data["pause_reason"] == "recoverable_error"
+    assert data["recovery"]["error_code"] == "worker_interrupted"
+    assert data["recovery"]["can_retry"] is True

--- a/backend/tests/test_forge_reliability_errors.py
+++ b/backend/tests/test_forge_reliability_errors.py
@@ -77,7 +77,8 @@ def test_classify_httpx_429() -> None:
 def test_classify_httpx_502() -> None:
     req = httpx.Request("POST", "https://example.com")
     resp = httpx.Response(502, request=req)
-    classified = classify_exception(httpx.HTTPStatusError("bad gateway", request=req, response=resp))
+    err = httpx.HTTPStatusError("bad gateway", request=req, response=resp)
+    classified = classify_exception(err)
     assert isinstance(classified, Provider5xx)
 
 

--- a/backend/tests/test_forge_reliability_errors.py
+++ b/backend/tests/test_forge_reliability_errors.py
@@ -1,0 +1,92 @@
+"""P0：统一错误分类 — Recoverable ≠ Run FAILED。"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.forge.reliability.errors import (
+    DataCorruption,
+    FatalError,
+    InvalidModelOutput,
+    InvariantViolation,
+    Provider5xx,
+    ProviderRateLimit,
+    ProviderTimeout,
+    RecoverableError,
+    SandboxOOM,
+    SandboxTimeout,
+    SecurityViolation,
+    UserActionRequired,
+    WorkerInterrupted,
+    classify_exception,
+    is_fatal,
+    is_recoverable,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [
+        ProviderTimeout,
+        ProviderRateLimit,
+        Provider5xx,
+        InvalidModelOutput,
+        SandboxTimeout,
+        SandboxOOM,
+        WorkerInterrupted,
+    ],
+)
+def test_recoverable_errors_are_not_fatal(exc_type: type[RecoverableError]) -> None:
+    err = exc_type("boom")
+    assert isinstance(err, RecoverableError)
+    assert is_recoverable(err)
+    assert not is_fatal(err)
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [DataCorruption, InvariantViolation, SecurityViolation],
+)
+def test_fatal_errors_are_not_recoverable(exc_type: type[FatalError]) -> None:
+    err = exc_type("boom")
+    assert isinstance(err, FatalError)
+    assert is_fatal(err)
+    assert not is_recoverable(err)
+
+
+def test_user_action_required_is_neither_recoverable_nor_fatal() -> None:
+    err = UserActionRequired("need confirm")
+    assert not is_recoverable(err)
+    assert not is_fatal(err)
+
+
+def test_classify_httpx_timeout() -> None:
+    classified = classify_exception(httpx.ReadTimeout("timed out"))
+    assert isinstance(classified, ProviderTimeout)
+    assert is_recoverable(classified)
+
+
+def test_classify_httpx_429() -> None:
+    req = httpx.Request("POST", "https://example.com")
+    resp = httpx.Response(429, request=req)
+    classified = classify_exception(httpx.HTTPStatusError("limited", request=req, response=resp))
+    assert isinstance(classified, ProviderRateLimit)
+
+
+def test_classify_httpx_502() -> None:
+    req = httpx.Request("POST", "https://example.com")
+    resp = httpx.Response(502, request=req)
+    classified = classify_exception(httpx.HTTPStatusError("bad gateway", request=req, response=resp))
+    assert isinstance(classified, Provider5xx)
+
+
+def test_classify_unknown_defaults_to_recoverable_worker_interrupted() -> None:
+    classified = classify_exception(RuntimeError("unexpected"))
+    assert isinstance(classified, WorkerInterrupted)
+    assert is_recoverable(classified)
+
+
+def test_fatal_passthrough() -> None:
+    original = InvariantViolation("broken")
+    assert classify_exception(original) is original

--- a/backend/tests/test_forge_reliability_idempotency.py
+++ b/backend/tests/test_forge_reliability_idempotency.py
@@ -1,0 +1,30 @@
+"""P0：副作用幂等键。"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.forge.reliability.idempotency import (
+    already_applied,
+    side_effect_key,
+    try_begin_side_effect,
+)
+
+
+def test_side_effect_key_stable() -> None:
+    run_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    a = side_effect_key(run_id, "code", "exec-1", "promote")
+    b = side_effect_key(run_id, "code", "exec-1", "promote")
+    assert a == b
+    assert a.startswith("forge:side:")
+
+
+@pytest.mark.asyncio
+async def test_try_begin_side_effect_only_once(redis_client) -> None:
+    run_id = uuid.uuid4()
+    key = side_effect_key(run_id, "code", "e1", "promote")
+    assert await try_begin_side_effect(redis_client, key) is True
+    assert await try_begin_side_effect(redis_client, key) is False
+    assert await already_applied(redis_client, key) is True

--- a/backend/tests/test_forge_reliability_pause.py
+++ b/backend/tests/test_forge_reliability_pause.py
@@ -1,0 +1,69 @@
+"""P0：pause_reason / recovery metadata（不改 RunStatus）。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.enums import PauseReason, RunStatus
+from app.forge.reliability.pause import (
+    RecoveryInfo,
+    apply_paused_metadata,
+    build_pause_checkpoint,
+    pause_reason_from_state,
+)
+
+
+def test_pause_reason_enum_values() -> None:
+    assert PauseReason.WAITING_USER.value == "waiting_user"
+    assert PauseReason.RECOVERABLE_ERROR.value == "recoverable_error"
+    assert PauseReason.QUOTA_BLOCKED.value == "quota_blocked"
+    assert PauseReason.MANUAL_HOLD.value == "manual_hold"
+
+
+def test_build_pause_checkpoint_for_hitl() -> None:
+    state = build_pause_checkpoint(
+        phase="plan_confirm",
+        pause_reason=PauseReason.WAITING_USER,
+        design_doc={"title": "t"},
+    )
+    assert state["phase"] == "plan_confirm"
+    assert state["pause_reason"] == "waiting_user"
+    assert state["design_doc"]["title"] == "t"
+    assert "recovery" not in state
+
+
+def test_build_pause_checkpoint_for_recoverable() -> None:
+    recovery = RecoveryInfo(
+        node="code",
+        error_code="provider_timeout",
+        attempts=3,
+        can_retry=True,
+    )
+    state = build_pause_checkpoint(
+        phase="code",
+        pause_reason=PauseReason.RECOVERABLE_ERROR,
+        recovery=recovery,
+    )
+    assert state["pause_reason"] == "recoverable_error"
+    assert state["recovery"] == {
+        "node": "code",
+        "error_code": "provider_timeout",
+        "attempts": 3,
+        "can_retry": True,
+    }
+
+
+def test_apply_paused_metadata_keeps_run_status_paused() -> None:
+    class _Run:
+        status = RunStatus.RUNNING.value
+
+    run = _Run()
+    apply_paused_metadata(run)  # type: ignore[arg-type]
+    assert run.status == RunStatus.PAUSED.value
+
+
+def test_pause_reason_from_state() -> None:
+    assert pause_reason_from_state({"pause_reason": "waiting_user"}) == PauseReason.WAITING_USER
+    assert pause_reason_from_state({}) is None
+    with pytest.raises(ValueError):
+        pause_reason_from_state({"pause_reason": "not_a_reason"})

--- a/backend/tests/test_forge_reliability_policy.py
+++ b/backend/tests/test_forge_reliability_policy.py
@@ -1,0 +1,28 @@
+"""P0：NodeExecutionPolicy 与 LLM 超时对齐。"""
+
+from __future__ import annotations
+
+from app.core.config import settings
+from app.forge.reliability.policy import (
+    NODE_EXECUTION_POLICIES,
+    resolve_node_run_timeout,
+)
+
+
+def test_policies_cover_core_nodes() -> None:
+    for name in ("plan", "art", "code_or_repair", "playtest", "diagnose", "code_qa_loop"):
+        assert name in NODE_EXECUTION_POLICIES
+
+
+def test_llm_nodes_timeout_exceeds_llm_request_timeout() -> None:
+    llm = settings.llm_request_timeout
+    for name in ("plan", "art", "code_or_repair", "diagnose"):
+        assert resolve_node_run_timeout(name) > llm
+
+
+def test_entry_router_fixed_short_timeout() -> None:
+    assert resolve_node_run_timeout("entry_router") == 10.0
+
+
+def test_playtest_timeout_independent_of_llm() -> None:
+    assert resolve_node_run_timeout("playtest") == 90.0

--- a/backend/tests/test_usage_idempotency.py
+++ b/backend/tests/test_usage_idempotency.py
@@ -1,0 +1,33 @@
+"""record_usage 幂等：相同 idempotency_key 不重复累加。"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.usage.store import get_user_usage, record_usage
+
+
+@pytest.mark.asyncio
+async def test_record_usage_idempotent_key_skips_duplicate(redis_client) -> None:
+    user_id = uuid.uuid4()
+    key = f"forge:side:{user_id}:plan:call-1:usage"
+    await record_usage(
+        redis_client,
+        user_id,
+        input_tokens=10,
+        output_tokens=5,
+        idempotency_key=key,
+    )
+    await record_usage(
+        redis_client,
+        user_id,
+        input_tokens=10,
+        output_tokens=5,
+        idempotency_key=key,
+    )
+    usage = await get_user_usage(redis_client, user_id, daily_limit=1_000_000)
+    assert usage.today.input_tokens == 10
+    assert usage.today.output_tokens == 5
+    assert usage.today.calls == 1

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -7183,6 +7183,33 @@
         "title": "ArtifactFileItem",
         "description": "产物单个文件的只读描述（代码预览用）。路径为相对产物根的 POSIX 路径。"
       },
+      "ArtifactGateDetail": {
+        "properties": {
+          "generation_success": {
+            "type": "boolean",
+            "title": "Generation Success",
+            "default": false
+          },
+          "previewable": {
+            "type": "boolean",
+            "title": "Previewable",
+            "default": false
+          },
+          "publishable": {
+            "type": "boolean",
+            "title": "Publishable",
+            "default": false
+          },
+          "qa_ok": {
+            "type": "boolean",
+            "title": "Qa Ok",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ArtifactGateDetail",
+        "description": "ADR-01：previewable ≠ publishable，build_ok ≠ qa_ok。"
+      },
       "AuditLogItem": {
         "properties": {
           "id": {
@@ -9695,6 +9722,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/RecoveryDetail"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "artifact_gate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtifactGateDetail"
               },
               {
                 "type": "null"

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -9295,6 +9295,34 @@
         ],
         "title": "Ready"
       },
+      "RecoveryDetail": {
+        "properties": {
+          "node": {
+            "type": "string",
+            "title": "Node"
+          },
+          "error_code": {
+            "type": "string",
+            "title": "Error Code"
+          },
+          "attempts": {
+            "type": "integer",
+            "title": "Attempts"
+          },
+          "can_retry": {
+            "type": "boolean",
+            "title": "Can Retry",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "node",
+          "error_code",
+          "attempts"
+        ],
+        "title": "RecoveryDetail"
+      },
       "RedisFlushReq": {
         "properties": {
           "scopes": {
@@ -9646,6 +9674,27 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/HitlWaitDetail"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pause_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pause Reason"
+          },
+          "recovery": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RecoveryDetail"
               },
               {
                 "type": "null"

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -1,0 +1,867 @@
+# Forge Runtime 演进计划 v2
+
+* Status: Draft（P0 架构歧义已关闭；见下方 ADR 状态）
+* Date: 2026-08-15
+* Owners: TBD
+* Reviewers: TBD
+* Related:
+  * [CodeQaLoop 设计](./superpowers/specs/2026-08-15-code-qa-loop-design.md)（硬约束）
+  * `backend/app/forge/graph.py` / `subgraphs/code_qa_loop.py`
+  * `backend/app/sandbox/`、`backend/app/forge/skills/`
+* ADR 状态:
+  * **ADR-01** Degraded Artifact Publishing — **Accepted**
+  * **ADR-05** Recoverable Pause Representation — **Accepted**
+  * **ADR-02** Preference Retention — Pending（阻塞 P1 Preference 写入策略细项）
+  * **ADR-03** Sandbox Provider Strategy — **Pending**（国内源码/数据出境不默认允许；P3 仅 PoC）
+  * **ADR-04** Conversation Storage Migration — Pending（阻塞 P1 message SoT 选型）
+* Implementation decisions（非 ADR）:
+  * Context Builder：**P1 MVP 建立规范路径；P5 Enforcement 拆除遗留拼装**
+
+---
+
+## 0. 总体原则
+
+本次升级**不以“重写 Runtime”为目标**，而以四个问题为主线：
+
+1. **可靠性**：单节点的可恢复故障不能销毁整个 Run。
+2. **上下文能力**：建立 Session Memory 与用户偏好，但避免过早引入复杂向量基础设施。
+3. **Agent 能力**：把现有 prompt snippets 升级为标准 Skill，同时明确平台 Policy 永远高于 Agent 自主选择。
+4. **执行隔离**：验证 E2B 是否优于现有 Docker，再决定迁移，而不是先假定 E2B 一定替换 Docker。
+
+每个 P 阶段必须具备：
+
+* MVP Scope
+* Explicit Out-of-Scope
+* Feature Flag
+* 旧模块映射
+* 退出条件 / Go·No-Go 指标
+* Rollback path
+
+**只有上一阶段指标证明有必要，才进入下一阶段。**
+
+目标形态（增量可达，非一次性切换）：
+
+```text
+LangGraph Workflow（串行）
+        │
+        ▼
+ entry_router
+        │
+        ▼
+   Plan Agent
+        │
+        ▼
+    Art Agent
+        │
+        ▼
+ Code + QA Loop（现有 CodeQaLoop，核心保留）
+        │
+        ▼
+      Done
+```
+
+Plan / Art / Code 是**串行逻辑角色**，不表示并行执行。
+
+横向能力：
+
+```text
+┌──────────────────────────────────────────────┐
+│ Platform Policies                            │
+│ Security / CDN / Engine / Audit / Quota / QA │
+└──────────────────────────────────────────────┘
+
+┌────────────┐ ┌────────────┐ ┌───────────────┐
+│ Memory     │ │ Skills     │ │ Sandbox       │
+│ Context    │ │ Router     │ │ Runtime       │
+└────────────┘ └────────────┘ └───────────────┘
+
+┌──────────────────────────────────────────────┐
+│ Reliability / Usage / Trace / Cache          │
+└──────────────────────────────────────────────┘
+```
+
+系统定位：
+
+> Forge 是以 LangGraph 为可靠编排层、以 bounded agent nodes 为智能执行层、以 Agent Skills 为能力扩展层、以独立 Memory 为个性化基础、以可插拔 Sandbox Backend 为隔离执行环境的游戏生成 Agent Runtime。
+
+**不需要变成 Multi-Agent 自治系统。**
+
+核心概念分离：
+
+```text
+Memory ≠ Cache ≠ Checkpoint ≠ Conversation History
+```
+
+---
+
+## 硬约束：CodeQaLoop
+
+任何 Sandbox、Skill、Memory、Cache、可靠性重构**不得削弱**现有 CodeQaLoop 的：
+
+* 有界 attempt（`code_qa_max_attempts`）
+* candidate 管理与 promote 语义
+* B 档 Playwright 可交互冒烟硬门禁
+* 禁止静态 DOM / 源码检查冒充生产 `qa_ok`
+* infra / product / build 失败分流
+
+CodeQaLoop 是已有可靠性资产，不是待替换遗留代码。未来只增强其外围：
+
+```text
+CodeQaLoop
+├── better Agent / Skills
+├── better Sandbox Backend
+└── better Recovery / Idempotency
+```
+
+禁止：
+
+```text
+Playwright 不可用 → deterministic / static QA fallback → qa_ok
+```
+
+正确路径：
+
+```text
+Playwright / Chromium 不可用
+  → failure_kind=infra（或等价）
+  → retry / PAUSED_RECOVERABLE / 运维告警
+  → 不得标记为 QA 通过
+```
+
+---
+
+# P0：先补可靠性，不重写整个状态机
+
+## P0 MVP
+
+第一阶段只做四件事。
+
+### 1. 统一错误分类
+
+最小错误体系：
+
+```text
+RecoverableError
+├── ProviderTimeout
+├── ProviderRateLimit
+├── Provider5xx
+├── InvalidModelOutput
+├── SandboxTimeout
+├── SandboxOOM
+└── WorkerInterrupted
+
+UserActionRequired
+
+FatalError
+├── DataCorruption
+├── InvariantViolation
+└── SecurityViolation
+```
+
+原则：
+
+```text
+RecoverableError ≠ Run FAILED
+```
+
+仅 FatalError（及明确的用户取消）进入不可恢复终态 `failed`。
+
+**BYOK 说明**：用户自带单一 provider key 时，不默认假设存在平台级 provider fallback。可恢复路径优先：retry →（若用户配置了备用）fallback model → `status=paused` + `pause_reason=recoverable_error` / template 降级（按节点定义）。平台审核模型与用户生成模型分离，互不冒充。
+
+### 2. LangGraph 节点 Timeout
+
+为现有节点配置明确 timeout（利用 `langgraph>=1.2` 的 `TimeoutPolicy` / `RetryPolicy`），统一落在：
+
+```python
+NODE_EXECUTION_POLICIES = {
+    "entry_router": ...,
+    "plan": ...,
+    "art": ...,
+    "code_qa_loop": ...,  # 或拆分子策略，见下
+}
+```
+
+禁止 timeout 散落在各节点业务代码里各自 `wait_for`。
+
+**预算对齐（必须）**：
+
+当前默认 `llm_request_timeout=300`。节点 timeout **必须严格大于**该节点内单次 LLM HTTP 读超时，否则正常长生成会被误杀：
+
+```text
+HTTP connect < LLM read timeout < Node attempt timeout
+```
+
+与 CodeQa / Build 预算正交，禁止相乘误解：
+
+| 预算 | 含义 | 谁拥有 |
+| --- | --- | --- |
+| `code_qa_max_attempts` | CodeQaLoop 总 attempt（含首次 generate） | 子图 |
+| `BUILD_MAX_RETRIES` | 单 attempt 内 Vite 构建修复 | build 内环 |
+| Node `max_attempts` | 节点级瞬态故障（网络/5xx）重试 | NodeExecutionPolicy |
+
+**暂定表（标定前）**：以配置为源，表中数值为「下限建议」，实装时取 `max(建议, llm_timeout + margin)`：
+
+| Node | 建议下限 | 备注 |
+| --- | ---: | --- |
+| entry_router | 10s | 规则路由，无 LLM |
+| plan | llm+60s | 含校验重试 |
+| art | llm+60s | |
+| code_or_repair（单次） | llm+120s | 不含整段 CodeQaLoop 外墙 |
+| playtest | 90s | Playwright 墙钟 |
+| diagnose | llm+30s | |
+| code_qa_loop（外墙） | 按 attempt×(code+playtest+diagnose) 推导 | 或只给子节点 timeout、外墙用 run deadline |
+
+第一版**不**强制完整 Phase/Run deadline hierarchy；有真实误杀/饿死数据后再加。
+
+### 3. 可恢复暂停（ADR-05：不新增 RunStatus）
+
+**P0 不修改 `RunStatus` 枚举。** 对外继续只暴露：
+
+```text
+running / paused / done / failed
+```
+
+可恢复故障在耗尽 retry/fallback 后进入：
+
+```text
+status = paused
+pause_reason = recoverable_error
+```
+
+示例 payload：
+
+```json
+{
+  "status": "paused",
+  "pause_reason": "recoverable_error",
+  "recovery": {
+    "node": "code",
+    "error_code": "provider_timeout",
+    "attempts": 3,
+    "can_retry": true
+  }
+}
+```
+
+HITL 等待用户：
+
+```json
+{
+  "status": "paused",
+  "pause_reason": "waiting_user"
+}
+```
+
+`pause_reason` 初始集合：
+
+```text
+paused
+├── waiting_user
+├── recoverable_error
+├── quota_blocked
+└── manual_hold
+```
+
+流转：
+
+```text
+RUNNING
+  ├─ success            → next node
+  ├─ recoverable error  → retry → fallback → paused (recoverable_error)
+  └─ fatal              → FAILED
+```
+
+原则：**reason 先行，enum 后置。** 仅当未来多种暂停在查询、SLA、生命周期与 UI 上必须分叉时，再考虑提升为一级 RunStatus。完整状态机重构不在 P0。
+
+须同步约定 `/retry` 与 `hitl/resolve`：对 `recoverable_error` 走重试/恢复，对 `waiting_user` 走 HITL；避免双路径 409。
+
+### 4. 幂等副作用
+
+以下操作必须带 idempotency key：
+
+```text
+create version / save candidate
+emit final artifact / promote
+usage billing
+HITL resume 副作用
+```
+
+推荐 key：
+
+```text
+run_id + node_name + node_execution_id + operation
+```
+
+目标：worker 在成功后、ack 前崩溃时，重放不产生重复 version / 重复扣费。
+
+与现有能力对接（复用，不重写）：
+
+* `run:executing:{id}` 执行租约
+* create_run Idempotency-Key
+* `forge_messages.dedupe_key`
+
+## P0 Out-of-Scope
+
+* 修改 `RunStatus` 枚举 / 新增 `paused_recoverable` status（见 ADR-05）
+* 大规模新 Run 状态机（RETRYING/DEGRADED/… 全量枚举）
+* Sandbox snapshot orchestration
+* 完整独立 Reconciler 平台（可增强现有 lease 心跳，不新造一套）
+* 平台级多 provider 动态调度
+* 多级 fallback planner
+* 分布式 cancellation propagation
+* Semantic Cache / Pinecone / E2B 生产切换
+* 用静态检测合成 `qa_ok` 或自动 `publishable`（见 ADR-01）
+
+## P0 Feature Flag / Rollback
+
+* Flag 示例：`reliability_node_timeout`、`reliability_pause_reason`、`reliability_idempotent_side_effects`
+* Rollback：关 flag → 回退到现有行为；**不引入新 RunStatus**，旧客户端只需继续理解 `paused`
+
+## P0 Go / No-Go
+
+故障注入后：
+
+* 可恢复故障 **0 次**直接 `failed`（无 pause/retry/fallback）
+* 可恢复暂停一律为 `status=paused` + `pause_reason=recoverable_error`（无新 enum）
+* 同一副作用重放 **不**产生重复 artifact / 重复 usage
+* Node timeout 误杀率（正常成功路径被 timeout）低于约定阈值（标定后写入）
+* CodeQaLoop 行为回归测试全绿（含「禁止静态 qa_ok」；`previewable` 不得推导 `qa_ok` / `publishable`）
+
+## P0 已关闭的架构歧义
+
+```text
+✓ 错误分类
+✓ node timeout（对齐 LLM 超时）
+✓ recoverable pause = paused + pause_reason（不改 RunStatus）
+✓ 幂等副作用
+✓ checkpoint 增强现有栈（不迁 checkpointer）
+✓ 不承诺 provider 热备
+✓ 不降低 QA gate
+```
+
+P0 适合作为第一批 PR；后续 Memory / Skill / E2B / Cache **不得**反过来要求 P0 重写。
+
+---
+
+# ADR 与实现决议
+
+## ADR-01：Degraded Artifact Publishing — **Accepted**
+
+**Decision：**
+
+生成/构建成功时**可以**向用户暴露预览；但：
+
+* **不得**合成 `qa_ok=true`（含静态 / deterministic smoke 冒充）
+* **不得**自动正式发布
+* 允许用户重试 QA / repair
+
+用三个**相互独立**的标志表达，禁止用单一 `completed_degraded` 包揽：
+
+```text
+generation_success = true|false
+previewable        = true|false
+publishable        = false|true   # 未过正式 QA 门禁时必须为 false
+```
+
+硬原则：
+
+> `previewable ≠ publishable`，`build_ok ≠ qa_ok`。
+
+典型场景：
+
+```text
+代码生成成功 → build 成功 → 游戏可打开
+→ Playwright / B 档 QA 未通过或不可执行
+
+结果：
+previewable=true
+qa_ok 不得为 true
+publishable=false
+允许重试 QA / repair
+```
+
+---
+
+## ADR-05：Recoverable Pause Representation — **Accepted**
+
+**Decision：**
+
+* P0 **不得**新增 `paused_recoverable`（或任何新的）`RunStatus` 枚举值
+* 可恢复暂停复用现有 `paused`，用 `pause_reason` + `recovery` metadata 区分
+* API consumer 只须理解：`running / paused / done / failed`
+
+见 P0 §3。
+
+---
+
+## Context Builder（Implementation Decision，非 ADR）
+
+> **P1 establishes Context Builder as the canonical memory/context composition path; P5 removes legacy prompt-assembly paths and enforces it as the sole production entry point.**
+
+| Milestone | 职责 |
+| --- | --- |
+| **P1 MVP** | 出现统一 `ContextBuilder.build(...)`；负责 Session Summary、Recent Turns、Explicit Preferences、Current Artifacts、Current Request + token budget |
+| **P5 Enforcement** | 所有正式 Node 禁止自行拼 Memory/历史；统一经 ContextBuilder；补 prompt fingerprint、skill/cache fingerprint、observability；删除遗留拼装路径 |
+
+P1 若不建 Builder，Memory 会迅速分裂为 plan/art/code/repair 各自拼装。
+
+---
+
+## ADR-02：偏好删除策略 — Pending
+
+删除 Game 时：
+
+* **Explicit** 用户偏好（如「以后都像素风」）→ 默认保留在 User Memory
+* **Inferred** 偏好若唯一 evidence 来自已删 Game → 删除或重算
+
+用户「清除我的偏好」→ 删除 long-term preference（含派生检索索引，若已存在）
+
+（P1 Explicit-only MVP 可先按「保留 explicit」落地；推断策略待本 ADR 定稿。）
+
+---
+
+## ADR-03：Sandbox Provider Strategy — **Pending**
+
+**在决议前默认：**
+
+```text
+Domestic production → DockerSandbox
+E2B → PoC / benchmark only
+```
+
+```text
+E2B integration success ≠ E2B production approval
+```
+
+**不**在文档中默认允许国内源码/prompt/资产出境。Go 条件至少包括：数据流确认、源码/prompt/资产是否出境、供应商保留政策、合同/DPA/合规、国内网络 benchmark。
+
+若最终「不允许 E2B」：SandboxBackend 抽象 + Docker 强化仍为**有效交付**，P3 不算失败。
+
+评估维度：成本、可用区、国内网络、数据/源码出境、UGC 合规、SLA、冷启动、延迟、vendor lock-in。允许未来 hybrid，但须另决议。
+
+---
+
+## ADR-04：`forge_messages` 演进 — Pending
+
+不得长期两套 Conversation Source of Truth。
+
+* 方案 A：扩展现表（session_id / token_count / …）
+* 方案 B：迁移到 `conversation_messages` + backfill
+
+先审计现字段与调用点再选。
+
+---
+
+# P1：Memory MVP（Postgres only）
+
+## P1 MVP
+
+```text
+Memory
+├── Session Memory（演进 forge_messages）
+└── User Preference（Postgres explicit only）
+```
+
+**不引入** Pinecone Preference / Conversation Vector（默认）。
+
+### P1.1 Session Memory
+
+逻辑：
+
+```text
+Game → Session（默认每 Game 一个主 Session）→ Messages
+```
+
+复用/演进 `forge_messages`，不平行新建 SoT。多 Session branch 不做。
+
+### P1.2 Context Builder MVP（规范路径，非最终强制）
+
+完整历史入库 ≠ 全量注入模型。
+
+P1 **必须**引入统一入口，避免各节点自行拼装：
+
+```python
+ContextBuilder.build(
+    node=...,
+    current_input=...,
+    session=...,
+    preferences=...,
+    artifacts=...,
+)
+```
+
+第一阶段只负责：
+
+```text
+Session Summary
+Recent Turns
+Explicit Preferences
+Current Artifacts
+Current Request
++ token budget
+```
+
+Working memory 示例构成：
+
+```text
+Current Request
++ Recent N turns
++ Session Summary
++ Current Design Doc
++ Current Version Metadata
++ Relevant Preferences
+```
+
+Token budget 示例（后续用 trace 标定）：
+
+```text
+System / Policy        15%
+Skills                 15%
+Preferences             5%
+Session summary        10%
+Recent turns           20%
+Artifacts              25%
+Current request        10%
+```
+
+Memory 中的历史自然语言**永远是 data**，不得当作 instruction（防偏好/历史注入）。
+
+遗留节点若暂未迁完，P1 允许并存但**新代码必须走 Builder**；P5 拆除遗留路径并强制唯一入口（见 P5）。
+
+### P1.3 Session Summary
+
+触发：`messages > N` 或 historical tokens > threshold（如 >20 条或 >12k tokens）。
+
+结构化 schema 示例：
+
+```json
+{
+  "current_goal": "",
+  "confirmed_decisions": [],
+  "rejected_options": [],
+  "gameplay_constraints": [],
+  "visual_constraints": [],
+  "technical_constraints": [],
+  "pending_requests": []
+}
+```
+
+### P1.4 Preference MVP
+
+表 `user_preferences`（字段可微调）：
+
+```text
+id, user_id, category, key, value_json
+source, confidence, status
+created_at, updated_at
+```
+
+MVP **仅自动写入 Explicit**（命中「以后 / 我喜欢 / 默认 / 每次都 / 不要再」等 + extractor schema 校验）。Inferred 后置。
+
+### P1.5 Pinecone / 向量检索：暂缓
+
+Explicit 偏好量级小，SQL 足够。Conversation semantic retrieval 仅当指标触发，例如：
+
+* p95 session messages > 100，或
+* summary 丢信息导致 revise failure > 约定阈值
+
+再开独立子阶段（不叫默认 P1）。
+
+## P1 Out-of-Scope
+
+* Preference → Pinecone
+* 跨 Game 隐式画像大规模推断
+* 多 Session 分支
+* 用 Memory 替代 `run_checkpoints`
+
+## P1 Go / No-Go
+
+* Game A 对话不泄漏到 Game B
+* 上下文长度不随消息线性失控（有 budget）
+* Explicit 偏好可查看 / 修改 / 清空
+* 删 Game 后 Session 不可检索；User explicit 偏好按 ADR-02
+* 仅一套 message SoT
+* 新节点/新调用路径经 `ContextBuilder`；无「第四套」私有拼装
+
+---
+
+# P2：Agent Skills（Policy ≠ Methodology）
+
+代码层面建议命名：
+
+```text
+Platform Policy   # 强制
+Agent Skills      # 可选方法论
+```
+
+避免两者权限被当成同一概念。
+
+## P2.1 Platform Policy（强制注入 / 代码权威）
+
+包括：Security、CDN 白名单、引擎钉死 URL、输出契约、网络规则、审核、沙箱限制、**QA 最低门禁（B 档 Playwright）** 等。
+
+Agent **无权**选择、跳过、卸载或覆盖。例如 Phaser CDN URL 来自 `ALLOWED_CDN_HOSTS` / `recommended_cdn_url`，不是 Skill「建议」。
+
+## P2.2 Methodology Skill（可发现、可选）
+
+如 `art/pixel-art`、`code/phaser3`、`repair/runtime-error`。流程：discover → choose → load（Progressive Disclosure；符合 Agent Skills `SKILL.md` 惯例）。
+
+## P2.3 Skill MVP（约 8 个，验证质量 lift）
+
+```text
+Art: pixel-art, hud-design, visual-composition
+Code: canvas, phaser3, pixijs
+Repair: runtime-error, gameplay-regression
+```
+
+目标：验证 routing 是否优于静态全量注入，**不是**一次性重写全部 prompt。
+
+## P2.4 分层 Routing
+
+```text
+Node Type → Platform Scope Filter → metadata catalog → Agent select → Loader
+```
+
+Art 不得看见 billing / sandbox admin / 内部 security runbook。
+
+## P2.5 playtest 拆分
+
+| 概念 | 类型 | 含义 |
+| --- | --- | --- |
+| playtest-policy | Platform Policy | 必须过 B 档 Playwright；不可静态假通过 |
+| playtest-methodology | Skill | 如何观察输入、运动弱信号、报告证据（给诊断/修复提示） |
+
+现有 `playtest.md` / `conventions.md` 按此拆分演进。
+
+## P2 Out-of-Scope
+
+* 几十上百 Skill 大目录
+* Agent 自选是否执行 QA 门禁
+* 开放 tool-use / ReAct harness
+
+## P2 Go / No-Go
+
+* 节点启动不加载全部 Skill 正文
+* Policy 始终注入；Methodology 可选
+* Skill 变更使依赖其的 cache key 失效（若已上 Exact Cache）
+* 离线 eval：selection precision / quality lift；无 lift 则停扩 catalog
+
+---
+
+# P3：Sandbox Backend 评估与抽象（非「立刻切 E2B」）
+
+阶段名称：**Sandbox Backend Evaluation & Abstraction**。
+
+受 **ADR-03 Pending** 约束：国内生产默认 Docker；E2B 仅 PoC/benchmark，**不得**因集成成功而默认生产切换或默认允许源码出境。
+
+## P3 MVP
+
+```python
+class SandboxBackend(Protocol):
+    async def create(...)
+    async def execute(...)
+    async def destroy(...)
+```
+
+第一版不强制 pause/snapshot。Adapter：
+
+* `LocalSandbox`（开发）
+* `DockerSandbox`（生产基线）
+* `E2BSandbox`（PoC）
+
+Feature flag：`sandbox_backend=local|docker|e2b`。
+
+**职责边界**：
+
+| 能力 | 默认位置 |
+| --- | --- |
+| 源码 execute / 构建命令 | Sandbox Backend |
+| B 档 Playwright 冒烟 | Worker 侧 Playwright（可与 sandbox 分离） |
+| Vite Builder | 现有 builder；不强行并入 E2B |
+
+HITL 长等待（可达 `hil_wait_timeout_s`）下：**默认销毁 sandbox，只保留对象存储/托管中的源码与 checkpoint**；用户回来再 create + restore。不默认 48h pause 计费会话。
+
+## P3.1 Benchmark
+
+样本量级建议：Canvas/Phaser/Pixi/Vite/Repair 对照集。指标：create/build/exec latency、OOM/timeout/failure、cost/run、cost/成功局、网络可靠性；区分国内外。
+
+## P3.2 数据合规 Gate
+
+Prompt、design_doc、源码、素材是否出境 → Data Flow Diagram → 才能谈默认 backend。
+
+## P3.3 Tier
+
+候选 lite/standard/heavy（或四档）；以 telemetry 为准，避免为省几十 MB 过度调度。
+
+## P3.4 复用
+
+允许：同 Run、同 CodeQaLoop 内复用。禁止：跨 Run / 跨用户。PoC 可先 one-run-one-sandbox。
+
+## P3 Go / No-Go（生产切换）
+
+同时满足才可默认 E2B，否则 **Docker 继续作为生产 Backend 是合法结果**：
+
+* 可靠性 ≥ Docker baseline
+* 成本在预算内
+* p95 latency 可接受
+* 数据合规通过
+* 国内网络策略明确
+* rollback 可行
+* sandbox leak = 0（实验窗口内）
+
+---
+
+# P4：Cache（先 Exact，Semantic 实验后置）
+
+## P4 MVP：Redis Exact Cache 白名单
+
+允许：
+
+```text
+entry_router / engine_router
+intent classification
+deterministic metadata extraction
+template selection
+```
+
+特点：低熵、结构化、temperature≈0。
+
+**禁止** Exact 与 Semantic：
+
+```text
+plan / art / code / repair / qa
+preference extraction / HITL revise
+```
+
+理由：创作与修复路径随机性高；Exact 命中也会固化「碰巧可跑的差版本」。
+
+### Cache Key
+
+```text
+node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
+```
+
+`preference_revision` **仅当**该节点实际消费 Preference 时加入。
+
+## P4.5 Semantic Cache（实验，非默认）
+
+前置：Exact 已证明有成本/延迟收益。
+
+* 仅 router/classification
+* **Shadow mode**：生产仍走真实推理；后台记 similarity vs 真实输出，标定 `T_direct` / `T_verify`
+* 未完成 calibration 与 false-hit 验收前，**禁止 direct hit 返回用户**
+* 默认禁止跨用户；Pinecone 与 Memory 逻辑空间分离（若引入）
+
+灰度：shadow → 5% → 20% → 50% → 100%。
+
+## P4 Go / No-Go
+
+* allowlist 外 0 缓存命中
+* Code/Repair/Art 无 cache
+* Semantic false direct-hit 目标（若上线）极高 precision（如 <0.1%），否则不下发
+
+---
+
+# P5：整合与硬化（不加核心子系统）
+
+* **Context Builder Enforcement**：所有正式 Node 禁止自行拼 Memory/加载历史；统一经 ContextBuilder；删除遗留 prompt-assembly；补 prompt / skill / cache fingerprint 与 observability
+* Observability：Memory / Skill / Sandbox / Cache span（Langfuse 等）
+* Migration cleanup、Feature flag 收敛、废弃路径删除
+* Chaos / Load / Security 测试
+* 文档与 ADR 归档
+
+---
+
+# 现有模块 → 新架构映射
+
+| 现有模块 | 新架构位置 | 处理方式 |
+| --- | --- | --- |
+| `entry_router` | Routing | 保留；加 timeout；可进 Exact Cache |
+| `plan` / `art` 节点 | Agent Node | 保留结构；后接 Methodology Skill |
+| `code_qa_loop` | Reliability + Agent Loop | **核心保留，不重写** |
+| `code_qa_exec` / `code_candidate` | Artifact / Loop 执行 | 保留；增强幂等与 metadata |
+| `design_doc` | Session Artifact | 保留；进 Context Builder |
+| `current_version` / hosting | Durable Artifact | 保留；repair SoT |
+| `forge_messages` | Session Memory | 演进/迁移，不平行重建 |
+| `run_checkpoints` + Redis ckpt | Reliability | 保留；增强恢复 metadata；不强制迁 LangGraph checkpointer（除非另立 ADR） |
+| Redis `run:executing` | Lease | 保留，不重复实现 |
+| Redis usage / ratelimit / circuit | Infra / Policy | 原样保留 |
+| blacklist / lexicon / audit | Platform Policy | 保留 |
+| Playwright playtest | Platform QA Gate | 保留硬门禁 |
+| `playtest.md` / `conventions.md` | Policy + Skill | 拆分演进 |
+| engines/*.md | Methodology Skills | 标准化 SKILL.md |
+| LocalSandbox / DockerSandbox | Sandbox Backend | 开发 / 生产基线；E2B 为对照 |
+| Vite Builder | Build Runtime | 不强行并入 E2B |
+| Langfuse | Observability | 保留并扩展 span |
+
+原则：**能复用的不重写。**
+
+---
+
+# 阶段总表
+
+| Priority | MVP | 完整增强（需 Go） |
+| --- | --- | --- |
+| **P0 Reliability** | 错误分类、node timeout、`paused`+`pause_reason`、幂等 | 高级 reconciler、复杂 fallback |
+| **P1 Memory** | forge_messages 演进、summary、PG explicit preference、**Context Builder MVP** | inferred preference、conversation vector retrieval |
+| **P2 Skills** | Policy/Methodology 分层、≈8 Skill、Router | 大规模 catalog |
+| **P3 Sandbox** | Backend 抽象 + E2B PoC + benchmark（ADR-03 Pending） | 按 ADR-03 选 E2B / Docker / hybrid |
+| **P4 Cache** | Redis Exact 白名单 | Semantic shadow → 灰度 |
+| **P5 Hardening** | **Context Builder Enforcement**、测试、清理 | 删除 legacy |
+
+统一推进节奏：
+
+```text
+MVP → Feature Flag / Shadow → Metrics → Review → Go/No-Go → 扩大范围
+```
+
+---
+
+# 架构验收红线
+
+1. **Sandbox 不是状态存储。** 随时可杀，Run 仍可从持久化源恢复。
+2. **Memory 不是全量 Prompt History。** 完整保存，注入受 Context Builder 约束。
+3. **Semantic similarity ≠ 业务等价。** 未标定禁止 direct hit。
+4. **Skill 可发现、可选、可版本化；Policy 不可选。** 禁止退化成「几十个 md 全塞 prompt」。
+5. **Node Failure ≠ Run Failure。** 可恢复故障必须被 retry / fallback / `paused`+`pause_reason=recoverable_error` 吸收。
+6. **CodeQaLoop B 档硬门禁不可削弱。** 静态检测不得成为生产 `qa_ok`；`previewable ≠ publishable`，`build_ok ≠ qa_ok`。
+
+### 范围控制
+
+每一 P：MVP、Out-of-Scope、Flag、Rollback、Go/No-Go；禁止因「最终架构需要」提前实现后续模块。
+
+### Migration
+
+* 单一 Conversation SoT；`forge_messages` 有兼容/backfill 计划
+* 滚动发布期间旧 Run 可恢复；老游戏历史不因 Memory 升级丢失
+
+### Sandbox
+
+E2B 是否进生产以 **ADR-03** 与对照指标/合规为准；在 Pending 期间国内生产保持 Docker。Docker 继续生产是合法结局。
+
+---
+
+## 修订说明（相对 v1 / 早期 v2 草稿）
+
+| 倾向 | 现行决议 |
+| --- | --- |
+| 目标态一次性 Runtime 替换 | 增量演进 + 每阶段 Go/No-Go |
+| 大状态机 / 新 `paused_recoverable` status | **ADR-05 Accepted**：`paused` + `pause_reason`；P0 不改 RunStatus |
+| `completed_degraded` 包揽语义 | **ADR-01 Accepted**：`generation_success` / `previewable` / `publishable` 三分立 |
+| Playwright → 静态 QA fallback | **禁止**；对齐 CodeQaLoop |
+| Pinecone 默认进 Memory | 暂缓；指标触发 |
+| 直接 E2B 迁移 / 默认允许国内出境 | **ADR-03 Pending**；生产 Docker；E2B 仅 PoC |
+| Semantic Cache 猜阈值 | Exact 先行；Semantic 仅 shadow |
+| Skill 全量方法论 | Policy 强制 / Methodology 可选；≈8 个验证 |
+| Context Builder 二选一里程碑 | **P1 MVP + P5 Enforcement** |
+| 「无需拍板即可开工」 | ADR-01/05 已 Accepted；02/03/04 仍按阶段阻塞 |
+
+---
+
+## 文档与命名
+
+* 规范文件名：`docs/2026-08-15-forge-runtime-evolution-plan.md`
+* 正文使用 specification 语气，避免对话体
+* 可恢复故障的正式表述：
+
+> 系统必须保证可恢复的基础设施与模型瞬态故障不会直接导致 Run 进入不可恢复终态；数据完整性破坏、安全违规与系统 invariant 破坏除外。

--- a/docs/26-08-15_system-improvement-proposal.md
+++ b/docs/26-08-15_system-improvement-proposal.md
@@ -1,0 +1,7 @@
+# 已迁移
+
+本文件已收敛并重写为增量演进规格：
+
+→ [2026-08-15-forge-runtime-evolution-plan.md](./2026-08-15-forge-runtime-evolution-plan.md)
+
+请勿在本文件继续修订。


### PR DESCRIPTION
## Summary
- 落地 Forge Runtime P0 可靠性底座：统一错误分类、`paused` + `pause_reason`（ADR-05）、节点 Timeout/Retry、副作用幂等。
- 落地 ADR-01 产物门禁：`generation_success` / `previewable` / `publishable` / `qa_ok` 三分立；构建可预览，仅 B 档 QA 通过后可发布。
- 附带演进计划文档与 OpenAPI 契约更新。

## 背景
PR #65（`feat/p0-reliability` → `feat/code-qa-loop`）已合并；本 PR 将含 P0 的 `feat/code-qa-loop` 合入 `main`。

## 改动点
- `app/forge/reliability/`：errors / pause / policy / idempotency / artifact_gate
- 主图接入可恢复暂停与节点执行策略；promote / usage / candidate 幂等
- `BuildDone` / `Done` / `GET /runs` 暴露 artifact_gate 字段
- Feature flags：`reliability_node_timeout`、`reliability_idempotent_side_effects`

## Test plan
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run pytest -q`（本地 Windows 忽略 `test_sandbox` 中依赖 `sh` 的 2 项；CI Ubuntu 全量）
- [ ] GitHub Actions CI 绿

## 影响
- 可恢复故障不再直接 FAILED，改为 `paused` + `recoverable_error`，走 `/retry`
- 未过 QA 的产物可预览但不可自动视为可发布