### PR TITLE
feat: wire skill cache hash, optional LLM summary, semantic shadow

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -114,6 +114,8 @@ class Settings(BaseSettings):
 
     # P1 Memory：超阈时刷新并持久化 Session Summary（确定性 synthesizer）
     memory_session_summary: bool = True
+    # P1 尾巴：Session Summary 走 LLM（失败回落确定性）；默认关以避免额外费用
+    memory_session_summary_llm: bool = False
 
     # P2 Skills：节点经 catalog/router 选择 Methodology；Policy 仍强制注入
     skills_router_enabled: bool = True
@@ -121,6 +123,9 @@ class Settings(BaseSettings):
     # P4 Exact Cache：仅白名单低熵节点；关则全部 miss
     exact_cache_enabled: bool = True
     exact_cache_ttl_s: int = 86_400
+    # P4.5：Semantic shadow 仅记标定样本，禁止 direct hit
+    semantic_cache_shadow_enabled: bool = False
+    semantic_cache_shadow_ttl_s: int = 604_800
 
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
     # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。

--- a/backend/app/forge/cache/__init__.py
+++ b/backend/app/forge/cache/__init__.py
@@ -14,6 +14,11 @@ from app.forge.cache.routers import (
     list_templates_cached,
     normalize_engine_id_cached,
 )
