### PR TITLE
feat(skills): optional LLM methodology selection + offline precision smoke

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -121,6 +121,8 @@ class Settings(BaseSettings):
 
     # P2 Skills：节点经 catalog/router 选择 Methodology；Policy 仍强制注入
     skills_router_enabled: bool = True
+    # P2 尾巴：Methodology 可由 LLM 自选（失败回落确定性）；Policy 永不交给 LLM
+    skills_llm_selection: bool = False
 
     # P4 Exact Cache：仅白名单低熵节点；关则全部 miss
     exact_cache_enabled: bool = True

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -25,10 +25,10 @@ from app.forge.design_doc import coerce_design_doc, design_doc_to_text
 from app.forge.engine_router import engine_scaffold
 from app.forge.events import publish_event
 from app.forge.prompts import (
-    build_code_prompt,
+    build_code_prompt_async,
     build_project_prompt,
     build_project_repair_prompt,
-    build_repair_prompt,
+    build_repair_prompt_async,
 )
 from app.forge.qa.diagnose import diagnose_playtest_failure
 from app.forge.reliability.artifact_gate import derive_artifact_gate
@@ -236,7 +236,12 @@ async def execute_code_or_repair(
                 repair_parts.append(f"【QA 根因分析】\n{qa_diagnosis}")
             repair_parts.append(f"【当前完整 index.html】\n{masked_html}")
             user_msg = "\n\n".join(repair_parts)
-            system_prompt = build_repair_prompt(design_doc["engine"]["id"])
+            system_prompt = await build_repair_prompt_async(
+                design_doc["engine"]["id"],
+                complete=lambda s, u: streamed_llm(
+                    ctx, s, u, "code", emit_delta=False
+                ),
+            )
             raw_output = await streamed_llm(
                 ctx, system_prompt, user_msg, "code", emit_delta=False
             )
@@ -250,7 +255,12 @@ async def execute_code_or_repair(
                     list(design_routing.dependencies),
                 )
             else:
-                system_prompt = build_code_prompt(engine_id)
+                system_prompt = await build_code_prompt_async(
+                    engine_id,
+                    complete=lambda s, u: streamed_llm(
+                        ctx, s, u, "code", emit_delta=False
+                    ),
+                )
             raw_output = await streamed_llm(
                 ctx, system_prompt, user_msg, "code", emit_delta=False
             )

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -41,9 +41,9 @@ from app.forge.phase_labels import phase_start_payload
 from app.forge.prompts import (
     PLAN_PROMPT,
     PLAN_REVISE_PROMPT,
-    build_art_detail_prompt,
-    build_art_options_prompt,
-    build_art_options_revise_prompt,
+    build_art_detail_prompt_async,
+    build_art_options_prompt_async,
+    build_art_options_revise_prompt_async,
 )
 from app.forge.reliability import (
     FatalError,
@@ -937,9 +937,10 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "requirement": ctx.game.requirement or "",
                     "goal": (design_doc.get("title") or ctx.game.title or ""),
                 }
-                art_options = await generate_art_options(
-                    build_art_options_prompt(art_hints), user_msg
+                system_prompt = await build_art_options_prompt_async(
+                    art_hints, complete=lambda s, u: _llm(ctx, s, u)
                 )
+                art_options = await generate_art_options(system_prompt, user_msg)
             except ContentAttacked:
                 raise
             except Exception as exc:  # noqa: BLE001 重试耗尽必须降级而非终止 run
@@ -985,9 +986,10 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "requirement": ctx.game.requirement or "",
                     "goal": (design_doc.get("title") or ctx.game.title or ""),
                 }
-                art_options = await generate_art_options(
-                    build_art_options_revise_prompt(art_hints), user_msg
+                system_prompt = await build_art_options_revise_prompt_async(
+                    art_hints, complete=lambda s, u: _llm(ctx, s, u)
                 )
+                art_options = await generate_art_options(system_prompt, user_msg)
             except ContentAttacked:
                 raise
             except Exception as exc:  # noqa: BLE001 重试耗尽必须降级而非终止 run
@@ -1047,16 +1049,16 @@ def _build_graph(ctx: _Ctx) -> Any:
                         design_doc=design_doc,
                         selected_option=selected_option,
                     )
+                    system_prompt = await build_art_detail_prompt_async(
+                        {
+                            "style": json.dumps(selected_option, ensure_ascii=False),
+                            "goal": (design_doc.get("title") or ctx.game.title or ""),
+                        },
+                        complete=lambda s, u: _llm(ctx, s, u),
+                    )
                     raw = await _streamed_llm_or_fallback(
                         ctx,
-                        build_art_detail_prompt(
-                            {
-                                "style": json.dumps(
-                                    selected_option, ensure_ascii=False
-                                ),
-                                "goal": (design_doc.get("title") or ctx.game.title or ""),
-                            }
-                        ),
+                        system_prompt,
                         user_msg,
                         "art",
                         emit_delta=False,

--- a/backend/app/forge/prompts.py
+++ b/backend/app/forge/prompts.py
@@ -329,9 +329,36 @@ def _art_skill_appendix(hints: dict[str, Any] | None = None) -> str:
     return "\n\n".join(p for p in parts if p)
 
 
+async def _art_skill_appendix_async(
+    hints: dict[str, Any] | None = None,
+    *,
+    complete: Any | None = None,
+) -> str:
+    if not settings.skills_router_enabled:
+        return ""
+    from app.forge.skills import resolve_skills_for_node_async
+
+    resolved = await resolve_skills_for_node_async(
+        "art", hints=hints or {}, complete=complete
+    )
+    parts = [resolved.policy_text(), resolved.methodology_text()]
+    return "\n\n".join(p for p in parts if p)
+
+
 def build_art_options_prompt(hints: dict[str, Any] | None = None) -> str:
     """P2/P5：Art options system prompt + Methodology Skill。"""
     appendix = _art_skill_appendix(hints)
+    if not appendix:
+        return ART_OPTIONS_PROMPT
+    return f"{ART_OPTIONS_PROMPT}\n\n{appendix}"
+
+
+async def build_art_options_prompt_async(
+    hints: dict[str, Any] | None = None,
+    *,
+    complete: Any | None = None,
+) -> str:
+    appendix = await _art_skill_appendix_async(hints, complete=complete)
     if not appendix:
         return ART_OPTIONS_PROMPT
     return f"{ART_OPTIONS_PROMPT}\n\n{appendix}"
@@ -344,6 +371,17 @@ def build_art_options_revise_prompt(hints: dict[str, Any] | None = None) -> str:
     return f"{ART_OPTIONS_REVISE_PROMPT}\n\n{appendix}"
 
 
+async def build_art_options_revise_prompt_async(
+    hints: dict[str, Any] | None = None,
+    *,
+    complete: Any | None = None,
+) -> str:
+    appendix = await _art_skill_appendix_async(hints, complete=complete)
+    if not appendix:
+        return ART_OPTIONS_REVISE_PROMPT
+    return f"{ART_OPTIONS_REVISE_PROMPT}\n\n{appendix}"
+
+
 def build_art_detail_prompt(hints: dict[str, Any] | None = None) -> str:
     appendix = _art_skill_appendix(hints)
     if not appendix:
@@ -351,13 +389,25 @@ def build_art_detail_prompt(hints: dict[str, Any] | None = None) -> str:
     return f"{ART_DETAIL_PROMPT}\n\n{appendix}"
 
 
-def build_qa_prompt(*, failure_kind: str = "product") -> str:
+async def build_art_detail_prompt_async(
+    hints: dict[str, Any] | None = None,
+    *,
+    complete: Any | None = None,
+) -> str:
+    appendix = await _art_skill_appendix_async(hints, complete=complete)
+    if not appendix:
+        return ART_DETAIL_PROMPT
+    return f"{ART_DETAIL_PROMPT}\n\n{appendix}"
+
+
+def build_qa_prompt(
+    *, failure_kind: str = "product", hints: dict[str, Any] | None = None
+) -> str:
     """Diagnose system prompt；可选注入 repair/playtest Methodology。"""
     if not settings.skills_router_enabled:
         return QA_PROMPT
-    resolved = resolve_skills_for_node(
-        "diagnose", hints={"failure_kind": failure_kind}
-    )
+    merged = {"failure_kind": failure_kind, **(hints or {})}
+    resolved = resolve_skills_for_node("diagnose", hints=merged)
     appendix = "\n\n".join(
         p for p in (resolved.policy_text(), resolved.methodology_text()) if p
     )
@@ -366,14 +416,16 @@ def build_qa_prompt(*, failure_kind: str = "product") -> str:
     return f"{QA_PROMPT}\n\n{appendix}"
 
 
-def build_code_prompt(engine_id: str) -> str:
+def build_code_prompt(
+    engine_id: str, hints: dict[str, Any] | None = None
+) -> str:
     """按选定引擎拼装代码生成 system prompt：通用骨架 + 引擎方法论 + 钉死 CDN。
 
     不同引擎的专属写法（Scene 结构 / Ticker / 裸 RAF）从独立方法论 md 注入，
     避免把多种引擎细节挤进单个提示词。非法 engine_id 在 router 内回退 canvas。
     """
     if settings.skills_router_enabled:
-        return _build_code_prompt_routed(engine_id)
+        return _build_code_prompt_routed(engine_id, hints=hints)
     methodology = engine_methodology(engine_id)
     return "\n\n".join(
         part
@@ -394,10 +446,55 @@ def build_code_prompt(engine_id: str) -> str:
     )
 
 
-def _build_code_prompt_routed(engine_id: str) -> str:
+async def build_code_prompt_async(
+    engine_id: str,
+    hints: dict[str, Any] | None = None,
+    *,
+    complete: Any | None = None,
+) -> str:
+    merged = {"engine_id": normalize_engine_id(engine_id), **(hints or {})}
+    if settings.skills_router_enabled and (
+        settings.skills_llm_selection or merged.get("methodology_ids")
+    ):
+        from app.forge.skills import resolve_skills_for_node_async
+
+        resolved = await resolve_skills_for_node_async(
+            "code", hints=merged, complete=complete
+        )
+        merged["methodology_ids"] = [s.id for s in resolved.methodology]
+    return build_code_prompt(engine_id, hints=merged)
+
+
+async def build_repair_prompt_async(
+    engine_id: str,
+    hints: dict[str, Any] | None = None,
+    *,
+    complete: Any | None = None,
+) -> str:
+    merged = {
+        "engine_id": normalize_engine_id(engine_id),
+        "failure_kind": "product",
+        **(hints or {}),
+    }
+    if settings.skills_router_enabled and (
+        settings.skills_llm_selection or merged.get("methodology_ids")
+    ):
+        from app.forge.skills import resolve_skills_for_node_async
+
+        resolved = await resolve_skills_for_node_async(
+            "repair", hints=merged, complete=complete
+        )
+        merged["methodology_ids"] = [s.id for s in resolved.methodology]
+    return build_repair_prompt(engine_id, hints=merged)
+
+
+def _build_code_prompt_routed(
+    engine_id: str, hints: dict[str, Any] | None = None
+) -> str:
     """P2：Policy 强制注入 + 仅加载所选引擎 Methodology（不全量 skill 正文）。"""
     eid = normalize_engine_id(engine_id)
-    resolved = resolve_skills_for_node("code", hints={"engine_id": eid})
+    merged = {"engine_id": eid, **(hints or {})}
+    resolved = resolve_skills_for_node("code", hints=merged)
     policy = resolved.policy_text()
     methodology = resolved.methodology_text()
     return "\n\n".join(
@@ -420,13 +517,15 @@ def _build_code_prompt_routed(engine_id: str) -> str:
     )
 
 
-def build_repair_prompt(engine_id: str) -> str:
+def build_repair_prompt(
+    engine_id: str, hints: dict[str, Any] | None = None
+) -> str:
     """修复工程师 prompt：在当前实现基础上修根因，保持原引擎选型不变。
 
     与 build_code_prompt 共享通用骨架与引擎方法论，额外约束「不切换引擎」防回归。
     """
     if settings.skills_router_enabled:
-        return _build_repair_prompt_routed(engine_id)
+        return _build_repair_prompt_routed(engine_id, hints=hints)
     methodology = engine_methodology(engine_id)
     repair_specific = (
         "修复规则：\n"
@@ -464,11 +563,12 @@ def build_repair_prompt(engine_id: str) -> str:
     )
 
 
-def _build_repair_prompt_routed(engine_id: str) -> str:
+def _build_repair_prompt_routed(
+    engine_id: str, hints: dict[str, Any] | None = None
+) -> str:
     eid = normalize_engine_id(engine_id)
-    resolved = resolve_skills_for_node(
-        "repair", hints={"engine_id": eid, "failure_kind": "product"}
-    )
+    merged = {"engine_id": eid, "failure_kind": "product", **(hints or {})}
+    resolved = resolve_skills_for_node("repair", hints=merged)
     repair_specific = (
         "修复规则：\n"
         "1. 优先做范围清晰的根因修复，保留当前已经正常工作的玩法、视觉、关卡和交互。\n"
@@ -643,11 +743,16 @@ __all__ = [
     "ART_DETAIL_PROMPT",
     "QA_PROMPT",
     "build_art_detail_prompt",
+    "build_art_detail_prompt_async",
     "build_art_options_prompt",
+    "build_art_options_prompt_async",
     "build_art_options_revise_prompt",
+    "build_art_options_revise_prompt_async",
     "build_code_prompt",
+    "build_code_prompt_async",
     "build_project_prompt",
     "build_project_repair_prompt",
     "build_qa_prompt",
     "build_repair_prompt",
+    "build_repair_prompt_async",
 ]

--- a/backend/app/forge/skills/__init__.py
+++ b/backend/app/forge/skills/__init__.py
@@ -12,7 +12,7 @@ from app.forge.skills.catalog import (
 )
 from app.forge.skills.loader import load_skill, load_skill_body, skills_root
 from app.forge.skills.models import LoadedSkill, ResolvedSkills, SkillMeta
-from app.forge.skills.router import resolve_skills_for_node
+from app.forge.skills.router import resolve_skills_for_node, resolve_skills_for_node_async
 
 __all__ = [
     "LoadedSkill",
@@ -24,6 +24,7 @@ __all__ = [
     "load_skill",
     "load_skill_body",
     "resolve_skills_for_node",
+    "resolve_skills_for_node_async",
     "skill_bundle_hash",
     "skills_root",
 ]

--- a/backend/app/forge/skills/llm_select.py
+++ b/backend/app/forge/skills/llm_select.py
@@ -1,0 +1,71 @@
+"""可选 LLM 自选 Methodology Skill（Policy 永不由 LLM 选择）。"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.forge.skills.models import SkillMeta
+
+LlmComplete = Callable[[str, str], Awaitable[str]]
+
+_SELECT_SYSTEM = """
+你是 Skill 路由器。只能从给定候选 Methodology 中选择，输出合法 JSON：
+{"skill_ids":["id1","id2"]}
+规则：最多选 3 个；禁止选择 policy/*；禁止编造未列出的 id；若不确定选最相关的 1–2 个。
+""".strip()
+
+
+async def select_methodology_ids_via_llm(
+    *,
+    node: str,
+    candidates: list[SkillMeta],
+    hints: dict[str, Any],
+    complete: LlmComplete,
+    max_skills: int = 3,
+) -> list[str] | None:
+    """返回 LLM 选择的 methodology id 列表；失败返回 None（调用方回落确定性路由）。"""
+    if not candidates:
+        return []
+    catalog = [
+        {"id": m.id, "name": m.name, "description": m.description}
+        for m in candidates
+        if m.kind == "methodology"
+    ]
+    allow = {c["id"] for c in catalog}
+    user = (
+        f"node={node}\n"
+        f"hints={json.dumps(hints, ensure_ascii=False, default=str)[:1200]}\n"
+        f"candidates={json.dumps(catalog, ensure_ascii=False)}\n"
+        "请输出 skill_ids JSON。"
+    )
+    try:
+        raw = await complete(_SELECT_SYSTEM, user)
+        ids = _parse_skill_ids(raw)
+    except Exception:  # noqa: BLE001 选路失败必须可回落
+        return None
+    filtered = [i for i in ids if i in allow][:max_skills]
+    return filtered
+
+
+def _parse_skill_ids(raw: str) -> list[str]:
+    text = (raw or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    data = json.loads(text)
+    if isinstance(data, dict):
+        ids = data.get("skill_ids") or data.get("skills") or []
+    elif isinstance(data, list):
+        ids = data
+    else:
+        return []
+    out: list[str] = []
+    for item in ids:
+        if isinstance(item, str) and item.strip():
+            out.append(item.strip())
+        elif isinstance(item, dict) and item.get("id"):
+            out.append(str(item["id"]).strip())
+    return out

--- a/backend/app/forge/skills/router.py
+++ b/backend/app/forge/skills/router.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
+from app.core.config import settings
 from app.forge.skills.catalog import list_skill_metas
 from app.forge.skills.loader import load_skill_body
 from app.forge.skills.models import LoadedSkill, ResolvedSkills, SkillMeta
+
+LlmComplete = Callable[[str, str], Awaitable[str]]
 
 
 def resolve_skills_for_node(
@@ -17,29 +21,73 @@ def resolve_skills_for_node(
     """discover(metadata) → choose → load(bodies)。
 
     Art 节点不会看到 billing/sandbox admin 等未登记 Skill（catalog 白名单即边界）。
+    hints.methodology_ids 若提供：仅在候选白名单内覆盖 Methodology 选择（Policy 仍强制）。
     """
     from app.forge.tracing import observe_subsystem
 
     hints = hints or {}
     with observe_subsystem("skill", "resolve", metadata={"node": node}):
-        metas = list_skill_metas()
-        node_key = _normalize_node(node)
+        return _resolve(node, hints)
 
-        policy_metas = [
-            m for m in metas if m.kind == "policy" and _node_allowed(m, node_key)
-        ]
-        candidates = [
-            m for m in metas if m.kind == "methodology" and _node_allowed(m, node_key)
-        ]
-        chosen = _choose_methodology(node_key, candidates, hints)
 
-        policy = tuple(_load(m) for m in policy_metas)
-        methodology = tuple(_load(m) for m in chosen)
-        return ResolvedSkills(
-            policy=policy,
-            methodology=methodology,
-            loaded_body_count=len(policy) + len(methodology),
-        )
+async def resolve_skills_for_node_async(
+    node: str,
+    *,
+    hints: dict[str, Any] | None = None,
+    complete: LlmComplete | None = None,
+) -> ResolvedSkills:
+    """可选 LLM 自选 Methodology；失败或关 flag 时回落确定性路由。Policy 始终强制。"""
+    from app.forge.tracing import observe_subsystem
+
+    hints = dict(hints or {})
+    with observe_subsystem(
+        "skill",
+        "resolve_async",
+        metadata={"node": node, "llm": bool(settings.skills_llm_selection and complete)},
+    ):
+        if (
+            settings.skills_llm_selection
+            and complete is not None
+            and "methodology_ids" not in hints
+        ):
+            node_key = _normalize_node(node)
+            candidates = [
+                m
+                for m in list_skill_metas()
+                if m.kind == "methodology" and _node_allowed(m, node_key)
+            ]
+            from app.forge.skills.llm_select import select_methodology_ids_via_llm
+
+            selected = await select_methodology_ids_via_llm(
+                node=node_key,
+                candidates=candidates,
+                hints=hints,
+                complete=complete,
+            )
+            if selected is not None:
+                hints["methodology_ids"] = selected
+        return _resolve(node, hints)
+
+
+def _resolve(node: str, hints: dict[str, Any]) -> ResolvedSkills:
+    metas = list_skill_metas()
+    node_key = _normalize_node(node)
+
+    policy_metas = [
+        m for m in metas if m.kind == "policy" and _node_allowed(m, node_key)
+    ]
+    candidates = [
+        m for m in metas if m.kind == "methodology" and _node_allowed(m, node_key)
+    ]
+    chosen = _choose_methodology(node_key, candidates, hints)
+
+    policy = tuple(_load(m) for m in policy_metas)
+    methodology = tuple(_load(m) for m in chosen)
+    return ResolvedSkills(
+        policy=policy,
+        methodology=methodology,
+        loaded_body_count=len(policy) + len(methodology),
+    )
 
 
 def _normalize_node(node: str) -> str:
@@ -66,11 +114,16 @@ def _choose_methodology(
 ) -> list[SkillMeta]:
     if not candidates:
         return []
+    override = hints.get("methodology_ids")
+    if isinstance(override, (list, tuple)) and override:
+        by_id = {m.id: m for m in candidates}
+        picked = [by_id[i] for i in override if isinstance(i, str) and i in by_id]
+        if picked:
+            return picked[:3]
     if node in {"art"}:
         return _choose_art(candidates, hints)
     if node in {"code", "repair", "qa", "diagnose"}:
         return _choose_code_or_repair(node, candidates, hints)
-    # plan 等：默认不塞 methodology，只保留 policy（若有）
     return []
 
 
@@ -88,7 +141,6 @@ def _choose_art(candidates: list[SkillMeta], hints: dict[str, Any]) -> list[Skil
     if "art/visual-composition" in by_id and len(picked) < 2:
         picked.append(by_id["art/visual-composition"])
     if not picked:
-        # 默认轻量组合，避免全量注入
         for skill_id in ("art/visual-composition", "art/hud-design"):
             if skill_id in by_id:
                 picked.append(by_id[skill_id])

--- a/backend/tests/test_llm_skill_selection.py
+++ b/backend/tests/test_llm_skill_selection.py
@@ -1,0 +1,93 @@
+"""P2：LLM Skill 自选与离线 selection precision 轻量 eval。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.forge.skills.llm_select import select_methodology_ids_via_llm
+from app.forge.skills.router import resolve_skills_for_node, resolve_skills_for_node_async
+
+
+def test_methodology_ids_hint_overrides_deterministic() -> None:
+    resolved = resolve_skills_for_node(
+        "art",
+        hints={"methodology_ids": ["art/pixel-art"], "style": "hud"},
+    )
+    ids = [s.id for s in resolved.methodology]
+    assert ids == ["art/pixel-art"]
+    assert any(s.id.startswith("policy/") for s in resolved.policy)
+
+
+def test_methodology_ids_cannot_inject_policy_or_unknown() -> None:
+    resolved = resolve_skills_for_node(
+        "art",
+        hints={"methodology_ids": ["policy/playtest", "billing/usage", "art/hud-design"]},
+    )
+    ids = [s.id for s in resolved.methodology]
+    assert "policy/playtest" not in ids
+    assert "billing/usage" not in ids
+    assert ids == ["art/hud-design"]
+
+
+@pytest.mark.asyncio
+async def test_llm_select_parses_and_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "skills_llm_selection", True)
+
+    async def complete(_system: str, _user: str) -> str:
+        return '{"skill_ids":["art/pixel-art","policy/playtest","nope"]}'
+
+    resolved = await resolve_skills_for_node_async(
+        "art", hints={"style": "像素"}, complete=complete
+    )
+    ids = [s.id for s in resolved.methodology]
+    assert ids == ["art/pixel-art"]
+    assert all(not s.id.startswith("policy/") for s in resolved.methodology)
+    assert any(s.id.startswith("policy/") for s in resolved.policy)
+
+
+@pytest.mark.asyncio
+async def test_llm_select_falls_back_on_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "skills_llm_selection", True)
+
+    async def complete(_system: str, _user: str) -> str:
+        return "not-json"
+
+    resolved = await resolve_skills_for_node_async(
+        "art", hints={"style": "像素 HUD"}, complete=complete
+    )
+    # 回落确定性：像素 → pixel-art
+    ids = [s.id for s in resolved.methodology]
+    assert "art/pixel-art" in ids
+
+
+def test_offline_eval_deterministic_precision_on_fixtures() -> None:
+    """轻量 offline eval：确定性路由在固定 fixtures 上的 precision@1。"""
+    fixtures = [
+        ("art", {"style": "像素风"}, "art/pixel-art"),
+        ("code", {"engine_id": "phaser3"}, "code/phaser3"),
+        ("repair", {"engine_id": "canvas", "failure_kind": "product"}, "repair/runtime-error"),
+    ]
+    hits = 0
+    for node, hints, expected in fixtures:
+        resolved = resolve_skills_for_node(node, hints=hints)
+        top = resolved.methodology[0].id if resolved.methodology else ""
+        if top == expected or expected in {s.id for s in resolved.methodology}:
+            hits += 1
+    precision = hits / len(fixtures)
+    assert precision >= 1.0
+
+
+@pytest.mark.asyncio
+async def test_select_methodology_ids_via_llm_unit() -> None:
+    from app.forge.skills.catalog import list_skill_metas
+
+    cands = [m for m in list_skill_metas() if m.kind == "methodology" and "art" in m.nodes]
+
+    async def complete(_s: str, _u: str) -> str:
+        return '{"skill_ids":["art/visual-composition"]}'
+
+    ids = await select_methodology_ids_via_llm(
+        node="art", candidates=cands, hints={}, complete=complete
+    )
+    assert ids == ["art/visual-composition"]

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -21,11 +21,11 @@
 * 落地进度（相对本仓库）:
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
-  * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt 已接 Methodology
+  * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）
   * **P3** ✅ SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）（PR `#76`）
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）
-  * **仍 gated** LLM 自选 Skill / 离线 eval / E2B 真 SDK+benchmark / HITL destroy+restore / ADR Accept 签字
+  * **仍 gated** 离线 eval 完整套件 / E2B 真 SDK+benchmark / HITL destroy+restore / ADR Accept 签字 / Flag 彻底删遗留 concat
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `skills_llm_selection` (default **false**): LLM may pick Methodology ids from catalog candidates only.
- **Policy skills are never LLM-selected**; invalid/unknown ids are filtered; failures fall back to deterministic router.
- Wire async art/code/repair prompt builders; add light offline precision@k smoke fixtures.

## Test plan
- [x] `uv run pytest tests/test_llm_skill_selection.py tests/test_skill_router.py tests/test_skill_prompts.py`
- [x] `uv run ruff check` on touched modules
- [ ] CI green

## Still out of scope
- Full offline eval suite / quality lift benchmarks
- E2B real SDK, HITL destroy+restore, ADR Accept sign-off

Made with [Cursor](https://cursor.com)