### PR TITLE
feat(cache): P4 Redis Exact Cache allowlist MVP

### DIFF
--- a/backend/app/api/games.py
+++ b/backend/app/api/games.py
@@ -119,8 +119,10 @@ async def _public_item(db: DbSession, game: Game, locale: str | None = None) -> 
 
 
 @router.post("", response_model=ApiResponse[GameResp], status_code=201, responses=ERR_403)
-async def create_game(req: GameCreate, user: CurrentUser, db: DbSession) -> ApiResponse[GameResp]:
-    return ApiResponse(data=_to_resp(await services.create_game(db, user, req)))
+async def create_game(
+    req: GameCreate, user: CurrentUser, db: DbSession, r: RedisClient
+) -> ApiResponse[GameResp]:
+    return ApiResponse(data=_to_resp(await services.create_game(db, user, req, r)))
 
 
 @router.get("/public", response_model=PaginatedData[PublicGameMeta])

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -3,8 +3,9 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from app.auth.deps import RedisClient
 from app.core.response import ApiResponse
-from app.forge.templates.loader import list_templates
+from app.forge.cache import list_templates_cached, normalize_engine_id_cached
 
 router = APIRouter(prefix="/templates", tags=["templates"])
 
@@ -36,5 +37,10 @@ def _to_item(row: dict) -> TemplateItem:
 
 
 @router.get("", response_model=ApiResponse[list[TemplateItem]])
-async def get_templates() -> ApiResponse[list[TemplateItem]]:
-    return ApiResponse(data=[_to_item(t) for t in list_templates()])
+async def get_templates(r: RedisClient) -> ApiResponse[list[TemplateItem]]:
+    rows = await list_templates_cached(r)
+    items: list[TemplateItem] = []
+    for t in rows:
+        engine = await normalize_engine_id_cached(r, t.get("engine"))
+        items.append(_to_item({**t, "engine": engine}))
+    return ApiResponse(data=items)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -116,6 +116,10 @@ class Settings(BaseSettings):
     # P2 Skills：节点经 catalog/router 选择 Methodology；Policy 仍强制注入
     skills_router_enabled: bool = True
 
+    # P4 Exact Cache：仅白名单低熵节点；关则全部 miss
+    exact_cache_enabled: bool = True
+    exact_cache_ttl_s: int = 86_400
+
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
     # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。
     thumbnail_enabled: bool = True

--- a/backend/app/forge/cache/__init__.py
+++ b/backend/app/forge/cache/__init__.py
@@ -1,0 +1,29 @@
+"""P4 Exact Cache package."""
+
+from app.forge.cache.exact import (
+    ALLOWLIST,
+    FORBIDDEN,
+    build_exact_cache_key,
+    exact_cache_get,
+    exact_cache_set,
+    is_cacheable_node,
+)
+from app.forge.cache.routers import (
+    classify_entry_phase_cached,
+    get_template_cached,
+    list_templates_cached,
+    normalize_engine_id_cached,
+)
+
+__all__ = [
+    "ALLOWLIST",
+    "FORBIDDEN",
+    "build_exact_cache_key",
+    "classify_entry_phase_cached",
+    "exact_cache_get",
+    "exact_cache_set",
+    "get_template_cached",
+    "is_cacheable_node",
+    "list_templates_cached",
+    "normalize_engine_id_cached",
+]

