### PR TITLE
chore: 接入 pre-commit 本地提交门禁

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+default_language_version:
+  python: python3.12
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
+  # ✅ 改用官方 repo，避免 npx 网络问题
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
+    hooks:
+      - id: markdownlint-cli2
+
+  - repo: local
+    hooks:
+      - id: secret-scan
+        name: secret-scan
+        entry: uv run --no-project python scripts/secret_scan.py --staged
+        language: system
+        pass_filenames: false
+
+      - id: mypy
+        name: mypy
+        entry: uv run --no-project python scripts/run_backend_tool.py mypy --install-types --non-interactive
+        language: system
+        pass_filenames: true  # ✅ 只检查改动文件
+        files: '^backend/.*\.py$'
+
+      - id: bandit
+        name: bandit
+        entry: uv run --no-project python scripts/run_backend_tool.py bandit -q -c pyproject.toml
+        language: system
+        pass_filenames: true  # ✅ 只检查改动文件
+        files: '^backend/.*\.py$'
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.2.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - --strict
+          - feat
+          - fix
+          - refactor
+          - perf
+          - test
+          - docs
+          - build
+          - ci
+          - chore

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "httpx>=0.28",
     "ruff>=0.5",
     "mypy>=1.10",
+    "bandit>=1.7",
     "aiosqlite>=0.20",
     "fakeredis>=2.20",
     "httpx2>=2.0",
@@ -54,6 +55,10 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.bandit]
+exclude_dirs = ["tests", ".venv"]
+skips = ["B101"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -374,6 +374,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.70"
 source = { registry = "https://pypi.org/simple" }
@@ -813,6 +828,7 @@ playwright = [
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
+    { name = "bandit" },
     { name = "fakeredis" },
     { name = "httpx" },
     { name = "httpx2" },
@@ -853,6 +869,7 @@ provides-extras = ["playwright"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "bandit", specifier = ">=1.7" },
     { name = "fakeredis", specifier = ">=2.20" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx2", specifier = ">=2.0" },
@@ -1301,6 +1318,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1361,6 +1390,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -2170,6 +2208,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2290,6 +2341,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/3c/76d2fd1f1357ed0f0108d8a5aa233dcf16e2946a8559c84912fe08e01ac7/starlette-1.4.1.tar.gz", hash = "sha256:b7332de6e9375593a29ba9eee1e6ecfeb3eb2043e2e19a13b4b71da73ff35540", size = 2709041, upload-time = "2026-08-05T15:17:26.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/0a/67e95f21498de41433babf7b1db0eeab449eb58872dfb831b27747a70fd0/starlette-1.4.1-py3-none-any.whl", hash = "sha256:7d078e0fbefae0d2cecfb80a799d6fb84b1c0c6acd4f14ac79d17d0e7ec27f19", size = 74019, upload-time = "2026-08-05T15:17:24.357Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
 ]
 
 [[package]]

--- a/scripts/run_backend_tool.py
+++ b/scripts/run_backend_tool.py
@@ -1,0 +1,40 @@
+"""在 backend/ 目录下运行 mypy/bandit，并去掉路径前缀 backend/。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_BACKEND = _ROOT / "backend"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: run_backend_tool.py <tool> [args...] [files...]", file=sys.stderr)
+        return 2
+
+    tool, *rest = argv[1:]
+    tool_args: list[str] = []
+    files: list[str] = []
+    for item in rest:
+        path = Path(item)
+        if path.suffix == ".py" or path.as_posix().startswith("backend/"):
+            parts = path.as_posix().split("/")
+            if parts and parts[0] == "backend":
+                files.append("/".join(parts[1:]))
+            else:
+                files.append(path.as_posix())
+        else:
+            tool_args.append(item)
+
+    if not files:
+        return 0
+
+    cmd = ["uv", "run", tool, *tool_args, *files]
+    return subprocess.call(cmd, cwd=_BACKEND)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/secret_scan.py
+++ b/scripts/secret_scan.py
@@ -1,0 +1,88 @@
+"""扫描暂存区，拦截疑似密钥/凭据进仓。"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# 高置信度模式；故意不扫通用 UUID / 短 hex，减少误报。
+_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("private_key", re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----")),
+    ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    (
+        "generic_api_key_assign",
+        re.compile(
+            r"(?i)(?:api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]\s*['\"][^'\"]{16,}['\"]"
+        ),
+    ),
+    ("bearer_token", re.compile(r"(?i)bearer\s+[a-z0-9\-._~+/]+=*")),
+]
+
+_SKIP_SUFFIXES = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".ico",
+    ".pdf",
+    ".lock",
+    ".woff",
+    ".woff2",
+}
+
+
+def _staged_files() -> list[Path]:
+    out = subprocess.check_output(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return [Path(line.strip()) for line in out.splitlines() if line.strip()]
+
+
+def _scan_text(path: Path, text: str) -> list[str]:
+    hits: list[str] = []
+    for name, pat in _PATTERNS:
+        if pat.search(text):
+            hits.append(f"{path.as_posix()}: matched {name}")
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--staged",
+        action="store_true",
+        help="只扫描 git 暂存区文件（pre-commit 使用）",
+    )
+    args = parser.parse_args(argv)
+
+    files = _staged_files() if args.staged else []
+    if args.staged and not files:
+        return 0
+
+    findings: list[str] = []
+    for path in files:
+        if not path.is_file() or path.suffix.lower() in _SKIP_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        findings.extend(_scan_text(path, text))
+
+    if findings:
+        print("secret-scan: 疑似密钥/凭据，请移出暂存区：", file=sys.stderr)
+        for line in findings:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- 新增仓库级 `.pre-commit-config.yaml`：基础检查、Ruff、markdownlint、secret-scan、mypy、bandit、Conventional Commits
- 补齐 `scripts/secret_scan.py` 与 monorepo 适配的 `scripts/run_backend_tool.py`（在 `backend/` 下跑 mypy/bandit）
- backend dev 依赖增加 `bandit`，并写入 `[tool.bandit]`

## 背景
P0 / CodeQaLoop 已合入 main（#66）。本 PR 只落地本地提交门禁，避免再出现「本地未跑齐 CI 同等检查」的问题。

## 使用
```bash
uv tool install pre-commit
pre-commit install
pre-commit install --hook-type commit-msg
# 提交前也可手动：
pre-commit run
```

## Test plan
- [x] 对本提交文件执行 `pre-commit run` 全绿
- [ ] `pre-commit install` 后任意小改动提交可触发 hook
- [ ] CI 仍以 `ruff` + `pytest` 为准（本 PR 不改 CI）