### PR TITLE
feat(memory): inferred preferences + ADR-02/03/04 Proposed drafts

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -109,6 +109,8 @@ class Settings(BaseSettings):
     memory_context_enforcement: bool = True
     # P1 Memory：注入/写入 Explicit Preferences
     memory_preferences: bool = True
+    # P1 尾巴：从单次需求推断弱偏好；默认关；不得覆盖 Explicit
+    memory_preferences_inferred: bool = False
     # P1 Memory：ContextBuilder 总 token 预算（后续用 trace 标定）
     memory_context_budget_tokens: int = 4000
 

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -338,17 +338,26 @@ async def _refresh_session_summary(ctx: _Ctx) -> None:
     await refresh_session_summary_if_needed(ctx.s, ctx.game, summarizer=summarizer)
 
 
+async def _upsert_preferences_from_text(ctx: _Ctx, text: str) -> None:
+    """写入 Explicit；可选写入 Inferred（不覆盖 Explicit）。"""
+    if not text.strip():
+        return
+    if settings.memory_preferences:
+        from app.forge.memory.preferences import upsert_explicit_from_text
+
+        await upsert_explicit_from_text(ctx.s, user_id=ctx.game.owner_id, text=text)
+    if settings.memory_preferences_inferred:
+        from app.forge.memory.preferences import upsert_inferred_from_text
+
+        await upsert_inferred_from_text(ctx.s, user_id=ctx.game.owner_id, text=text)
+
+
 async def _compose_plan_input(
     ctx: _Ctx, *, current_input: str, design_doc: dict[str, Any] | None = None
 ) -> str:
     """Plan/revise 用户消息：可选写入 Explicit 偏好，并经 ContextBuilder 拼装。"""
     await _refresh_session_summary(ctx)
-    if settings.memory_preferences:
-        from app.forge.memory.preferences import upsert_explicit_from_text
-
-        await upsert_explicit_from_text(
-            ctx.s, user_id=ctx.game.owner_id, text=current_input
-        )
+    await _upsert_preferences_from_text(ctx, current_input)
     wrapped = _wrap_user_input(current_input)
     from app.forge.memory.loader import build_node_context, use_context_builder
 
@@ -388,12 +397,7 @@ async def _compose_art_input(
 ) -> str:
     """Art/revise 用户消息：经 ContextBuilder 注入 summary/preferences。"""
     await _refresh_session_summary(ctx)
-    if settings.memory_preferences and current_input.strip():
-        from app.forge.memory.preferences import upsert_explicit_from_text
-
-        await upsert_explicit_from_text(
-            ctx.s, user_id=ctx.game.owner_id, text=current_input
-        )
+    await _upsert_preferences_from_text(ctx, current_input)
     design_block = (
         "【已确认游戏策划稿 JSON】\n" + design_doc_to_text(design_doc)
     )