--- a/backend/app/forge/cache/exact.py
+++ b/backend/app/forge/cache/exact.py
@@ -1,0 +1,133 @@
+"""P4 Exact Cache：白名单节点 Redis 精确缓存。
+
+允许：entry_router / engine_router / intent_classification / template_selection /
+deterministic_metadata。
+禁止：plan / art / code / repair / qa / preference / HITL revise。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "entry_router",
+        "engine_router",
+        "intent_classification",
+        "template_selection",
+        "deterministic_metadata",
+    }
+)
+
+FORBIDDEN: frozenset[str] = frozenset(
+    {
+        "plan",
+        "art",
+        "art_options",
+        "art_detail",
+        "code",
+        "repair",
+        "qa",
+        "diagnose",
+        "preference_extraction",
+        "hitl_revise",
+        "revise_plan",
+        "revise_art_options",
+    }
+)
+
+PROMPT_VERSION = "v1"
+POLICY_VERSION = "v1"
+
+
+def is_cacheable_node(node: str) -> bool:
+    n = (node or "").strip()
+    if n in FORBIDDEN:
+        return False
+    return n in ALLOWLIST
+
+
+def build_exact_cache_key(
+    *,
+    node: str,
+    input_payload: Any,
+    model: str = "",
+    prompt_version: str = PROMPT_VERSION,
+    policy_version: str = POLICY_VERSION,
+    skill_bundle_hash: str = "",
+    preference_revision: str | None = None,
+) -> str:
+    """Cache key：node + input_hash + model + prompt/policy/skill（+ optional pref）。"""
+    raw = json.dumps(input_payload, ensure_ascii=False, sort_keys=True, default=str)
+    input_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+    parts = [
+        "forge:exact",
+        node,
+        input_hash,
+        model or "-",
+        prompt_version,
+        policy_version,
+        skill_bundle_hash or "-",
+    ]
+    if preference_revision is not None:
+        parts.append(preference_revision)
+    return ":".join(parts)
+
+
+async def exact_cache_get(
+    r: redis.Redis,
+    *,
+    node: str,
+    input_payload: Any,
+    model: str = "",
+    skill_bundle_hash: str = "",
+    preference_revision: str | None = None,
+) -> Any | None:
+    if not settings.exact_cache_enabled or not is_cacheable_node(node):
+        return None
+    key = build_exact_cache_key(
+        node=node,
+        input_payload=input_payload,
+        model=model,
+        skill_bundle_hash=skill_bundle_hash,
+        preference_revision=preference_revision,
+    )
+    raw = await r.get(key)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+async def exact_cache_set(
+    r: redis.Redis,
+    *,
+    node: str,
+    input_payload: Any,
+    value: Any,
+    model: str = "",
+    skill_bundle_hash: str = "",
+    preference_revision: str | None = None,
+    ttl_s: int | None = None,
+) -> bool:
+    """写入成功返回 True；禁止节点或关 flag 时返回 False（且不写）。"""
+    if not settings.exact_cache_enabled or not is_cacheable_node(node):
+        return False
+    key = build_exact_cache_key(
+        node=node,
+        input_payload=input_payload,
+        model=model,
+        skill_bundle_hash=skill_bundle_hash,
+        preference_revision=preference_revision,
+    )
+    ttl = ttl_s if ttl_s is not None else settings.exact_cache_ttl_s
+    await r.set(key, json.dumps(value, ensure_ascii=False, default=str), ex=ttl)
+    return True

--- a/backend/app/forge/cache/routers.py
+++ b/backend/app/forge/cache/routers.py
@@ -1,0 +1,78 @@
+"""白名单节点的 Exact Cache 包装（同步纯函数 + Redis get/set）。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import redis.asyncio as redis
+
+from app.enums import EntryPhase
+from app.forge.cache.exact import exact_cache_get, exact_cache_set
+from app.forge.engine_router import normalize_engine_id
+from app.forge.entry_router import classify_entry_phase
+from app.forge.templates.loader import get_template, list_templates
+
+
+async def classify_entry_phase_cached(
+    r: redis.Redis,
+    requirement: str | None,
+    *,
+    has_prior_version: bool,
+) -> EntryPhase:
+    payload = {
+        "requirement": (requirement or "").strip(),
+        "has_prior_version": bool(has_prior_version),
+    }
+    hit = await exact_cache_get(r, node="entry_router", input_payload=payload)
+    if isinstance(hit, str):
+        try:
+            return EntryPhase(hit)
+        except ValueError:
+            pass
+    result = classify_entry_phase(requirement, has_prior_version=has_prior_version)
+    await exact_cache_set(
+        r, node="entry_router", input_payload=payload, value=result.value
+    )
+    return result
+
+
+async def normalize_engine_id_cached(r: redis.Redis, value: object) -> str:
+    payload = {"value": value if isinstance(value, str) else repr(value)}
+    hit = await exact_cache_get(r, node="engine_router", input_payload=payload)
+    if isinstance(hit, str) and hit:
+        return hit
+    result = normalize_engine_id(value)
+    await exact_cache_set(r, node="engine_router", input_payload=payload, value=result)
+    return result
+
+
+async def get_template_cached(
+    r: redis.Redis,
+    template_id: str,
+    *,
+    require_verified: bool = False,
+) -> dict[str, Any]:
+    payload = {
+        "template_id": template_id,
+        "require_verified": bool(require_verified),
+    }
+    hit = await exact_cache_get(r, node="template_selection", input_payload=payload)
+    if isinstance(hit, dict) and hit.get("template_id"):
+        return hit
+    result = get_template(template_id, require_verified=require_verified)
+    await exact_cache_set(r, node="template_selection", input_payload=payload, value=result)
+    return result
+
+
+async def list_templates_cached(
+    r: redis.Redis,
+    *,
+    verified_only: bool = False,
+) -> list[dict[str, Any]]:
+    payload = {"verified_only": bool(verified_only), "op": "list"}
+    hit = await exact_cache_get(r, node="template_selection", input_payload=payload)
+    if isinstance(hit, list):
+        return hit
+    result = list_templates(verified_only=verified_only)
+    await exact_cache_set(r, node="template_selection", input_payload=payload, value=result)
+    return result

