### PR TITLE
feat(memory): P5 ContextBuilder Enforcement and subsystem spans

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -105,6 +105,8 @@ class Settings(BaseSettings):
     reliability_idempotent_side_effects: bool = True
     # P1 Memory：ContextBuilder 规范路径；关则节点保持旧拼装
     memory_context_builder: bool = True
+    # P5：正式 Node 强制经 build_node_context；开则禁用 plan/art/code 遗留 concat
+    memory_context_enforcement: bool = True
     # P1 Memory：注入/写入 Explicit Preferences
     memory_preferences: bool = True
     # P1 Memory：ContextBuilder 总 token 预算（后续用 trace 标定）

--- a/backend/app/forge/cache/exact.py
+++ b/backend/app/forge/cache/exact.py
@@ -98,7 +98,10 @@ async def exact_cache_get(
         skill_bundle_hash=skill_bundle_hash,
         preference_revision=preference_revision,
     )
-    raw = await r.get(key)
+    from app.forge.tracing import observe_subsystem
+
+    with observe_subsystem("cache", "exact_get", metadata={"node": node}):
+        raw = await r.get(key)
     if raw is None:
         return None
     try:
@@ -129,5 +132,8 @@ async def exact_cache_set(
         preference_revision=preference_revision,
     )
     ttl = ttl_s if ttl_s is not None else settings.exact_cache_ttl_s