--- a/backend/app/forge/memory/inferred.py
+++ b/backend/app/forge/memory/inferred.py
@@ -1,0 +1,45 @@
+"""P1 尾巴：Inferred 偏好抽取（弱信号；不得覆盖 Explicit）。"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.forge.memory.explicit import looks_like_explicit_preference
+
+# 无「以后/默认」等显式标记时，仍可从重复风格/难度措辞推断弱偏好
+_INFERRED_HINTS: list[tuple[re.Pattern[str], str, str, dict[str, Any]]] = [
+    (re.compile(r"像素|pixel", re.I), "visual", "style", {"style": "pixel"}),
+    (re.compile(r"卡通", re.I), "visual", "style", {"style": "cartoon"}),
+    (re.compile(r"手绘", re.I), "visual", "style", {"style": "hand_drawn"}),
+    (re.compile(r"简单|休闲|难度低", re.I), "gameplay", "difficulty", {"difficulty": "easy"}),
+    (re.compile(r"硬核|很难|高难度", re.I), "gameplay", "difficulty", {"difficulty": "hard"}),
+    (re.compile(r"静音|不要.*音效|无声", re.I), "audio", "muted", {"muted": True}),
+]
+
+
+def extract_inferred_preferences(text: str) -> list[dict[str, Any]]:
+    """从单次需求推断弱偏好；已含 Explicit 触发词则返回空（交给 explicit 路径）。"""
+    raw = (text or "").strip()
+    if not raw or looks_like_explicit_preference(raw):
+        return []
+    found: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for pattern, category, key, value in _INFERRED_HINTS:
+        if not pattern.search(raw):
+            continue
+        pair = (category, key)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        found.append(
+            {
+                "category": category,
+                "key": key,
+                "value_json": {**value, "evidence": {"kind": "utterance"}},
+                "source": "inferred",
+                "confidence": 0.4,
+                "status": "active",
+            }
+        )
+    return found

--- a/backend/app/forge/memory/preferences.py
+++ b/backend/app/forge/memory/preferences.py
@@ -1,4 +1,4 @@
-"""用户偏好读写（P1 Explicit-only）。"""
+"""用户偏好读写（P1 Explicit；可选 Inferred）。"""
 
 from __future__ import annotations
 
@@ -89,6 +89,39 @@ async def upsert_explicit_from_text(
             value_json=dict(item["value_json"]),
             source=str(item.get("source") or "explicit"),
             confidence=float(item.get("confidence") or 0.8),
+            status=str(item.get("status") or "active"),
+        )
+        written.append(row)
+    return written
+
+
+async def upsert_inferred_from_text(
+    db: AsyncSession, *, user_id: uuid.UUID, text: str
+) -> list[UserPreference]:
+    """写入 Inferred；若同 category/key 已是 Explicit 则跳过，避免降级覆盖。"""
+    from app.forge.memory.inferred import extract_inferred_preferences
+
+    written: list[UserPreference] = []
+    for item in extract_inferred_preferences(text):
+        category = str(item["category"])
+        key = str(item["key"])
+        existing = await db.scalar(
+            select(UserPreference).where(
+                UserPreference.user_id == user_id,
+                UserPreference.category == category,
+                UserPreference.key == key,
+            )
+        )
+        if existing is not None and existing.source == "explicit":
+            continue
+        row = await upsert_preference(
+            db,
+            user_id=user_id,
+            category=category,
+            key=key,
+            value_json=dict(item["value_json"]),
+            source="inferred",
+            confidence=float(item.get("confidence") or 0.4),
             status=str(item.get("status") or "active"),
         )
         written.append(row)

--- a/backend/tests/test_inferred_preferences.py
+++ b/backend/tests/test_inferred_preferences.py
@@ -1,0 +1,77 @@
+"""Inferred 偏好：弱信号抽取且不覆盖 Explicit。"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.forge.memory.inferred import extract_inferred_preferences
+from app.forge.memory.preferences import (
+    upsert_explicit_from_text,
+    upsert_inferred_from_text,
+)
+from app.models.user import User
+from app.models.user_preference import UserPreference
+
+
+def test_inferred_extracts_pixel_without_explicit_marker() -> None:
+    prefs = extract_inferred_preferences("做一个像素风跑酷")
+    assert len(prefs) == 1
+    assert prefs[0]["source"] == "inferred"
+    assert prefs[0]["value_json"]["style"] == "pixel"
+    assert prefs[0]["confidence"] <= 0.5
+
+
+def test_inferred_skips_when_explicit_marker_present() -> None:
+    assert extract_inferred_preferences("以后都用像素风") == []
+
+
+@pytest.mark.asyncio
+async def test_inferred_does_not_overwrite_explicit(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "memory_preferences_inferred", True)
+    user = User(
+        id=uuid4(),
+        email=f"inf-{uuid4().hex[:8]}@example.com",
+        password_hash="x",
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    await upsert_explicit_from_text(db_session, user_id=user.id, text="以后都用像素风")
+    await upsert_inferred_from_text(
+        db_session, user_id=user.id, text="这次改成卡通风格试试"
+    )
+    row = await db_session.scalar(
+        select(UserPreference).where(
+            UserPreference.user_id == user.id,
+            UserPreference.category == "visual",
+            UserPreference.key == "style",
+        )
+    )
+    assert row is not None
+    assert row.source == "explicit"
+    assert row.value_json.get("style") == "pixel"
+
+
+@pytest.mark.asyncio
+async def test_inferred_writes_when_empty(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "memory_preferences_inferred", True)
+    user = User(
+        id=uuid4(),
+        email=f"inf2-{uuid4().hex[:8]}@example.com",
+        password_hash="x",
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    written = await upsert_inferred_from_text(
+        db_session, user_id=user.id, text="做一个硬核平台跳跃"
+    )
+    assert written
+    assert written[0].source == "inferred"
+    assert written[0].value_json.get("difficulty") == "hard"

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -13,19 +13,19 @@
 * ADR 状态:
   * **ADR-01** Degraded Artifact Publishing — **Accepted**（见 `docs/adr/`）
   * **ADR-05** Recoverable Pause Representation — **Accepted**（见 `docs/adr/`）
-  * **ADR-02** Preference Retention — Pending（阻塞 P1 Preference 写入策略细项；MVP 已按「Explicit 保留」落地）
-  * **ADR-03** Sandbox Provider Strategy — **Pending**（国内源码/数据出境不默认允许；P3 仅 PoC）
-  * **ADR-04** Conversation Storage Migration — Pending（阻塞 P1 message SoT 选型；MVP 继续以 `forge_messages` 为唯一 SoT，不平行建表）
+  * **ADR-02** Preference Retention — **Proposed**（Explicit 保留；Inferred 不覆盖 Explicit；删 Game 不自动清 Inferred）
+  * **ADR-03** Sandbox Provider Strategy — **Proposed**（生产默认 Docker；E2B 仅 PoC）
+  * **ADR-04** Conversation Storage Migration — **Proposed**（`forge_messages` 唯一 SoT）
 * Implementation decisions（非 ADR）:
   * Context Builder：**P1 MVP 建立规范路径；P5 Enforcement 拆除遗留拼装**
 * 落地进度（相对本仓库）:
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
-  * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）
+  * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt 已接 Methodology
   * **P3** ✅ SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）（PR `#76`）
-  * **P4** ✅ Redis Exact Cache 白名单 MVP（entry/engine/template）；`skill_bundle_hash` 已接入；Semantic **shadow 骨架**（禁止 direct hit）
-  * **P5** ✅ ContextBuilder Enforcement + fingerprint + spans（PR `#79`）；diagnose / Art skill / ADR 归档（PR `#80`）
-  * **尾巴** 🚧 LLM Session Summary（flag 默认关）；Inferred 偏好 / LLM 选 Skill / E2B SDK / ADR-02..04 定稿仍未做
+  * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
+  * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）
+  * **仍 gated** LLM 自选 Skill / 离线 eval / E2B 真 SDK+benchmark / HITL destroy+restore / ADR Accept 签字
 
 ---
 

--- a/docs/adr/ADR-02-preference-retention.md
+++ b/docs/adr/ADR-02-preference-retention.md
@@ -1,17 +1,29 @@
 # ADR-02: Preference Retention
 
-* Status: **Pending**
-* Date: 2026-08-15
+* Status: **Proposed**（待 Accept；代码已按本草案 interim 行为落地）
+* Date: 2026-08-16
 * Related: P1 Memory Preferences
 
 ## Context
 
 When a Game is deleted, Explicit vs Inferred preferences need different retention rules.
 
-## Current interim
+## Proposed Decision
 
-MVP retains **Explicit** user preferences. Inferred preferences are not written yet.
+1. **Explicit** preferences are **user-scoped** and **retained** when any Game is deleted.
+2. **Inferred** preferences are user-scoped weak signals (`source=inferred`, lower confidence).
+   * They **must not overwrite** an existing Explicit row for the same `(category, key)`.
+   * Without a dedicated `evidence_game_id` column (not in MVP schema), deleting a Game
+     does **not** auto-purge Inferred rows; use “clear my preferences” for full wipe.
+3. **Clear my preferences** (`DELETE /me/preferences`) removes **all** rows for the user
+   (Explicit + Inferred).
 
-## Blocking
+## Current implementation
 
-Final delete / “clear my preferences” semantics until this ADR is accepted.
+* Explicit extract + API clear: shipped (P1).
+* Inferred extract gated by `memory_preferences_inferred` (default **false**).
+
+## Acceptance criteria to mark Accepted
+
+* Product/legal sign-off on retention copy shown to users.
+* Optional follow-up: add `evidence_game_id` / evidence list if Game-scoped purge is required.

--- a/docs/adr/ADR-03-sandbox-provider-strategy.md
+++ b/docs/adr/ADR-03-sandbox-provider-strategy.md
@@ -1,18 +1,28 @@
 # ADR-03: Sandbox Provider Strategy
 
-* Status: **Pending**
-* Date: 2026-08-15
+* Status: **Proposed**（生产默认仍为 Docker；E2B 仅 PoC）
+* Date: 2026-08-16
 * Related: P3 Sandbox
 
 ## Context
 
-E2B vs Docker for production isolation, including domestic data-egress / compliance.
+Choose production sandbox provider: Docker vs E2B (or hybrid), with domestic data-egress constraints.
 
-## Current interim
+## Proposed Decision
 
-* Production default: DockerSandbox (or LocalSandbox for dev)
-* E2B: PoC only, gated by `sandbox_e2b_enabled=false`
+1. **Production default: `DockerSandbox`** (`sandbox_backend=docker`).
+2. **E2B remains PoC-only** until Go criteria below are met; `sandbox_e2b_enabled` stays
+   default **false**. Adapter may exist, but enabling it is not a production approval.
+3. LocalSandbox remains the default for developer machines (`sandbox_backend=local`).
+4. Hybrid (Docker domestic + E2B overseas) requires a **new** ADR amendment, not silent flag flips.
 
-## Go condition (non-exhaustive)
+## Go criteria for E2B production (all required)
 
-Data-flow confirmation, egress policy, DPA/compliance, domestic network benchmarks.
+* Data-flow diagram reviewed (source/prompt/assets egress paths).
+* Contract/DPA + retention policy acceptable.
+* Domestic network latency/cost benchmark vs Docker recorded.
+* Security review of UGC execution surface.
+
+## No-Go default
+
+Until Accepted with Go criteria checked: **do not** set E2B as production `sandbox_backend`.

--- a/docs/adr/ADR-04-conversation-storage-migration.md
+++ b/docs/adr/ADR-04-conversation-storage-migration.md
@@ -1,17 +1,22 @@
 # ADR-04: Conversation Storage Migration
 
-* Status: **Pending**
-* Date: 2026-08-15
+* Status: **Proposed**（继续以 `forge_messages` 为唯一 SoT）
+* Date: 2026-08-16
 * Related: P1 Session Memory
 
 ## Context
 
-Whether `forge_messages` remains the sole source of truth or migrates to another store.
+Whether conversation history needs a parallel store (e.g. vector DB) or a schema migration away from `forge_messages`.
 
-## Current interim
+## Proposed Decision
 
-**`forge_messages` is the only SoT.** No parallel conversation table.
+1. **`forge_messages` remains the sole source of truth** for session turns.
+2. Context injection stays via **ContextBuilder** (summary + recent turns + preferences + artifacts).
+3. **No parallel conversation table** and **no vector retrieval in production** until a follow-up ADR
+   with retention, isolation (per-game/per-user), and cost model is Accepted.
+4. Session Summary (`games.session_summary_json`) is a **derived cache**, not a second SoT.
 
-## Blocking
+## Consequences
 
-Vector retrieval / alternate SoT until this ADR is accepted.
+* Offline / RAG experiments must stay behind flags and must not dual-write user history.
+* Migrations that replace `forge_messages` require explicit cutover plan + backfill.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,12 +1,12 @@
 # ADR Index
 
-Accepted and pending Architecture Decision Records for Forge Runtime evolution.
+Accepted, proposed, and pending Architecture Decision Records for Forge Runtime evolution.
 Full narrative lives in [2026-08-15-forge-runtime-evolution-plan.md](../2026-08-15-forge-runtime-evolution-plan.md).
 
 | ADR | Title | Status |
 | --- | --- | --- |
 | [ADR-01](./ADR-01-degraded-artifact-publishing.md) | Degraded Artifact Publishing | **Accepted** |
-| [ADR-02](./ADR-02-preference-retention.md) | Preference Retention | Pending |
-| [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | Pending |
-| [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | Pending |
+| [ADR-02](./ADR-02-preference-retention.md) | Preference Retention | **Proposed** |
+| [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Proposed** |
+| [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Proposed** |
 | [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** |


### PR DESCRIPTION
## Summary
- Add Inferred preference extraction (`source=inferred`, low confidence) gated by `memory_preferences_inferred` (default **false**).
- Never overwrite an existing Explicit preference for the same `(category, key)`.
- Promote ADR-02/03/04 from Pending stubs to **Proposed** decisions (Docker production default, `forge_messages` sole SoT, preference retention rules).

## Test plan
- [x] `uv run pytest tests/test_inferred_preferences.py tests/test_explicit_preferences.py`
- [x] `uv run ruff check` on touched modules
- [ ] CI green

## Note
ADRs remain **Proposed** until product/legal Accept — not auto-Accepted by this PR.

Made with [Cursor](https://cursor.com)