--- a/backend/app/games/services.py
+++ b/backend/app/games/services.py
@@ -17,7 +17,7 @@ from app.core.errors import AppError, ErrorCode
 from app.enums import EntryPhase, GameStatus, PauseReason, RunPhase, RunStatus
 from app.forge import control as run_ctrl
 from app.forge import state as ckpt
-from app.forge.entry_router import classify_entry_phase
+from app.forge.cache import classify_entry_phase_cached
 from app.forge.messages import add_message
 from app.forge.queue import enqueue_resume
 from app.forge.reliability.pause import build_pause_checkpoint
@@ -69,14 +69,21 @@ async def _count_games(db: AsyncSession, user_id: UUID, status: GameStatus) -> i
     return int(n or 0)
 
 
-async def create_game(db: AsyncSession, user: User, req: GameCreate) -> Game:
+async def create_game(
+    db: AsyncSession, user: User, req: GameCreate, r: redis.Redis | None = None
+) -> Game:
     _require_verified(user)
     title = (req.title or "").strip()
     requirement = (req.requirement or "").strip()
     if req.template_id:
-        from app.forge.templates.loader import get_template
+        if r is not None:
+            from app.forge.cache import get_template_cached
 
-        tpl = get_template(req.template_id)
+            tpl = await get_template_cached(r, req.template_id)
+        else:
+            from app.forge.templates.loader import get_template
+
+            tpl = get_template(req.template_id)
         if not title:
             title = str(tpl["title"])
         if not requirement:
@@ -364,8 +371,8 @@ async def create_run(
             )
             if cfg is None:
                 raise AppError(ErrorCode.LLM_CONFIG_NOT_FOUND, "LLM 配置不存在")
