### PR TITLE
feat(memory): session summary refresh and art ContextBuilder

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -107,6 +107,8 @@ class Settings(BaseSettings):
     memory_preferences: bool = True
     # P1 Memory：ContextBuilder 总 token 预算（后续用 trace 标定）
     memory_context_budget_tokens: int = 4000
+    # P1 Memory：超阈时刷新并持久化 Session Summary（确定性 synthesizer）
+    memory_session_summary: bool = True
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
     # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。
     thumbnail_enabled: bool = True

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -307,6 +307,10 @@ async def _compose_plan_input(
     ctx: _Ctx, *, current_input: str, design_doc: dict[str, Any] | None = None
 ) -> str:
     """Plan/revise 用户消息：可选写入 Explicit 偏好，并经 ContextBuilder 拼装。"""
+    if settings.memory_session_summary:
+        from app.forge.memory.refresh import refresh_session_summary_if_needed
+
+        await refresh_session_summary_if_needed(ctx.s, ctx.game)
     if settings.memory_preferences:
         from app.forge.memory.preferences import upsert_explicit_from_text
 
@@ -341,6 +345,56 @@ async def _compose_plan_input(
         f"{design_doc_to_text(design_doc)}\n\n"
         + built.user_message
     )
+
+
+async def _compose_art_input(
+    ctx: _Ctx,
+    *,
+    current_input: str,
+    design_doc: dict[str, Any],
+    previous_options: dict[str, Any] | None = None,
+) -> str:
+    """Art/revise 用户消息：经 ContextBuilder 注入 summary/preferences。"""
+    if settings.memory_session_summary:
+        from app.forge.memory.refresh import refresh_session_summary_if_needed
+
+        await refresh_session_summary_if_needed(ctx.s, ctx.game)
+    if settings.memory_preferences and current_input.strip():
+        from app.forge.memory.preferences import upsert_explicit_from_text
+
+        await upsert_explicit_from_text(
+            ctx.s, user_id=ctx.game.owner_id, text=current_input
+        )
+    design_block = (
+        "【已确认游戏策划稿 JSON】\n" + design_doc_to_text(design_doc)
+    )
+    if previous_options is not None:
+        design_block += (
+            "\n\n【上一轮方向 JSON】\n"
+            + json.dumps(previous_options, ensure_ascii=False)
+        )
+    if not current_input.strip():
+        prompt_input = "请基于已确认策划稿给出美术方向选项。"
+    else:
+        prompt_input = current_input
+    wrapped = _wrap_user_input(prompt_input)
+    if not settings.memory_context_builder:
+        if not current_input.strip():
+            return design_block
+        return f"{design_block}\n\n【用户反馈】\n{wrapped}"
+    from app.forge.memory.loader import build_node_context
+
+    built = await build_node_context(
+        ctx.s,
+        node="art",
+        game=ctx.game,
+        user_id=ctx.game.owner_id,
+        current_input=wrapped,
+        design_doc=None,
+    )
+    if not current_input.strip():
+        return f"{design_block}\n\n{built.user_message}"
+    return f"{design_block}\n\n【用户反馈】\n{built.user_message}"
 
 
 async def _streamed_llm_or_fallback(
@@ -813,10 +867,10 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "failed": ctrl == "cancel",
                 }
             try:
-                art_options = await generate_art_options(
-                    ART_OPTIONS_PROMPT,
-                    f"【已确认游戏策划稿 JSON】\n{design_doc_to_text(design_doc)}",
+                user_msg = await _compose_art_input(
+                    ctx, current_input="", design_doc=design_doc
                 )
+                art_options = await generate_art_options(ART_OPTIONS_PROMPT, user_msg)
             except ContentAttacked:
                 raise
             except Exception as exc:  # noqa: BLE001 重试耗尽必须降级而非终止 run
@@ -850,10 +904,11 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "failed": ctrl == "cancel",
                 }
             previous = state.get("art_options") or {}