-    await r.set(key, json.dumps(value, ensure_ascii=False, default=str), ex=ttl)
+    from app.forge.tracing import observe_subsystem
+
+    with observe_subsystem("cache", "exact_set", metadata={"node": node, "ttl_s": ttl}):
+        await r.set(key, json.dumps(value, ensure_ascii=False, default=str), ex=ttl)
     return True

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -110,14 +110,33 @@ async def execute_code_or_repair(
         qa_diagnosis = state.get("qa_diagnosis") or ""
         attempt = int(state.get("attempt") or 0) + 1
 
-        base_user_msg = f"【已确认设计稿 JSON】\n{design_text}"
+        # P5：Memory/设计稿经 ContextBuilder；assets/scaffold/repair 仍为任务载荷追加
+        from app.forge.memory.loader import build_node_context, use_context_builder
+
+        entry_block = (entry_req or "").strip() or "请按已确认设计稿实现可运行游戏。"
+        if use_context_builder():
+            if settings.memory_session_summary:
+                from app.forge.memory.refresh import refresh_session_summary_if_needed
+
+                await refresh_session_summary_if_needed(ctx.s, ctx.game)
+            built = await build_node_context(
+                ctx.s,
+                node="code" if attempt <= 1 and not entry_req else "repair",
+                game=ctx.game,
+                user_id=ctx.game.owner_id,
+                current_input=entry_block,
+                design_doc=design_doc,
+            )
+            base_user_msg = built.user_message
+        else:
+            base_user_msg = f"【已确认设计稿 JSON】\n{design_text}"
+            if entry_req:
+                base_user_msg += f"\n\n【本次实现变更要求】\n{entry_req}"
         if art_direction:
             base_user_msg += (
                 "\n\n【已确认美术实现设计稿 JSON】\n"
                 + json.dumps(art_direction, ensure_ascii=False, indent=2)
             )
-        if entry_req:
-            base_user_msg += f"\n\n【本次实现变更要求】\n{entry_req}"
         generation_user_msg = base_user_msg
         if assets_block:
             generation_user_msg += f"\n\n【可用内置素材】{assets_block}"

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -318,7 +318,9 @@ async def _compose_plan_input(
             ctx.s, user_id=ctx.game.owner_id, text=current_input
         )
     wrapped = _wrap_user_input(current_input)
-    if not settings.memory_context_builder:
+    from app.forge.memory.loader import build_node_context, use_context_builder
+
+    if not use_context_builder():
         if design_doc is None:
             return wrapped
         return (
@@ -327,9 +329,7 @@ async def _compose_plan_input(
             "【用户修改意见】\n"
             f"{wrapped}"
         )
-    from app.forge.memory.loader import build_node_context
-
-    # revise 场景：设计稿仍用显式标签前置（对齐 PLAN_REVISE）；Memory 走 Builder
+    # revise：设计稿用显式标签前置（对齐 PLAN_REVISE）；Memory 走 Builder
     built = await build_node_context(
         ctx.s,
         node="plan",
@@ -378,12 +378,12 @@ async def _compose_art_input(
     else:
         prompt_input = current_input
     wrapped = _wrap_user_input(prompt_input)
-    if not settings.memory_context_builder:
+    from app.forge.memory.loader import build_node_context, use_context_builder
+
+    if not use_context_builder():
         if not current_input.strip():
             return design_block
         return f"{design_block}\n\n【用户反馈】\n{wrapped}"
-    from app.forge.memory.loader import build_node_context
-
     built = await build_node_context(
         ctx.s,
         node="art",
@@ -395,6 +395,39 @@ async def _compose_art_input(
     if not current_input.strip():
         return f"{design_block}\n\n{built.user_message}"
     return f"{design_block}\n\n【用户反馈】\n{built.user_message}"
+
+
+async def _compose_art_detail_input(
+    ctx: _Ctx,
+    *,
+    design_doc: dict[str, Any],
+    selected_option: dict[str, Any],
+) -> str:
+    """Art detail：经 ContextBuilder 注入 Memory；设计稿/选项作任务载荷。"""
+    if settings.memory_session_summary:
+        from app.forge.memory.refresh import refresh_session_summary_if_needed
+
+        await refresh_session_summary_if_needed(ctx.s, ctx.game)
+    option_json = json.dumps(selected_option, ensure_ascii=False)
+    task = (
+        "【已确认游戏策划稿 JSON】\n"
+        f"{design_doc_to_text(design_doc)}\n\n"
+        "【用户选定的美术方向】\n"
+        f"{option_json}"
+    )
+    from app.forge.memory.loader import build_node_context, use_context_builder
+
+    if not use_context_builder():
+        return task
+    built = await build_node_context(
+        ctx.s,
+        node="art_detail",
+        game=ctx.game,
+        user_id=ctx.game.owner_id,
+        current_input="请基于已确认策划稿与选定美术方向生成详细实现设计。",
+        design_doc=design_doc,
+    )
+    return f"{task}\n\n{built.user_message}"
 
 
 async def _streamed_llm_or_fallback(
@@ -968,12 +1001,15 @@ def _build_graph(ctx: _Ctx) -> Any:
             last_error = "未知错误"
             for attempt in range(1, settings.art_max_retries + 1):
                 try:
+                    user_msg = await _compose_art_detail_input(
+                        ctx,
+                        design_doc=design_doc,
+                        selected_option=selected_option,
+                    )
                     raw = await _streamed_llm_or_fallback(
                         ctx,
                         ART_DETAIL_PROMPT,
-                        f"【已确认游戏策划稿 JSON】\n{design_doc_to_text(design_doc)}\n\n"
-                        "【用户选定的美术方向】\n"
-                        + json.dumps(selected_option, ensure_ascii=False),
+                        user_msg,
                         "art",
                         emit_delta=False,
                     )

--- a/backend/app/forge/memory/__init__.py
+++ b/backend/app/forge/memory/__init__.py
@@ -5,6 +5,7 @@ from app.forge.memory.context_builder import (
     ContextArtifacts,
     ContextBuilder,
     ContextTurn,
+    context_fingerprint,
     estimate_tokens,
 )
 from app.forge.memory.summary import (
@@ -22,6 +23,7 @@ __all__ = [
     "ContextTurn",
     "SessionSummary",
     "coerce_session_summary",
+    "context_fingerprint",
     "empty_session_summary",
     "estimate_tokens",
     "should_refresh_summary",

--- a/backend/app/forge/memory/context_builder.py
+++ b/backend/app/forge/memory/context_builder.py
@@ -1,10 +1,11 @@
-"""Context Builder：统一拼装 Session / Preference / Artifact 注入文本（P1 MVP）。
+"""Context Builder：统一拼装 Session / Preference / Artifact 注入文本（P1 MVP / P5 Enforcement）。
 
 历史与偏好永远是 data，不得当作 instruction（防注入）。
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from typing import Any
@@ -15,6 +16,20 @@ def estimate_tokens(text: str) -> int:
     if not text:
         return 0
     return max(1, (len(text) + 3) // 4)
+
+
+def context_fingerprint(*, node: str, sections: dict[str, str], token_estimate: int) -> str:
+    """Prompt fingerprint：node + section 内容哈希 + token 估计（可观测 / cache 对齐）。"""
+    h = hashlib.sha256()
+    h.update((node or "").encode("utf-8"))
+    h.update(b"\0")
+    for key in sorted(sections):
+        h.update(key.encode("utf-8"))
+        h.update(b"=")
+        h.update((sections.get(key) or "").encode("utf-8"))
+        h.update(b"\n")
+    h.update(str(token_estimate).encode("utf-8"))
+    return h.hexdigest()[:16]
 
 
 @dataclass(frozen=True)
@@ -35,6 +50,7 @@ class BuiltContext:
     sections: dict[str, str]
     token_estimate: int
     node: str
+    fingerprint: str = ""
 
 
 # 预算占比（与演进计划一致；后续用 trace 标定）
@@ -97,11 +113,15 @@ class ContextBuilder:
                 body = _assemble(sections)
                 break
 
+        token_estimate = estimate_tokens(body)
         return BuiltContext(
             user_message=body,
             sections=sections,
-            token_estimate=estimate_tokens(body),
+            token_estimate=token_estimate,
             node=node,
+            fingerprint=context_fingerprint(
+                node=node, sections=sections, token_estimate=token_estimate
+            ),
         )
 
 

--- a/backend/app/forge/memory/loader.py
+++ b/backend/app/forge/memory/loader.py
@@ -1,4 +1,4 @@
-"""从 DB 装配 ContextBuilder 输入（P1）。"""
+"""从 DB 装配 ContextBuilder 输入（P1）；P5 为正式 Node 唯一拼装入口。"""
 
 from __future__ import annotations
 
@@ -21,6 +21,11 @@ from app.models.forge_message import ForgeMessage
 from app.models.game import Game
 
 
+def use_context_builder() -> bool:
+    """Builder 或 Enforcement 任一开启时，正式 Node 必须走 build_node_context。"""
+    return bool(settings.memory_context_builder or settings.memory_context_enforcement)
+
+
 async def build_node_context(
     db: AsyncSession,
     *,
@@ -31,7 +36,7 @@ async def build_node_context(
     design_doc: dict | None = None,
     recent_limit: int = 12,
 ) -> BuiltContext:
-    """规范路径：新节点应经此入口拼装，而非自行拼历史。"""
+    """规范路径：正式节点必须经此入口拼装，禁止自行拼历史/偏好。"""
     summary = coerce_session_summary(game.session_summary_json)
     prefs: list[dict] = []
     if settings.memory_preferences:
@@ -54,15 +59,27 @@ async def build_node_context(
         ]
 
     artifacts = ContextArtifacts(design_doc=design_doc) if design_doc else ContextArtifacts()
-    return ContextBuilder.build(
-        node=node,
-        current_input=current_input,
-        session_summary=dict(summary) if summary else None,
-        recent_turns=turns,
-        preferences=prefs,
-        artifacts=artifacts,
-        budget_tokens=settings.memory_context_budget_tokens,
-    )
+    from app.forge.tracing import observe_context_build, observe_subsystem
+
+    with observe_subsystem("memory", "build_node_context", metadata={"node": node}):
+        built = ContextBuilder.build(
+            node=node,
+            current_input=current_input,
+            session_summary=dict(summary) if summary else None,
+            recent_turns=turns,
+            preferences=prefs,
+            artifacts=artifacts,
+            budget_tokens=settings.memory_context_budget_tokens,
+        )
+        section_lens = {k: len(v or "") for k, v in built.sections.items()}
+        with observe_context_build(
+            node=built.node,
+            token_estimate=built.token_estimate,
+            fingerprint=built.fingerprint,
+            section_lens=section_lens,
+        ):
+            pass
+    return built
 
 
 async def maybe_touch_session_summary_flag(db: AsyncSession, game_id: uuid.UUID) -> bool:

--- a/backend/app/forge/skills/router.py
+++ b/backend/app/forge/skills/router.py
@@ -18,25 +18,28 @@ def resolve_skills_for_node(
 
     Art 节点不会看到 billing/sandbox admin 等未登记 Skill（catalog 白名单即边界）。
     """
+    from app.forge.tracing import observe_subsystem
+
     hints = hints or {}
-    metas = list_skill_metas()
-    node_key = _normalize_node(node)
+    with observe_subsystem("skill", "resolve", metadata={"node": node}):
+        metas = list_skill_metas()
+        node_key = _normalize_node(node)
 
-    policy_metas = [
-        m for m in metas if m.kind == "policy" and _node_allowed(m, node_key)
-    ]
-    candidates = [
-        m for m in metas if m.kind == "methodology" and _node_allowed(m, node_key)
-    ]
-    chosen = _choose_methodology(node_key, candidates, hints)
+        policy_metas = [
+            m for m in metas if m.kind == "policy" and _node_allowed(m, node_key)
+        ]
+        candidates = [
+            m for m in metas if m.kind == "methodology" and _node_allowed(m, node_key)
+        ]
+        chosen = _choose_methodology(node_key, candidates, hints)
 
-    policy = tuple(_load(m) for m in policy_metas)
-    methodology = tuple(_load(m) for m in chosen)
-    return ResolvedSkills(
-        policy=policy,
-        methodology=methodology,
-        loaded_body_count=len(policy) + len(methodology),
-    )
+        policy = tuple(_load(m) for m in policy_metas)
+        methodology = tuple(_load(m) for m in chosen)
+        return ResolvedSkills(
+            policy=policy,
+            methodology=methodology,
+            loaded_body_count=len(policy) + len(methodology),
+        )
 
 
 def _normalize_node(node: str) -> str:

--- a/backend/app/forge/tracing.py
+++ b/backend/app/forge/tracing.py
@@ -1,4 +1,4 @@
-"""Langfuse trace 集成（docs/02 §可观测）：run/phase span 包装。
+"""Langfuse trace 集成（docs/02 §可观测）：run/phase/subsystem span 包装。
 
 client 访问与生命周期统一在 app.core.langfuse；此处仅保留 forge 编排语义命名，
 供 graph.py 用 observe_run / observe_phase。未配置 key 时为空操作。
@@ -23,4 +23,34 @@ def observe_run(run_id: str, name: str = "generation_run") -> Iterator[Any]:
 @contextmanager
 def observe_phase(phase: str) -> Iterator[Any]:
     with observe_span(f"phase:{phase}") as span:
+        yield span
+
+
+@contextmanager
+def observe_context_build(
+    *,
+    node: str,
+    token_estimate: int,
+    fingerprint: str,
+    section_lens: dict[str, int] | None = None,
+) -> Iterator[Any]:
+    """P5：ContextBuilder 拼装 span（fingerprint / token / section 长度）。"""
+    meta: dict[str, Any] = {
+        "node": node,
+        "token_estimate": token_estimate,
+        "fingerprint": fingerprint,
+    }
+    if section_lens:
+        meta["section_lens"] = section_lens
+    with observe_span("context_build", metadata=meta) as span:
+        yield span
+
+
+@contextmanager
+def observe_subsystem(
+    kind: str, name: str, metadata: dict[str, Any] | None = None
+) -> Iterator[Any]:
+    """P5：Memory / Skill / Sandbox / Cache 子系统 span。"""
+    meta = {"subsystem": kind, **(metadata or {})}
+    with observe_span(f"{kind}:{name}", metadata=meta) as span:
         yield span

--- a/backend/app/sandbox/__init__.py
+++ b/backend/app/sandbox/__init__.py
@@ -18,7 +18,12 @@ _sandbox: Sandbox | None = None
 def get_sandbox_backend() -> SandboxBackend:
     global _backend
     if _backend is None:
-        _backend = _build_backend(settings.sandbox_backend)
+        from app.forge.tracing import observe_subsystem
+
+        with observe_subsystem(
+            "sandbox", "select_backend", metadata={"backend": settings.sandbox_backend}
+        ):
+            _backend = _build_backend(settings.sandbox_backend)
     return _backend
 
 

--- a/backend/tests/test_context_builder.py
+++ b/backend/tests/test_context_builder.py
@@ -1,4 +1,4 @@
-"""P1：ContextBuilder 统一拼装入口与 token budget。"""
+"""P1：ContextBuilder 统一拼装入口与 token budget；P5 fingerprint。"""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from app.forge.memory.context_builder import (
     ContextArtifacts,
     ContextBuilder,
     ContextTurn,
+    context_fingerprint,
 )
 
 
@@ -34,6 +35,28 @@ def test_build_includes_required_sections_and_data_fence() -> None:
     assert built.sections["current_request"]
     assert built.token_estimate > 0
     assert built.token_estimate <= 2000
+    assert built.fingerprint
+    assert len(built.fingerprint) == 16
+
+
+def test_fingerprint_stable_for_identical_inputs() -> None:
+    kwargs = dict(
+        node="code",
+        current_input="实现关卡",
+        session_summary={"current_goal": "g"},
+        recent_turns=[ContextTurn(role="user", content="hi")],
+        preferences=[],
+        artifacts=ContextArtifacts(design_doc={"title": "t"}),
+        budget_tokens=800,
+    )
+    a = ContextBuilder.build(**kwargs)
+    b = ContextBuilder.build(**kwargs)
+    assert a.fingerprint == b.fingerprint
+    assert a.fingerprint == context_fingerprint(
+        node=a.node, sections=a.sections, token_estimate=a.token_estimate
+    )
+    c = ContextBuilder.build(**{**kwargs, "current_input": "另一请求"})
+    assert c.fingerprint != a.fingerprint
 
 
 def test_budget_truncates_recent_turns_first() -> None:
@@ -93,3 +116,15 @@ def test_empty_optional_sections_still_build() -> None:
     )
     assert "hello" in built.user_message
     assert built.token_estimate <= 200
+    assert built.fingerprint
+
+
+def test_use_context_builder_respects_enforcement(monkeypatch) -> None:
+    from app.core.config import settings
+    from app.forge.memory.loader import use_context_builder
+
+    monkeypatch.setattr(settings, "memory_context_builder", False)
+    monkeypatch.setattr(settings, "memory_context_enforcement", False)
+    assert use_context_builder() is False
+    monkeypatch.setattr(settings, "memory_context_enforcement", True)
+    assert use_context_builder() is True

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -1,6 +1,6 @@
 # Forge Runtime 演进计划 v2
 
-* Status: In Progress（**P0–P4 MVP 已落地**；P3 E2B 生产切换与 P4.5 Semantic 仍 gated；P5 未开始）
+* Status: In Progress（**P0–P4 MVP 已落地**；**P5 Enforcement 推进中**；P3 E2B 生产切换与 P4.5 Semantic 仍 gated）
 * Date: 2026-08-15
 * Owners: TBD
 * Reviewers: TBD
@@ -8,7 +8,7 @@
   * [CodeQaLoop 设计](./superpowers/specs/2026-08-15-code-qa-loop-design.md)（硬约束）
   * `backend/app/forge/graph.py` / `subgraphs/code_qa_loop.py`
   * `backend/app/sandbox/`、`backend/app/forge/skills/`、`backend/app/forge/cache/`
-  * `backend/app/forge/memory/`（P1 ContextBuilder / Summary / Preferences）
+  * `backend/app/forge/memory/`（P1 ContextBuilder / Summary / Preferences；P5 Enforcement）
 * ADR 状态:
   * **ADR-01** Degraded Artifact Publishing — **Accepted**
   * **ADR-05** Recoverable Pause Representation — **Accepted**
@@ -22,8 +22,8 @@
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）
   * **P2** ✅ Skills catalog/router（PR `#75`）
   * **P3** ✅ SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）（PR `#76`）
-  * **P4** ✅ Redis Exact Cache 白名单 MVP（entry/engine/template）；Semantic Cache 未开
-  * **P5** 未开始
+  * **P4** ✅ Redis Exact Cache 白名单 MVP（entry/engine/template）；Semantic Cache 未开（PR `#78`）
+  * **P5** 🚧 ContextBuilder Enforcement + fingerprint + Memory/Skill/Sandbox/Cache spans（diagnose 任务载荷仍可外挂）
 
 ---
 
@@ -779,6 +779,8 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 * Migration cleanup、Feature flag 收敛、废弃路径删除
 * Chaos / Load / Security 测试
 * 文档与 ADR 归档
+
+**MVP 进度（本仓库）**：`memory_context_enforcement` 默认开；`BuiltContext.fingerprint` + `observe_context_build`；plan/art/art_detail/code|repair 经 `build_node_context`；Skill/Sandbox/Cache 挂 `observe_subsystem`。diagnose 的错误/HTML 摘录仍为任务载荷（非 Memory SoT）。Chaos/Load/Security 与 ADR 归档另开。
 
 ---
 


### PR DESCRIPTION
## Summary
- Enforce ContextBuilder as the production Memory entry (`memory_context_enforcement`): `art_detail` and `code`/`repair` now go through `build_node_context`; plan/art already did.
- Add `BuiltContext.fingerprint` plus `observe_context_build` / `observe_subsystem` spans for Memory, Skill, Sandbox, and Exact Cache.
- Task payloads (assets, scaffold, selected art option, repair HTML) stay appended outside Memory SoT. Diagnose excerpt path and Chaos/Load/Security remain follow-ups.

## Test plan
- [x] `uv run pytest tests/test_context_builder.py` (fence, budget, fingerprint stability, enforcement flag)
- [x] `uv run pytest tests/test_exact_cache.py tests/test_skill_router.py`
- [x] `uv run ruff check` on touched modules
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)