-        entry = classify_entry_phase(
-            req.requirement, has_prior_version=game.current_version > 0
+        entry = await classify_entry_phase_cached(
+            r, req.requirement, has_prior_version=game.current_version > 0
         )
         initial_phase = RunPhase.CODE if entry == EntryPhase.CODE else RunPhase.PLAN
         run = GenerationRun(

--- a/backend/tests/test_exact_cache.py
+++ b/backend/tests/test_exact_cache.py
@@ -1,0 +1,140 @@
+"""P4 Exact Cache：白名单强制 + Redis get/set + 路由包装。"""
+
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest
+
+from app.core.config import settings
+from app.enums import EntryPhase
+from app.forge.cache.exact import (
+    ALLOWLIST,
+    FORBIDDEN,
+    build_exact_cache_key,
+    exact_cache_get,
+    exact_cache_set,
+    is_cacheable_node,
+)
+from app.forge.cache.routers import (
+    classify_entry_phase_cached,
+    get_template_cached,
+    normalize_engine_id_cached,
+)
+
+
+@pytest.fixture
+def redis_client() -> fakeredis.aioredis.FakeRedis:
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+def test_allowlist_and_forbidden_disjoint() -> None:
+    assert ALLOWLIST.isdisjoint(FORBIDDEN)
+    for node in ("plan", "art", "code", "repair", "qa", "preference_extraction", "hitl_revise"):
+        assert node in FORBIDDEN
+        assert not is_cacheable_node(node)
+    for node in ("entry_router", "engine_router", "template_selection"):
+        assert node in ALLOWLIST
+        assert is_cacheable_node(node)
+
+
+def test_cache_key_includes_skill_and_optional_pref() -> None:
+    base = build_exact_cache_key(
+        node="entry_router",
+        input_payload={"a": 1},
+        model="m1",
+        skill_bundle_hash="abc",
+    )
+    with_pref = build_exact_cache_key(
+        node="entry_router",
+        input_payload={"a": 1},
+        model="m1",
+        skill_bundle_hash="abc",
+        preference_revision="r2",
+    )
+    assert "entry_router" in base
+    assert "abc" in base
+    assert with_pref != base
+    assert with_pref.endswith(":r2")
+
+
+@pytest.mark.asyncio
+async def test_forbidden_nodes_never_write(redis_client: fakeredis.aioredis.FakeRedis) -> None:
+    for node in ("plan", "code", "art", "repair", "qa", "preference_extraction"):
+        ok = await exact_cache_set(
+            redis_client,
+            node=node,
+            input_payload={"x": 1},
+            value={"bad": True},
+        )
+        assert ok is False
+        assert await exact_cache_get(redis_client, node=node, input_payload={"x": 1}) is None
+    keys = await redis_client.keys("forge:exact:*")
+    assert keys == []
+
+
+@pytest.mark.asyncio
+async def test_exact_cache_roundtrip_allowlist(
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> None:
+    payload = {"requirement": "把背景改成紫色", "has_prior_version": True}
+    assert await exact_cache_get(redis_client, node="entry_router", input_payload=payload) is None
+    assert await exact_cache_set(
+        redis_client, node="entry_router", input_payload=payload, value="code"
+    )
+    assert (
+        await exact_cache_get(redis_client, node="entry_router", input_payload=payload) == "code"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_cache_disabled_skips(
+    redis_client: fakeredis.aioredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "exact_cache_enabled", False)
+    assert not await exact_cache_set(
+        redis_client, node="entry_router", input_payload={"a": 1}, value="plan"
+    )
+    assert await exact_cache_get(redis_client, node="entry_router", input_payload={"a": 1}) is None
+
+
+@pytest.mark.asyncio
+async def test_classify_entry_phase_cached_hits(
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> None:
+    first = await classify_entry_phase_cached(
+        redis_client, "把背景改成紫色", has_prior_version=True
+    )
+    assert first == EntryPhase.CODE
+    # 第二次应命中缓存；篡改 Redis 后仍返回缓存值可证明走了 cache
+    payload = {"requirement": "把背景改成紫色", "has_prior_version": True}
+    key = build_exact_cache_key(node="entry_router", input_payload=payload)
+    await redis_client.set(key, '"plan"')
+    second = await classify_entry_phase_cached(
+        redis_client, "把背景改成紫色", has_prior_version=True
+    )
+    assert second == EntryPhase.PLAN
+
+
+@pytest.mark.asyncio
+async def test_normalize_engine_id_cached(
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> None:
+    assert await normalize_engine_id_cached(redis_client, "phaser3") == "phaser3"
+    assert await normalize_engine_id_cached(redis_client, "unknown") == "canvas"
+    keys = await redis_client.keys("forge:exact:engine_router:*")
+    assert len(keys) >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_template_cached(redis_client: fakeredis.aioredis.FakeRedis) -> None:
+    from app.forge.templates.loader import list_templates
+
+    rows = list_templates()
+    assert rows, "catalog 应有至少一条模板"
+    tid = str(rows[0]["template_id"])
+    a = await get_template_cached(redis_client, tid)
+    b = await get_template_cached(redis_client, tid)
+    assert a["template_id"] == tid
+    assert b == a
+    keys = await redis_client.keys("forge:exact:template_selection:*")
+    assert len(keys) >= 1

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -1,13 +1,13 @@
 # Forge Runtime 演进计划 v2
 
-* Status: In Progress（**P0/P1/P2 已合入**；**P3 Sandbox 推进中**）
+* Status: In Progress（**P0–P4 MVP 已落地**；P3 E2B 生产切换与 P4.5 Semantic 仍 gated；P5 未开始）
 * Date: 2026-08-15
 * Owners: TBD
 * Reviewers: TBD
 * Related:
   * [CodeQaLoop 设计](./superpowers/specs/2026-08-15-code-qa-loop-design.md)（硬约束）
   * `backend/app/forge/graph.py` / `subgraphs/code_qa_loop.py`
-  * `backend/app/sandbox/`、`backend/app/forge/skills/`
+  * `backend/app/sandbox/`、`backend/app/forge/skills/`、`backend/app/forge/cache/`
   * `backend/app/forge/memory/`（P1 ContextBuilder / Summary / Preferences）
 * ADR 状态:
   * **ADR-01** Degraded Artifact Publishing — **Accepted**
@@ -21,8 +21,9 @@
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）
   * **P2** ✅ Skills catalog/router（PR `#75`）
-  * **P3** 🚧 SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）
-  * **P4–P5** 未开始
+  * **P3** ✅ SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）（PR `#76`）
+  * **P4** ✅ Redis Exact Cache 白名单 MVP（entry/engine/template）；Semantic Cache 未开
+  * **P5** 未开始
 
 ---
 
@@ -766,6 +767,8 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 * allowlist 外 0 缓存命中
 * Code/Repair/Art 无 cache
 * Semantic false direct-hit 目标（若上线）极高 precision（如 <0.1%），否则不下发
+
+**MVP 验收（本仓库）**：`exact_cache_enabled` 默认开；`test_exact_cache.py` 覆盖禁止节点不写 Redis、白名单 roundtrip、flag 关闭、entry/engine/template 包装；`create_run` / `GET /templates` / `create_game(template_id)` 已接线。P4.5 Semantic 仍实验未开。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `forge.cache` Exact Cache with allowlist/forbidden enforcement, Redis get/set, and cache key shape (`node` / `input_hash` / `model` / `prompt_version` / `policy_version` / `skill_bundle_hash`).
- Wire cached helpers into `create_run` (entry_router), `create_game(template_id)` and `GET /templates` (template_selection + engine_router).
- Gate with `exact_cache_enabled` / `exact_cache_ttl_s`; Creative nodes (plan/art/code/repair/qa) remain uncacheable. Semantic Cache stays out of scope.

## Test plan
- [x] `uv run pytest tests/test_exact_cache.py` (allowlist, forbidden never writes, roundtrip, flag off, cached wrappers)
- [x] `uv run pytest tests/test_entry_phase.py` (create_run entry still routes correctly)
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)