### PR TITLE
docs: use shield badges for README language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GameForge
 
-English | [中文](./README_zh.md)
+![English](https://img.shields.io/badge/English-0A66C2?style=for-the-badge)
+[![中文](https://img.shields.io/badge/%E4%B8%AD%E6%96%87-555555?style=for-the-badge)](./README_zh.md)
 
 > Use natural language to turn a game idea into a browser-ready experience that can be played, managed, and delivered.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,7 @@
 # GameForge
 
-[English](./README.md) | 中文
+[![English](https://img.shields.io/badge/English-555555?style=for-the-badge)](./README.md)
+![中文](https://img.shields.io/badge/%E4%B8%AD%E6%96%87-0A66C2?style=for-the-badge)
 
 > 用自然语言，把游戏想法推进为可在浏览器直接试玩、管理与交付的作品。
 


### PR DESCRIPTION
## Summary
- Replace the plain-text README language switcher with shields.io `for-the-badge` pills.
- On each locale page, the active language is a solid blue badge; the other language is a gray linked badge.

## Background
PR #68 shipped the English-first README and `README_zh.md`, but it was merged before the badge-switcher follow-up landed. This PR brings that UI change onto `main`.

## Changes
- `README.md`: blue **English** badge (active) + gray linked **Chinese** badge
- `README_zh.md`: blue **Chinese** badge (active) + gray linked **English** badge

## Test plan
- [ ] Open `README.md` on GitHub: blue English badge, gray Chinese badge is clickable
- [ ] Open `README_zh.md`: blue Chinese badge, gray English badge is clickable
- [ ] Language badges render correctly (shields.io images load)