+from app.forge.cache.semantic import (
+    semantic_cache_lookup,
+    semantic_direct_hit_allowed,
+    semantic_shadow_record,
+)
 
 __all__ = [
     "ALLOWLIST",
@@ -26,4 +31,7 @@ __all__ = [
     "is_cacheable_node",
     "list_templates_cached",
     "normalize_engine_id_cached",
+    "semantic_cache_lookup",
+    "semantic_direct_hit_allowed",
+    "semantic_shadow_record",
 ]

--- a/backend/app/forge/cache/routers.py
+++ b/backend/app/forge/cache/routers.py
@@ -10,7 +10,13 @@ from app.enums import EntryPhase
 from app.forge.cache.exact import exact_cache_get, exact_cache_set
 from app.forge.engine_router import normalize_engine_id
 from app.forge.entry_router import classify_entry_phase
+from app.forge.skills.catalog import catalog_skill_bundle_hash
 from app.forge.templates.loader import get_template, list_templates
+
+
+def _skill_hash() -> str:
+    """Skill 变更后 key 失效（进程内 catalog 缓存；部署重启后生效）。"""
+    return catalog_skill_bundle_hash()
 
 
 async def classify_entry_phase_cached(
@@ -23,7 +29,10 @@ async def classify_entry_phase_cached(
         "requirement": (requirement or "").strip(),
         "has_prior_version": bool(has_prior_version),
     }
-    hit = await exact_cache_get(r, node="entry_router", input_payload=payload)
+    skill_h = _skill_hash()
+    hit = await exact_cache_get(
+        r, node="entry_router", input_payload=payload, skill_bundle_hash=skill_h
+    )
     if isinstance(hit, str):
         try:
             return EntryPhase(hit)
@@ -31,18 +40,36 @@ async def classify_entry_phase_cached(
             pass
     result = classify_entry_phase(requirement, has_prior_version=has_prior_version)
     await exact_cache_set(
-        r, node="entry_router", input_payload=payload, value=result.value
+        r,
+        node="entry_router",
+        input_payload=payload,
+        value=result.value,
+        skill_bundle_hash=skill_h,
+    )
+    from app.forge.cache.semantic import semantic_shadow_record
+
+    await semantic_shadow_record(
+        r, node="entry_router", query=payload, actual_output=result.value
     )
     return result
 
 
 async def normalize_engine_id_cached(r: redis.Redis, value: object) -> str:
     payload = {"value": value if isinstance(value, str) else repr(value)}
-    hit = await exact_cache_get(r, node="engine_router", input_payload=payload)
+    skill_h = _skill_hash()
+    hit = await exact_cache_get(
+        r, node="engine_router", input_payload=payload, skill_bundle_hash=skill_h
+    )
     if isinstance(hit, str) and hit:
         return hit
     result = normalize_engine_id(value)
-    await exact_cache_set(r, node="engine_router", input_payload=payload, value=result)
+    await exact_cache_set(
+        r,
+        node="engine_router",
+        input_payload=payload,
+        value=result,
+        skill_bundle_hash=skill_h,
+    )
     return result
 
 
@@ -56,11 +83,20 @@ async def get_template_cached(
         "template_id": template_id,
         "require_verified": bool(require_verified),
     }
-    hit = await exact_cache_get(r, node="template_selection", input_payload=payload)
+    skill_h = _skill_hash()
+    hit = await exact_cache_get(
+        r, node="template_selection", input_payload=payload, skill_bundle_hash=skill_h
+    )
     if isinstance(hit, dict) and hit.get("template_id"):
         return hit
     result = get_template(template_id, require_verified=require_verified)
-    await exact_cache_set(r, node="template_selection", input_payload=payload, value=result)
+    await exact_cache_set(
+        r,
+        node="template_selection",
+        input_payload=payload,
+        value=result,
+        skill_bundle_hash=skill_h,
+    )
     return result
 
 
@@ -70,9 +106,18 @@ async def list_templates_cached(
     verified_only: bool = False,
 ) -> list[dict[str, Any]]:
     payload = {"verified_only": bool(verified_only), "op": "list"}
-    hit = await exact_cache_get(r, node="template_selection", input_payload=payload)
+    skill_h = _skill_hash()
+    hit = await exact_cache_get(
+        r, node="template_selection", input_payload=payload, skill_bundle_hash=skill_h
+    )
     if isinstance(hit, list):
         return hit
     result = list_templates(verified_only=verified_only)
-    await exact_cache_set(r, node="template_selection", input_payload=payload, value=result)
+    await exact_cache_set(
+        r,
+        node="template_selection",
+        input_payload=payload,
+        value=result,
+        skill_bundle_hash=skill_h,
+    )
     return result

--- a/backend/app/forge/cache/semantic.py
+++ b/backend/app/forge/cache/semantic.py
@@ -1,0 +1,68 @@
+"""P4.5 Semantic Cache：仅 shadow / 标定，禁止未校准 direct hit。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+from app.forge.cache.exact import is_cacheable_node
+
+
+def semantic_direct_hit_allowed() -> bool:
+    """Go/No-Go：未完成 calibration 前永远 False。"""
+    return False
+
+
+async def semantic_cache_lookup(
+    r: redis.Redis,
+    *,
+    node: str,
+    query: Any,
+) -> Any | None:
+    """生产路径查找：在标定完成前一律 miss（禁止 false direct-hit）。"""
+    _ = (r, query)
+    if not is_cacheable_node(node):
+        return None
+    if not semantic_direct_hit_allowed():
+        return None
+    return None
+
+
+async def semantic_shadow_record(
+    r: redis.Redis,
+    *,
+    node: str,
+    query: Any,
+    actual_output: Any,
+    similarity: float | None = None,
+) -> bool:
+    """Shadow：后台记 query/output 指纹与可选相似度，不返回给用户路径。"""
+    if not settings.semantic_cache_shadow_enabled:
+        return False
+    if not is_cacheable_node(node):
+        return False
+    from app.forge.tracing import observe_subsystem
+
+    payload = {
+        "node": node,
+        "query_hash": _hash_payload(query),
+        "output_hash": _hash_payload(actual_output),
+        "similarity": similarity,
+        "ts": int(time.time()),
+    }
+    key = f"forge:semantic:shadow:{node}"
+    with observe_subsystem("cache", "semantic_shadow", metadata={"node": node}):
+        await r.lpush(key, json.dumps(payload, ensure_ascii=False))
+        await r.ltrim(key, 0, 999)
+        await r.expire(key, settings.semantic_cache_shadow_ttl_s)
+    return True
+
+
+def _hash_payload(value: Any) -> str:
+    raw = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -303,14 +303,46 @@ def _wrap_user_input(text: str) -> str:
     )
 
 
+async def _refresh_session_summary(ctx: _Ctx) -> None:
+    """超阈刷新 Session Summary；可选 LLM（失败回落确定性）。"""
+    if not settings.memory_session_summary:
+        return
+    from app.forge.memory.refresh import refresh_session_summary_if_needed
+
+    summarizer = None
+    if settings.memory_session_summary_llm:
+        from app.forge.memory.context_builder import ContextTurn
+        from app.forge.memory.llm_summary import synthesize_summary_via_llm
+        from app.forge.memory.summary import SessionSummary
+
+        async def summarizer(
+            turns: list[ContextTurn], previous: SessionSummary | None
+        ) -> SessionSummary:
+            async def complete(system: str, user_msg: str) -> str:
+                content, _usage, _prov = await llm_client.call_llm(
+                    ctx.s,
+                    ctx.r,
+                    ctx.run.user_id,
+                    ctx.run.llm_config_id,
+                    system,
+                    user_msg,
+                    game_id=ctx.game.id,
+                    run_id=ctx.run.id,
+                )
+                return content
+
+            return await synthesize_summary_via_llm(
+                turns, previous, complete=complete
+            )
+
+    await refresh_session_summary_if_needed(ctx.s, ctx.game, summarizer=summarizer)
+
+
 async def _compose_plan_input(
     ctx: _Ctx, *, current_input: str, design_doc: dict[str, Any] | None = None
 ) -> str:
     """Plan/revise 用户消息：可选写入 Explicit 偏好，并经 ContextBuilder 拼装。"""
-    if settings.memory_session_summary:
-        from app.forge.memory.refresh import refresh_session_summary_if_needed
-
-        await refresh_session_summary_if_needed(ctx.s, ctx.game)
+    await _refresh_session_summary(ctx)
     if settings.memory_preferences:
         from app.forge.memory.preferences import upsert_explicit_from_text
 
@@ -355,10 +387,7 @@ async def _compose_art_input(
     previous_options: dict[str, Any] | None = None,
 ) -> str:
     """Art/revise 用户消息：经 ContextBuilder 注入 summary/preferences。"""
-    if settings.memory_session_summary:
-        from app.forge.memory.refresh import refresh_session_summary_if_needed
-
-        await refresh_session_summary_if_needed(ctx.s, ctx.game)
+    await _refresh_session_summary(ctx)
     if settings.memory_preferences and current_input.strip():
         from app.forge.memory.preferences import upsert_explicit_from_text
 
@@ -404,10 +433,7 @@ async def _compose_art_detail_input(
     selected_option: dict[str, Any],
 ) -> str:
     """Art detail：经 ContextBuilder 注入 Memory；设计稿/选项作任务载荷。"""
-    if settings.memory_session_summary:
-        from app.forge.memory.refresh import refresh_session_summary_if_needed
-
-        await refresh_session_summary_if_needed(ctx.s, ctx.game)
+    await _refresh_session_summary(ctx)
     option_json = json.dumps(selected_option, ensure_ascii=False)
     task = (
         "【已确认游戏策划稿 JSON】\n"

--- a/backend/app/forge/memory/__init__.py
+++ b/backend/app/forge/memory/__init__.py
@@ -8,6 +8,7 @@ from app.forge.memory.context_builder import (
     context_fingerprint,
     estimate_tokens,
 )
+from app.forge.memory.llm_summary import synthesize_summary_via_llm
 from app.forge.memory.summary import (
     SessionSummary,
     coerce_session_summary,
@@ -28,4 +29,5 @@ __all__ = [
     "estimate_tokens",
     "should_refresh_summary",
     "synthesize_summary_from_turns",
+    "synthesize_summary_via_llm",
 ]

--- a/backend/app/forge/memory/llm_summary.py
+++ b/backend/app/forge/memory/llm_summary.py
@@ -1,0 +1,69 @@
+"""可选 LLM Session Summary（P1 尾巴；默认关，失败回落确定性 synthesizer）。"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.forge.memory.context_builder import ContextTurn
+from app.forge.memory.summary import (
+    SessionSummary,
+    coerce_session_summary,
+    empty_session_summary,
+    synthesize_summary_from_turns,
+)
+
+LlmComplete = Callable[[str, str], Awaitable[str]]
+
+_SUMMARY_SYSTEM = """
+你是游戏创作会话摘要器。根据对话轮次输出一个合法 JSON 对象（不要 Markdown），字段仅限：
+current_goal(string), confirmed_decisions(list[string]), rejected_options(list[string]),
+gameplay_constraints(list[string]), visual_constraints(list[string]),
+technical_constraints(list[string]), pending_requests(list[string])。
+只保留对后续生成有用的稳定约定；不要发明未出现的事实。
+""".strip()
+
+
+async def synthesize_summary_via_llm(
+    turns: list[ContextTurn],
+    previous: SessionSummary | None,
+    *,
+    complete: LlmComplete,
+) -> SessionSummary:
+    """调用 LLM 生成 SessionSummary；解析失败则回落确定性 synthesizer。"""
+    user_msg = _build_user_message(turns, previous)
+    try:
+        raw = await complete(_SUMMARY_SYSTEM, user_msg)
+        parsed = _parse_summary_json(raw)
+        coerced = coerce_session_summary(parsed)
+        if coerced is not None:
+            return coerced
+    except Exception:  # noqa: BLE001 摘要增强失败不得阻断 Memory
+        pass
+    return synthesize_summary_from_turns(turns, previous=previous)
+
+
+def _build_user_message(
+    turns: list[ContextTurn], previous: SessionSummary | None
+) -> str:
+    lines = ["【Recent Turns】"]
+    for t in turns[-30:]:
+        lines.append(f"{t.role}: {t.content.strip()[:400]}")
+    if previous:
+        lines.append("【Previous Summary】")
+        lines.append(json.dumps(previous, ensure_ascii=False))
+    lines.append("请输出更新后的 Session Summary JSON。")
+    return "\n".join(lines)
+
+
+def _parse_summary_json(raw: str) -> dict[str, Any]:
+    text = (raw or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        return dict(empty_session_summary())
+    return data

--- a/backend/app/forge/skills/__init__.py
+++ b/backend/app/forge/skills/__init__.py
@@ -4,7 +4,12 @@ P2：Platform Policy（强制）与 Agent Skills / Methodology（可选）分层
 节点通过 ``resolve_skills_for_node`` 做 Progressive Disclosure。
 """
 
-from app.forge.skills.catalog import get_skill_meta, list_skill_metas, skill_bundle_hash
+from app.forge.skills.catalog import (
+    catalog_skill_bundle_hash,
+    get_skill_meta,
+    list_skill_metas,
+    skill_bundle_hash,
+)
 from app.forge.skills.loader import load_skill, load_skill_body, skills_root
 from app.forge.skills.models import LoadedSkill, ResolvedSkills, SkillMeta
 from app.forge.skills.router import resolve_skills_for_node
@@ -13,6 +18,7 @@ __all__ = [
     "LoadedSkill",
     "ResolvedSkills",
     "SkillMeta",
+    "catalog_skill_bundle_hash",
     "get_skill_meta",
     "list_skill_metas",
     "load_skill",

--- a/backend/app/forge/skills/catalog.py
+++ b/backend/app/forge/skills/catalog.py
@@ -124,3 +124,9 @@ def skill_bundle_hash(skill_ids: list[str] | tuple[str, ...]) -> str:
         h.update(body.encode("utf-8"))
         h.update(b"\n")
     return h.hexdigest()
+
+
+@lru_cache(maxsize=1)
+def catalog_skill_bundle_hash() -> str:
+    """全量 catalog hash：任一 Skill 正文变更后进程重启即打穿 Exact Cache。"""
+    return skill_bundle_hash(tuple(m.id for m in list_skill_metas()))

--- a/backend/tests/test_exact_cache.py
+++ b/backend/tests/test_exact_cache.py
@@ -101,18 +101,51 @@ async def test_exact_cache_disabled_skips(
 async def test_classify_entry_phase_cached_hits(
     redis_client: fakeredis.aioredis.FakeRedis,
 ) -> None:
+    from app.forge.skills.catalog import catalog_skill_bundle_hash
+
     first = await classify_entry_phase_cached(
         redis_client, "把背景改成紫色", has_prior_version=True
     )
     assert first == EntryPhase.CODE
     # 第二次应命中缓存；篡改 Redis 后仍返回缓存值可证明走了 cache
     payload = {"requirement": "把背景改成紫色", "has_prior_version": True}
-    key = build_exact_cache_key(node="entry_router", input_payload=payload)
+    key = build_exact_cache_key(
+        node="entry_router",
+        input_payload=payload,
+        skill_bundle_hash=catalog_skill_bundle_hash(),
+    )
     await redis_client.set(key, '"plan"')
     second = await classify_entry_phase_cached(
         redis_client, "把背景改成紫色", has_prior_version=True
     )
     assert second == EntryPhase.PLAN
+
+
+@pytest.mark.asyncio
+async def test_skill_bundle_hash_change_misses_cache(
+    redis_client: fakeredis.aioredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await classify_entry_phase_cached(
+        redis_client, "把背景改成紫色", has_prior_version=True
+    )
+    monkeypatch.setattr(
+        "app.forge.cache.routers.catalog_skill_bundle_hash", lambda: "changed-hash"
+    )
+    # hash 变了应重新计算，不会读到旧 key
+    payload = {"requirement": "把背景改成紫色", "has_prior_version": True}
+    assert (
+        await exact_cache_get(
+            redis_client,
+            node="entry_router",
+            input_payload=payload,
+            skill_bundle_hash="changed-hash",
+        )
+        is None
+    )
+    again = await classify_entry_phase_cached(
+        redis_client, "把背景改成紫色", has_prior_version=True
+    )
+    assert again == EntryPhase.CODE
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_llm_summary_and_semantic.py
+++ b/backend/tests/test_llm_summary_and_semantic.py
@@ -1,0 +1,78 @@
+"""P1 LLM summary 与 P4.5 Semantic shadow。"""
+
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest
+
+from app.core.config import settings
+from app.forge.cache.semantic import (
+    semantic_cache_lookup,
+    semantic_direct_hit_allowed,
+    semantic_shadow_record,
+)
+from app.forge.memory.context_builder import ContextTurn
+from app.forge.memory.llm_summary import synthesize_summary_via_llm
+from app.forge.memory.summary import synthesize_summary_from_turns
+
+
+@pytest.mark.asyncio
+async def test_llm_summary_parses_json() -> None:
+    async def complete(_system: str, _user: str) -> str:
+        return (
+            '{"current_goal":"像素跑酷","confirmed_decisions":["双跳"],'
+            '"rejected_options":[],"gameplay_constraints":[],'
+            '"visual_constraints":["像素"],"technical_constraints":[],'
+            '"pending_requests":[]}'
+        )
+
+    turns = [ContextTurn(role="user", content="做一个像素跑酷")]
+    out = await synthesize_summary_via_llm(turns, None, complete=complete)
+    assert out["current_goal"] == "像素跑酷"
+    assert "双跳" in out["confirmed_decisions"]
+
+
+@pytest.mark.asyncio
+async def test_llm_summary_falls_back_on_bad_json() -> None:
+    async def complete(_system: str, _user: str) -> str:
+        return "not-json"
+
+    turns = [ContextTurn(role="user", content="做一个像素风跑酷")]
+    out = await synthesize_summary_via_llm(turns, None, complete=complete)
+    expected = synthesize_summary_from_turns(turns, previous=None)
+    assert out["current_goal"] == expected["current_goal"]
+
+
+def test_semantic_direct_hit_always_blocked() -> None:
+    assert semantic_direct_hit_allowed() is False
+
+
+@pytest.mark.asyncio
+async def test_semantic_lookup_never_hits() -> None:
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    assert await semantic_cache_lookup(r, node="entry_router", query={"a": 1}) is None
+    assert await semantic_cache_lookup(r, node="code", query={"a": 1}) is None
+
+
+@pytest.mark.asyncio
+async def test_semantic_shadow_records_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(settings, "semantic_cache_shadow_enabled", True)
+    ok = await semantic_shadow_record(
+        r, node="entry_router", query={"q": 1}, actual_output="code", similarity=0.9
+    )
+    assert ok is True
+    rows = await r.lrange("forge:semantic:shadow:entry_router", 0, -1)
+    assert len(rows) == 1
+    assert "query_hash" in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_semantic_shadow_disabled_by_default() -> None:
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    ok = await semantic_shadow_record(
+        r, node="entry_router", query={"q": 1}, actual_output="code"
+    )
+    assert ok is False

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -23,8 +23,9 @@
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt 已接 Methodology
   * **P3** ✅ SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）（PR `#76`）
-  * **P4** ✅ Redis Exact Cache 白名单 MVP（entry/engine/template）；Semantic Cache 未开（PR `#78`）
-  * **P5** ✅ ContextBuilder Enforcement + fingerprint + spans（PR `#79`）；diagnose Memory 信封 / Art skill 接线 / ADR 归档 / 安全与 cache chaos 轻量测
+  * **P4** ✅ Redis Exact Cache 白名单 MVP（entry/engine/template）；`skill_bundle_hash` 已接入；Semantic **shadow 骨架**（禁止 direct hit）
+  * **P5** ✅ ContextBuilder Enforcement + fingerprint + spans（PR `#79`）；diagnose / Art skill / ADR 归档（PR `#80`）
+  * **尾巴** 🚧 LLM Session Summary（flag 默认关）；Inferred 偏好 / LLM 选 Skill / E2B SDK / ADR-02..04 定稿仍未做
 
 ---
 


### PR DESCRIPTION
## Summary
- Pass `catalog_skill_bundle_hash` into Exact Cache keys for entry/engine/template so skill body changes invalidate after deploy.
- Add optional LLM Session Summary (`memory_session_summary_llm`, default off) with deterministic fallback.
- Add P4.5 Semantic Cache **shadow** scaffold; `semantic_direct_hit_allowed()` is hard-false (no uncalibrated direct hit).

## Test plan
- [x] `uv run pytest tests/test_exact_cache.py tests/test_llm_summary_and_semantic.py tests/test_skill_router.py`
- [x] `uv run ruff check` on touched modules
- [ ] CI green

## Still out of scope
- Inferred preferences, LLM skill selection, offline eval
- E2B real SDK / benchmarks / ADR-02..04 decisions

Made with [Cursor](https://cursor.com)