### PR TITLE
docs: center README title and language badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# GameForge
+<h1 align="center">🎮 GameForge</h1>
 
-![English](https://img.shields.io/badge/English-0A66C2?style=for-the-badge)
-[![中文](https://img.shields.io/badge/%E4%B8%AD%E6%96%87-555555?style=for-the-badge)](./README_zh.md)
+<p align="center">
+  <img src="https://img.shields.io/badge/English-0A66C2?style=for-the-badge" alt="English" />
+  <a href="./README_zh.md"><img src="https://img.shields.io/badge/%E4%B8%AD%E6%96%87-555555?style=for-the-badge" alt="Chinese" /></a>
+</p>
 
 > Use natural language to turn a game idea into a browser-ready experience that can be played, managed, and delivered.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,9 @@
-# GameForge
+<h1 align="center">🎮 GameForge</h1>
 
-[![English](https://img.shields.io/badge/English-555555?style=for-the-badge)](./README.md)
-![中文](https://img.shields.io/badge/%E4%B8%AD%E6%96%87-0A66C2?style=for-the-badge)
+<p align="center">
+  <a href="./README.md"><img src="https://img.shields.io/badge/English-555555?style=for-the-badge" alt="English" /></a>
+  <img src="https://img.shields.io/badge/%E4%B8%AD%E6%96%87-0A66C2?style=for-the-badge" alt="中文" />
+</p>
 
 > 用自然语言，把游戏想法推进为可在浏览器直接试玩、管理与交付的作品。
 


### PR DESCRIPTION
## Summary
- Center the project title and language switcher on the README.
- Prefix the title with a gamepad emoji (`🎮 GameForge`).
- Keep the shields.io language badges, now centered under the title.

## Changes
- `README.md` / `README_zh.md`: `<h1 align="center">` title + centered badge row

## Test plan
- [ ] Title is centered and shows the gamepad emoji
- [ ] Language badges are centered under the title
- [ ] Active locale stays solid blue; the other locale remains clickable