-            user_msg = (
-                f"【已确认游戏策划稿 JSON】\n{design_doc_to_text(design_doc)}\n\n"
-                f"【上一轮方向 JSON】\n{json.dumps(previous, ensure_ascii=False)}\n\n"
-                f"【用户反馈】\n{_wrap_user_input(state.get('modify_text') or '')}"
+            user_msg = await _compose_art_input(
+                ctx,
+                current_input=state.get("modify_text") or "",
+                design_doc=design_doc,
+                previous_options=previous if isinstance(previous, dict) else {},
             )
             try:
                 art_options = await generate_art_options(

--- a/backend/app/forge/memory/__init__.py
+++ b/backend/app/forge/memory/__init__.py
@@ -12,6 +12,7 @@ from app.forge.memory.summary import (
     coerce_session_summary,
     empty_session_summary,
     should_refresh_summary,
+    synthesize_summary_from_turns,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "empty_session_summary",
     "estimate_tokens",
     "should_refresh_summary",
+    "synthesize_summary_from_turns",
 ]

--- a/backend/app/forge/memory/loader.py
+++ b/backend/app/forge/memory/loader.py
@@ -16,7 +16,7 @@ from app.forge.memory.context_builder import (
     estimate_tokens,
 )
 from app.forge.memory.preferences import list_active_preferences, preference_to_context_dict
-from app.forge.memory.summary import coerce_session_summary
+from app.forge.memory.summary import coerce_session_summary, should_refresh_summary
 from app.models.forge_message import ForgeMessage
 from app.models.game import Game
 
@@ -66,11 +66,10 @@ async def build_node_context(
 
 
 async def maybe_touch_session_summary_flag(db: AsyncSession, game_id: uuid.UUID) -> bool:
-    """若消息量超阈返回 True（调用方再决定是否跑 LLM 摘要；P1 MVP 只暴露触发条件）。"""
+    """若消息量超阈返回 True（兼容旧调用点）。"""
     count = await db.scalar(
         select(func.count()).select_from(ForgeMessage).where(ForgeMessage.game_id == game_id)
     ) or 0
-    # 粗估：取最近 50 条内容长度
     rows = (
         await db.scalars(
             select(ForgeMessage.content)
@@ -80,6 +79,4 @@ async def maybe_touch_session_summary_flag(db: AsyncSession, game_id: uuid.UUID)
         )
     ).all()
     tokens = sum(estimate_tokens(c or "") for c in rows)
-    from app.forge.memory.summary import should_refresh_summary
-
     return should_refresh_summary(message_count=int(count), historical_tokens=tokens)

--- a/backend/app/forge/memory/refresh.py
+++ b/backend/app/forge/memory/refresh.py
@@ -1,0 +1,75 @@
+"""Session Summary 持久化刷新（P1）。"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.forge.memory.context_builder import ContextTurn, estimate_tokens
+from app.forge.memory.summary import (
+    SessionSummary,
+    coerce_session_summary,
+    should_refresh_summary,
+    synthesize_summary_from_turns,
+)
+from app.models.forge_message import ForgeMessage
+from app.models.game import Game
+
+Summarizer = Callable[[list[ContextTurn], SessionSummary | None], Awaitable[SessionSummary]]
+
+
+async def load_recent_turns(
+    db: AsyncSession, game_id: uuid.UUID, *, limit: int = 50
+) -> list[ContextTurn]:
+    rows = (
+        await db.scalars(
+            select(ForgeMessage)
+            .where(ForgeMessage.game_id == game_id)
+            .order_by(ForgeMessage.created_at.desc(), ForgeMessage.id.desc())
+            .limit(limit)
+        )
+    ).all()
+    return [
+        ContextTurn(role=m.role, content=m.content) for m in reversed(list(rows))
+    ]
+
+
+async def refresh_session_summary_if_needed(
+    db: AsyncSession,
+    game: Game,
+    *,
+    summarizer: Summarizer | None = None,
+    force: bool = False,
+) -> SessionSummary | None:
+    """超阈（或 force）时刷新并写回 ``game.session_summary_json``。
+
+    默认用确定性 synthesizer；可注入 async summarizer（例如 LLM）做增强。
+    """
+    if not settings.memory_session_summary and not force:
+        return coerce_session_summary(game.session_summary_json)
+
+    turns = await load_recent_turns(db, game.id)
+    count = await db.scalar(
+        select(func.count()).select_from(ForgeMessage).where(ForgeMessage.game_id == game.id)
+    ) or 0
+    tokens = sum(estimate_tokens(t.content) for t in turns)
+    if not force and not should_refresh_summary(
+        message_count=int(count), historical_tokens=tokens
+    ):
+        return coerce_session_summary(game.session_summary_json)
+
+    previous = coerce_session_summary(game.session_summary_json)
+    if summarizer is not None:
+        summary = await summarizer(turns, previous)
+    else:
+        summary = synthesize_summary_from_turns(turns, previous=previous)
+    coerced = coerce_session_summary(dict(summary)) or synthesize_summary_from_turns(
+        turns, previous=previous
+    )
+    game.session_summary_json = dict(coerced)
+    await db.flush()
+    return coerced

--- a/backend/app/forge/memory/summary.py
+++ b/backend/app/forge/memory/summary.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
+from app.forge.memory.context_builder import ContextTurn
+
 
 class SessionSummary(TypedDict, total=False):
     current_goal: str
@@ -53,3 +55,57 @@ def coerce_session_summary(raw: Any) -> SessionSummary | None:
         elif isinstance(val, list):
             base[key] = [str(x) for x in val]
     return base
+
+
+def synthesize_summary_from_turns(
+    turns: list[ContextTurn],
+    *,
+    previous: SessionSummary | None,
+) -> SessionSummary:
+    """无 LLM 的确定性摘要：从对话轮次提炼结构化 Session Summary。
+
+    P1 默认路径；昂贵的 LLM 摘要可后置为可选增强，不得阻塞 Memory MVP。
+    """
+    out = empty_session_summary()
+    if previous:
+        for key, val in previous.items():
+            if key == "current_goal" and isinstance(val, str):
+                out["current_goal"] = val
+            elif isinstance(val, list):
+                out[key] = list(val)  # type: ignore[literal-required]
+
+    user_texts = [
+        t.content.strip() for t in turns if t.role == "user" and t.content.strip()
+    ]
+    if user_texts:
+        out["current_goal"] = _clip(user_texts[-1], 200)
+        earlier = user_texts[:-1][-5:]
+        for text in earlier:
+            _append_unique(out["confirmed_decisions"], _clip(text, 120))
+
+    for text in user_texts[-8:]:
+        low = text.lower()
+        if any(k in text for k in ("像素", "卡通", "手绘")) or "pixel" in low:
+            _append_unique(out["visual_constraints"], _clip(text, 80))
+        if any(k in text for k in ("难度", "简单", "硬核", "关卡")):
+            _append_unique(out["gameplay_constraints"], _clip(text, 80))
+        if any(k in text for k in ("引擎", "phaser", "pixi", "canvas", "vite")):
+            _append_unique(out["technical_constraints"], _clip(text, 80))
+        if any(k in text for k in ("不要", "别再", "取消")):
+            _append_unique(out["rejected_options"], _clip(text, 80))
+        if any(k in text for k in ("还要", "另外", "待会", "之后再")):
+            _append_unique(out["pending_requests"], _clip(text, 80))
+
+    return out
+
+
+def _append_unique(items: list[str], value: str) -> None:
+    if value and value not in items:
+        items.append(value)
+
+
+def _clip(text: str, n: int) -> str:
+    text = text.strip()
+    if len(text) <= n:
+        return text
+    return text[: n - 1].rstrip() + "…"

--- a/backend/tests/test_session_summary_refresh.py
+++ b/backend/tests/test_session_summary_refresh.py
@@ -1,0 +1,85 @@
+"""P1：Session Summary 持久化刷新。"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.forge.memory.refresh import refresh_session_summary_if_needed
+from app.forge.messages import add_message
+from app.models.game import Game
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_summary_when_forced(db_session) -> None:
+    user = User(
+        id=uuid4(),
+        email=f"sum-{uuid4().hex[:8]}@example.com",
+        password_hash="x",
+        email_verified=True,
+    )
+    game = Game(
+        id=uuid4(),
+        owner_id=user.id,
+        title="摘要游戏",
+        requirement="初始需求",
+    )
+    db_session.add_all([user, game])
+    await db_session.flush()
+    await add_message(
+        db_session,
+        game_id=game.id,
+        run_id=None,
+        user_id=user.id,
+        role="user",
+        kind="requirement",
+        content="做一个像素风跑酷",
+    )
+    await db_session.commit()
+
+    summary = await refresh_session_summary_if_needed(db_session, game, force=True)
+    await db_session.commit()
+
+    assert summary is not None
+    assert "跑酷" in summary["current_goal"] or "像素" in summary["current_goal"]
+    row = await db_session.scalar(select(Game).where(Game.id == game.id))
+    assert row is not None
+    assert row.session_summary_json is not None
+    assert row.session_summary_json.get("current_goal")
+
+
+@pytest.mark.asyncio
+async def test_refresh_skipped_below_threshold(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.forge.memory.refresh.settings.memory_session_summary", True
+    )
+    user = User(
+        id=uuid4(),
+        email=f"sum2-{uuid4().hex[:8]}@example.com",
+        password_hash="x",
+        email_verified=True,
+    )
+    game = Game(
+        id=uuid4(),
+        owner_id=user.id,
+        title="短对话",
+        requirement="短",
+    )
+    db_session.add_all([user, game])
+    await db_session.flush()
+    await add_message(
+        db_session,
+        game_id=game.id,
+        run_id=None,
+        user_id=user.id,
+        role="user",
+        kind="requirement",
+        content="一句话",
+    )
+    await db_session.commit()
+
+    out = await refresh_session_summary_if_needed(db_session, game, force=False)
+    assert out is None or game.session_summary_json is None

--- a/backend/tests/test_session_summary_synth.py
+++ b/backend/tests/test_session_summary_synth.py
@@ -1,0 +1,46 @@
+"""P1：Session Summary 合成与刷新。"""
+
+from __future__ import annotations
+
+from app.forge.memory.context_builder import ContextTurn, estimate_tokens
+from app.forge.memory.summary import (
+    coerce_session_summary,
+    empty_session_summary,
+    should_refresh_summary,
+    synthesize_summary_from_turns,
+)
+
+
+def test_synthesize_sets_goal_from_latest_user_turn() -> None:
+    turns = [
+        ContextTurn(role="user", content="做一个跑酷"),
+        ContextTurn(role="assistant", content="设计方案已生成"),
+        ContextTurn(role="user", content="改成双人合作"),
+    ]
+    summary = synthesize_summary_from_turns(turns, previous=None)
+    assert summary["current_goal"] == "改成双人合作"
+    assert "做一个跑酷" in summary["confirmed_decisions"] or summary["pending_requests"]
+
+
+def test_synthesize_merges_previous_constraints() -> None:
+    prev = empty_session_summary()
+    prev["visual_constraints"] = ["像素风"]
+    prev["confirmed_decisions"] = ["一关"]
+    turns = [ContextTurn(role="user", content="以后都用像素风，再加一关")]
+    summary = synthesize_summary_from_turns(turns, previous=prev)
+    assert "像素风" in summary["visual_constraints"]
+    assert summary["current_goal"]
+
+
+def test_coerce_roundtrip_after_synthesize() -> None:
+    turns = [ContextTurn(role="user", content="平台跳跃")]
+    raw = synthesize_summary_from_turns(turns, previous=None)
+    coerced = coerce_session_summary(raw)
+    assert coerced is not None
+    assert coerced["current_goal"] == "平台跳跃"
+
+
+def test_should_refresh_still_holds() -> None:
+    assert should_refresh_summary(message_count=21, historical_tokens=10) is True
+    tokens = estimate_tokens("x" * 50_000)
+    assert should_refresh_summary(message_count=1, historical_tokens=tokens) is True

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -19,7 +19,7 @@
   * Context Builder：**P1 MVP 建立规范路径；P5 Enforcement 拆除遗留拼装**
 * 落地进度（相对本仓库）:
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
-  * **P1** 🚧 `ContextBuilder` + token budget、`user_preferences` + `/me/preferences`、`games.session_summary_json`、plan/revise 经 Builder；Session Summary **LLM 自动刷新**尚未接（仅 schema + 触发判定）
+  * **P1** 🚧 ContextBuilder / Preferences / plan+art 经 Builder；Session Summary **确定性刷新+持久化**已接（LLM 摘要仍为可选后置）；code 节点仍走遗留拼装至 P5
   * **P2–P5** 未开始
 
 ---


### PR DESCRIPTION
## Summary
- Add a deterministic Session Summary synthesizer and persist refreshed summaries to `games.session_summary_json` when message/token thresholds are hit.
- Gate refresh with `memory_session_summary` (default on); keep LLM summarization as an optional injectable path, not the default.
- Wire summary refresh into plan/art composition and route `art_options` / `revise_art_options` through ContextBuilder.

## Background
Continues P1 Memory from PR #72 per `docs/2026-08-15-forge-runtime-evolution-plan.md`. The previous MVP had summary schema/trigger helpers only; this closes the persistence + art-node ContextBuilder gaps without blocking on LLM summarization cost.

## Changes
- `synthesize_summary_from_turns` + unit tests
- `refresh_session_summary_if_needed` + persistence tests + `memory_session_summary` flag
- `_compose_art_input` and plan/art refresh hooks in `graph.py`
- Evolution plan progress note

## Impact & Risks
- Extra DB reads/writes when thresholds are exceeded on plan/art nodes
- Art prompts gain Memory sections when ContextBuilder is enabled; disable via `memory_context_builder=false` / `memory_session_summary=false`
- Code nodes still use legacy prompt assembly (deferred to P5)
- Deterministic summary is intentionally shallow vs a future LLM summarizer

## Test plan
- [x] `uv run pytest tests/test_session_summary_synth.py tests/test_session_summary_refresh.py tests/test_session_summary.py tests/test_context_builder.py tests/test_explicit_preferences.py`
- [ ] Smoke: accumulate >20 forge messages on a game, run plan/art, confirm `session_summary_json` populated
- [ ] Smoke: art revise with preference-like feedback still pauses at art_confirm
- [ ] Toggle `memory_session_summary=false` and confirm no summary writes

Made with [Cursor](https://cursor.com)