### PR TITLE
docs: update repo description for multi-stack game builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
   <a href="./README_zh.md"><img src="https://img.shields.io/badge/%E4%B8%AD%E6%96%87-555555?style=for-the-badge" alt="Chinese" /></a>
 </p>
 
-> Use natural language to turn a game idea into a browser-ready experience that can be played, managed, and delivered.
+> Use natural language to turn a game idea into a playable browser game —
+> from single-file HTML to Vite/React and Phaser projects — then iterate,
+> playtest, and publish.
 
 <p align="center">
   <a href="https://htmlpreview.github.io/?https://raw.githubusercontent.com/ByteTitan-star/GameForge-Copilot/main/docs/showcase/index.html?lang=en">
@@ -21,7 +23,7 @@
 
 ## What is GameForge?
 
-GameForge is an AI-assisted workspace for creating browser games. Creators start with a gameplay description, move through AI planning, human review, and game generation, then receive a browser game they can play immediately, manage as versions, download, or publish.
+GameForge is an AI-assisted workspace for creating browser games. Creators start with a gameplay description, move through AI planning, human review, and game generation, then receive a playable result in the browser — whether as a compact HTML build or a Vite project (React UI, Canvas / Phaser / PixiJS, and more) — and can keep managing versions, downloading, or publishing.
 
 ## Product flow
 
@@ -61,8 +63,9 @@ A colorful tower defense prototype. Place defensive towers, stop enemy waves, an
 | --- | --- |
 | Natural-language driven | Start creating by describing the gameplay instead of writing code. |
 | Human-guided AI | AI handles planning and generation while the creator controls the final direction. |
+| Flexible game stacks | Generate single-file HTML or Vite projects with React UI and engines such as Canvas, Phaser, and PixiJS. |
 | Browser native | Open and play generated results immediately without extra installation. |
-| Standalone delivery | Download, save, and share games as independent HTML files. |
+| Deliverable builds | Download, save, and share playable browser builds. |
 | Traceable versions | Manage drafts, previous versions, and public creations in one place. |
 | Creation ecosystem | Publish, discover, favorite, like, and share game creations. |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -5,7 +5,9 @@
   <img src="https://img.shields.io/badge/%E4%B8%AD%E6%96%87-0A66C2?style=for-the-badge" alt="中文" />
 </p>
 
-> 用自然语言，把游戏想法推进为可在浏览器直接试玩、管理与交付的作品。
+> 用自然语言，把游戏想法做成可玩的浏览器游戏——
+> 既支持单文件 HTML，也支持 Vite/React、Phaser 等工程化构建，
+> 再迭代、试玩与发布。
 
 <p align="center">
   <a href="https://htmlpreview.github.io/?https://raw.githubusercontent.com/ByteTitan-star/GameForge-Copilot/main/docs/showcase/index.html">
@@ -21,7 +23,7 @@
 
 ## GameForge 是什么
 
-GameForge 是一个面向浏览器游戏的 AI 辅助创作工作区。创作者从一句玩法描述开始，经过 AI 策划、人工确认和游戏生成，即可得到能够直接试玩的浏览器游戏，并继续完成版本管理、下载与发布。
+GameForge 是一个面向浏览器游戏的 AI 辅助创作工作区。创作者从一句玩法描述开始，经过 AI 策划、人工确认和游戏生成，即可得到能直接在浏览器试玩的结果——可以是轻量单文件 HTML，也可以是 Vite 工程（React UI，以及 Canvas / Phaser / PixiJS 等渲染栈）——并继续完成版本管理、下载与发布。
 
 ## 产品链路
 
@@ -61,8 +63,9 @@ GameForge 是一个面向浏览器游戏的 AI 辅助创作工作区。创作者
 | --- | --- |
 | 自然语言驱动 | 不需要编写代码，通过描述玩法开始创作。 |
 | 人机协同把关 | AI 负责策划与生成，创作者决定最终方向。 |
+| 多技术栈生成 | 支持单文件 HTML，或 Vite 工程（React UI，以及 Canvas / Phaser / PixiJS 等）。 |
 | 浏览器原生 | 无需安装，生成结果可以立即打开试玩。 |
-| 独立作品交付 | 游戏可作为独立 HTML 下载、保存与分享。 |
+| 可交付产物 | 下载、保存与分享可玩的浏览器构建。 |
 | 版本可追溯 | 统一管理草稿、历史版本和公开作品。 |
 | 作品生态 | 支持发布、发现、收藏、点赞与分享。 |
 


### PR DESCRIPTION
## Summary
- Update product copy so GameForge is no longer described as HTML-only.
- Reflect current generation targets: single-file HTML and Vite projects (React UI, Canvas / Phaser / PixiJS, etc.).

## Background
The GitHub About blurb and README still said "playable HTML games", but the forge pipeline already supports project builds via Vite (including React UI and multiple renderers).

## Changes
- `README.md` / `README_zh.md`: tagline, overview, and core-feature rows
- GitHub repository About description updated to match (already applied on the remote)

## Test plan
- [ ] Repo About no longer claims HTML-only generation
- [ ] English and Chinese READMEs mention single-file HTML and Vite/React stacks