### PR TITLE
feat(sandbox): E2B SDK adapter and HITL destroy/restore

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,6 +59,10 @@ class Settings(BaseSettings):
     sandbox_default_tier: str = "standard"
     # ADR-03：E2B 默认关闭；仅批准的 benchmark/PoC 可显式打开
     sandbox_e2b_enabled: bool = False
+    e2b_api_key: str = ""
+    e2b_timeout_s: int = 120
+    # PoC 默认不开外网，降低 UGC 出站风险；对照网络 benchmark 时可显式打开
+    e2b_allow_internet: bool = False
 
     # 构建链（docs/build-pipeline.md P1+）
     build_pipeline_enabled: bool = False

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -567,6 +567,22 @@ async def _pause_hitl(
         raise RunFinalized
     apply_paused_metadata(ctx.run)
     existing = await ckpt.load_state(ctx.r, ctx.run.id, ctx.s) or {}
+    extra_data = dict(extra or {})
+    # HITL 长等待：若携带活沙箱会话则显式 destroy，不保留计费会话
+    live_session = extra_data.pop("sandbox_session", None)
+    if live_session is not None:
+        from app.sandbox import get_sandbox_backend
+        from app.sandbox.base import SandboxSession
+        from app.sandbox.lifecycle import destroy_for_hitl, sandbox_session_from_checkpoint
+
+        session_obj = (
+            live_session
+            if isinstance(live_session, SandboxSession)
+            else sandbox_session_from_checkpoint(live_session)
+        )
+        if session_obj is not None and not session_obj.closed:
+            hitl_meta = await destroy_for_hitl(get_sandbox_backend(), session_obj)
+            extra_data["sandbox_hitl"] = hitl_meta
     checkpoint = build_pause_checkpoint(
         phase=str(existing.get("phase") or node),
         pause_reason=PauseReason.WAITING_USER,
@@ -575,7 +591,7 @@ async def _pause_hitl(
             **{k: v for k, v in existing.items() if k not in {"recovery", "pause_reason"}},
             "phase": str(existing.get("phase") or node),
             "design_doc": design_doc,
-            **(extra or {}),
+            **extra_data,
         },
     )
     # build_pause_checkpoint 已写入 pause_reason；去掉可能被 extra 带入的 recovery

--- a/backend/app/sandbox/__init__.py
+++ b/backend/app/sandbox/__init__.py
@@ -9,6 +9,7 @@ from app.sandbox.base import (
     SandboxBackend,
     SandboxSession,
 )
+from app.sandbox.lifecycle import destroy_for_hitl, restore_after_hitl
 from app.sandbox.local import LocalSandbox
 
 _backend: SandboxBackend | None = None
@@ -40,6 +41,9 @@ def reset_sandbox_for_tests() -> None:
     global _backend, _sandbox
     _backend = None
     _sandbox = None
+    from app.sandbox.e2b import clear_e2b_live_for_tests
+
+    clear_e2b_live_for_tests()
 
 
 def _build_backend(name: str) -> SandboxBackend:
@@ -66,7 +70,9 @@ __all__ = [
     "Sandbox",
     "SandboxBackend",
     "SandboxSession",
+    "destroy_for_hitl",
     "get_sandbox",
     "get_sandbox_backend",
     "reset_sandbox_for_tests",
+    "restore_after_hitl",
 ]

--- a/backend/app/sandbox/e2b.py
+++ b/backend/app/sandbox/e2b.py
@@ -1,33 +1,52 @@
-"""E2B Sandbox PoC（ADR-03 Pending：默认禁用，不得作为国内生产默认后端）。
+"""E2B Sandbox 真 SDK 适配（ADR-03：默认禁用，≠ 生产批准）。
 
-集成成功 ≠ 生产批准。未显式开启 ``sandbox_e2b_enabled`` 时拒绝 create。
+依赖可选 extra ``e2b``（``uv sync --extra e2b``）。未安装 SDK 或未开 flag 时拒绝 create。
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
+from typing import Any
 
 from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
+from app.core.metrics import SANDBOX_RUNS
 from app.sandbox.base import BuildResult, SandboxSession
+
+log = logging.getLogger(__name__)
+
+_WORKDIR = "/home/user/gameforge"
+# 进程内持有活会话；HITL destroy 必须 kill 并弹出
+_LIVE: dict[str, Any] = {}
 
 
 class E2BSandbox:
-    """PoC 占位：生命周期接口齐备，默认拒绝以免误开源码出境路径。"""
+    """AsyncSandbox 生命周期：create → execute → destroy。"""
 
     backend_id = "e2b"
 
     async def create(self, *, tier: str | None = None) -> SandboxSession:
-        if not settings.sandbox_e2b_enabled:
-            raise AppError(
-                ErrorCode.SANDBOX_FAILED,
-                "E2B sandbox is PoC-only and disabled by default (ADR-03). "
-                "Set sandbox_e2b_enabled=true only for approved benchmarks.",
-            )
-        raise AppError(
-            ErrorCode.SANDBOX_FAILED,
-            "E2B adapter is not implemented yet; DockerSandbox remains the production baseline.",
+        self._require_enabled()
+        AsyncSandbox = _import_async_sandbox()
+        kwargs: dict[str, Any] = {
+            "timeout": settings.e2b_timeout_s,
+            "allow_internet_access": settings.e2b_allow_internet,
+        }
+        if settings.e2b_api_key:
+            kwargs["api_key"] = settings.e2b_api_key
+        try:
+            sbx = await AsyncSandbox.create(**kwargs)
+        except Exception as exc:  # noqa: BLE001 SDK/网络错误映射为沙箱失败
+            raise AppError(ErrorCode.SANDBOX_FAILED, f"E2B create failed: {exc}") from exc
+        sandbox_id = getattr(sbx, "sandbox_id", None) or getattr(sbx, "id", None) or ""
+        session = SandboxSession.new(
+            self.backend_id,
+            tier=tier or settings.sandbox_default_tier,
+            handle=str(sandbox_id),
         )
+        _LIVE[session.id] = sbx
+        return session
 
     async def execute(
         self,
@@ -37,8 +56,120 @@ class E2BSandbox:
         *,
         collect_root: str = ".",
     ) -> BuildResult:
-        raise AppError(ErrorCode.SANDBOX_FAILED, "E2B execute is unavailable")
+        if session.closed:
+            return BuildResult(ok=False, error="sandbox session closed")
+        sbx = await self._resolve_live(session)
+        try:
+            await sbx.commands.run(f"mkdir -p {_WORKDIR}", timeout=30)
+            for rel, content in source.items():
+                remote = f"{_WORKDIR}/{rel.lstrip('/')}"
+                parent = remote.rsplit("/", 1)[0]
+                if parent and parent != _WORKDIR:
+                    await sbx.commands.run(f"mkdir -p {parent}", timeout=30)
+                await sbx.files.write(remote, content)
+            logs = ""
+            if build_cmd:
+                cmd = " && ".join(build_cmd)
+                result = await sbx.commands.run(
+                    f"cd {_WORKDIR} && {cmd}",
+                    timeout=float(settings.e2b_timeout_s),
+                )
+                logs = (getattr(result, "stdout", "") or "") + (
+                    getattr(result, "stderr", "") or ""
+                )
+                exit_code = int(getattr(result, "exit_code", 1) or 0)
+                if exit_code != 0:
+                    SANDBOX_RUNS.labels("e2b", "fail").inc()
+                    return BuildResult(
+                        ok=False, logs=logs, error=f"build exit {exit_code}"
+                    )
+            files = await self._collect(sbx, collect_root=collect_root)
+            SANDBOX_RUNS.labels("e2b", "ok").inc()
+            return BuildResult(ok=True, files=files, logs=logs)
+        except AppError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            SANDBOX_RUNS.labels("e2b", "error").inc()
+            return BuildResult(ok=False, error=str(exc))
 
     async def destroy(self, session: SandboxSession) -> None:
+        if session.closed:
+            return
+        sbx = _LIVE.pop(session.id, None)
+        if sbx is not None:
+            try:
+                kill = getattr(sbx, "kill", None)
+                if kill is not None:
+                    await kill()
+            except Exception:  # noqa: BLE001 destroy 路径不得抛崩
+                log.exception("e2b kill failed session=%s", session.id)
         session.closed = True
         session.handle = None
+
+    async def _resolve_live(self, session: SandboxSession) -> Any:
+        sbx = _LIVE.get(session.id)
+        if sbx is not None:
+            return sbx
+        if not session.handle:
+            raise AppError(ErrorCode.SANDBOX_FAILED, "E2B session handle missing")
+        AsyncSandbox = _import_async_sandbox()
+        connect = getattr(AsyncSandbox, "connect", None)
+        if connect is None:
+            raise AppError(
+                ErrorCode.SANDBOX_FAILED,
+                "E2B session lost and SDK has no connect(); recreate after HITL",
+            )
+        kwargs: dict[str, Any] = {}
+        if settings.e2b_api_key:
+            kwargs["api_key"] = settings.e2b_api_key
+        try:
+            sbx = await connect(session.handle, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            raise AppError(
+                ErrorCode.SANDBOX_FAILED, f"E2B reconnect failed: {exc}"
+            ) from exc
+        _LIVE[session.id] = sbx
+        return sbx
+
+    async def _collect(self, sbx: Any, *, collect_root: str) -> dict[str, bytes]:
+        root = _WORKDIR if collect_root in (".", "") else f"{_WORKDIR}/{collect_root}"
+        files: dict[str, bytes] = {}
+        listed = await sbx.commands.run(f"find {root} -type f", timeout=60)
+        stdout = getattr(listed, "stdout", "") or ""
+        limit = settings.artifact_max_size_mb * 1024 * 1024
+        total = 0
+        for line in stdout.splitlines():
+            path = line.strip()
+            if not path:
+                continue
+            data = await sbx.files.read(path, format="bytes")
+            raw = data.encode("utf-8") if isinstance(data, str) else bytes(data)
+            total += len(raw)
+            if total > limit:
+                raise AppError(ErrorCode.QUOTA_EXCEEDED, "产物超出大小上限")
+            rel = path[len(root) :].lstrip("/")
+            files[rel or path.rsplit("/", 1)[-1]] = raw
+        return files
+
+    def _require_enabled(self) -> None:
+        if not settings.sandbox_e2b_enabled:
+            raise AppError(
+                ErrorCode.SANDBOX_FAILED,
+                "E2B sandbox is PoC-only and disabled by default (ADR-03). "
+                "Set sandbox_e2b_enabled=true only for approved benchmarks.",
+            )
+
+
+def _import_async_sandbox() -> Any:
+    try:
+        from e2b import AsyncSandbox  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise AppError(
+            ErrorCode.SANDBOX_FAILED,
+            "E2B SDK not installed; run: uv sync --extra e2b",
+        ) from exc
+    return AsyncSandbox
+
+
+def clear_e2b_live_for_tests() -> None:
+    _LIVE.clear()

--- a/backend/app/sandbox/lifecycle.py
+++ b/backend/app/sandbox/lifecycle.py
@@ -1,0 +1,48 @@
+"""HITL 长等待：显式 destroy，resume 后 restore（新建 session，不强制 snapshot）。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.sandbox.base import SandboxBackend, SandboxSession
+
+
+async def destroy_for_hitl(
+    backend: SandboxBackend, session: SandboxSession
+) -> dict[str, Any]:
+    """暂停前销毁沙箱会话，避免 HITL 期间计费/泄漏。
+
+    返回可写入 checkpoint 的元数据（不含可执行 handle）。
+    """
+    meta = {
+        "session_id": session.id,
+        "backend_id": session.backend_id,
+        "tier": session.tier,
+        "destroyed_for_hitl": True,
+    }
+    await backend.destroy(session)
+    return meta
+
+
+async def restore_after_hitl(
+    backend: SandboxBackend, *, tier: str | None = None
+) -> SandboxSession:
+    """HITL 恢复后新建沙箱会话（本仓库不强制跨等待 snapshot）。"""
+    return await backend.create(tier=tier)
+
+
+def sandbox_session_from_checkpoint(raw: dict[str, Any] | None) -> SandboxSession | None:
+    """从 checkpoint 中的 sandbox_session 字段还原句柄（可能已 destroy）。"""
+    if not isinstance(raw, dict):
+        return None
+    sid = raw.get("id") or raw.get("session_id")
+    backend_id = raw.get("backend_id")
+    if not sid or not backend_id:
+        return None
+    return SandboxSession(
+        id=str(sid),
+        backend_id=str(backend_id),
+        tier=str(raw.get("tier") or "standard"),
+        closed=bool(raw.get("closed", False)),
+        handle=raw.get("handle"),
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
 playwright = [
     "playwright>=1.45",
 ]
+e2b = [
+    "e2b>=1.0.0",
+]
 
 [tool.ruff]
 line-length = 100

--- a/backend/tests/test_e2b_and_hitl_lifecycle.py
+++ b/backend/tests/test_e2b_and_hitl_lifecycle.py
@@ -1,0 +1,108 @@
+"""E2B SDK 适配（mock）与 HITL destroy/restore 编排。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from app.core.errors import AppError
+from app.sandbox.e2b import E2BSandbox, clear_e2b_live_for_tests
+from app.sandbox.lifecycle import destroy_for_hitl, restore_after_hitl
+from app.sandbox.local import LocalSandbox
+
+
+class _FakeFiles:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def write(self, path: str, data: str) -> None:
+        self.store[path] = data
+
+    async def read(self, path: str, format: str = "text") -> Any:
+        text = self.store.get(path, "")
+        return text.encode("utf-8") if format == "bytes" else text
+
+
+class _FakeCommands:
+    def __init__(self, files: _FakeFiles) -> None:
+        self.files = files
+
+    async def run(self, cmd: str, timeout: float = 60) -> SimpleNamespace:
+        if cmd.startswith("mkdir"):
+            return SimpleNamespace(stdout="", stderr="", exit_code=0)
+        if cmd.startswith("find "):
+            root = cmd.split(" ", 1)[1].split(" ", 1)[0]
+            paths = [p for p in self.files.store if p.startswith(root)]
+            return SimpleNamespace(stdout="\n".join(paths), stderr="", exit_code=0)
+        if "&&" in cmd and "false" in cmd:
+            return SimpleNamespace(stdout="", stderr="boom", exit_code=1)
+        return SimpleNamespace(stdout="ok", stderr="", exit_code=0)
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.sandbox_id = "sbx_test_1"
+        self.files = _FakeFiles()
+        self.commands = _FakeCommands(self.files)
+        self.killed = False
+
+    async def kill(self) -> None:
+        self.killed = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_e2b() -> None:
+    clear_e2b_live_for_tests()
+    yield
+    clear_e2b_live_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_e2b_create_blocked_when_disabled() -> None:
+    settings.sandbox_e2b_enabled = False
+    with pytest.raises(AppError):
+        await E2BSandbox().create()
+
+
+@pytest.mark.asyncio
+async def test_e2b_lifecycle_with_mocked_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings.sandbox_e2b_enabled = True
+    fake = _FakeSandbox()
+
+    class _AS:
+        @staticmethod
+        async def create(**_kwargs: Any) -> _FakeSandbox:
+            return fake
+
+    monkeypatch.setattr("app.sandbox.e2b._import_async_sandbox", lambda: _AS)
+    backend = E2BSandbox()
+    session = await backend.create(tier="standard")
+    assert session.backend_id == "e2b"
+    assert session.handle == "sbx_test_1"
+    result = await backend.execute(
+        session,
+        source={"index.html": "<!DOCTYPE html><html></html>"},
+        build_cmd=None,
+    )
+    assert result.ok
+    assert "index.html" in result.files
+    await backend.destroy(session)
+    assert session.closed
+    assert fake.killed is True
+    settings.sandbox_e2b_enabled = False
+
+
+@pytest.mark.asyncio
+async def test_hitl_destroy_and_restore_local() -> None:
+    backend = LocalSandbox()
+    session = await backend.create()
+    meta = await destroy_for_hitl(backend, session)
+    assert meta["destroyed_for_hitl"] is True
+    assert session.closed
+    restored = await restore_after_hitl(backend, tier="standard")
+    assert not restored.closed
+    assert restored.id != session.id
+    await backend.destroy(restored)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -417,6 +417,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -593,6 +602,19 @@ wheels = [
 ]
 
 [[package]]
+name = "connectrpc"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b5/63e14ab9d4d4cc58818562db4120a35fa7454e3035633da41bdc6b712abd/connectrpc-0.11.1.tar.gz", hash = "sha256:18277f7838847b4271ca38d40c7d2387b5a2ea6a29f240689c19e1ec84aaff66", size = 46222, upload-time = "2026-07-15T06:33:31.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/ac/aa647675812cd075f2cb9acb00d62f4f2cbcbc6736049a62342b7371ce5b/connectrpc-0.11.1-py3-none-any.whl", hash = "sha256:8a52e2e92a485fa9681c1101a79a5ebeb31807e3ea3d5aabd41f484a6398bc7b", size = 64991, upload-time = "2026-07-15T06:33:29.396Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -658,6 +680,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "connectrpc" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/89/6b07538ca727b027b1885fa87b614949a50dbb5744dc9ea2f1abcc3f5ae7/e2b-2.39.1.tar.gz", hash = "sha256:458ca8dc4c1ed39e66fed6dcefae02b4328b79c7f04b707622f259fcec392293", size = 210506, upload-time = "2026-08-13T16:56:07.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/07/0e1706b38523cdeb09890687d4fbb48e2f7b75512e1bc5ff89ebcaf8ed1e/e2b-2.39.1-py3-none-any.whl", hash = "sha256:71595fc48ebb00c549cef28b0a93fefff83407d43d21d7daa63e940614696a95", size = 371626, upload-time = "2026-08-13T16:56:08.5Z" },
 ]
 
 [[package]]
@@ -821,6 +875,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+e2b = [
+    { name = "e2b" },
+]
 playwright = [
     { name = "playwright" },
 ]
@@ -848,6 +905,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "boto3", specifier = ">=1.35" },
     { name = "cryptography", specifier = ">=42.0" },
+    { name = "e2b", marker = "extra == 'e2b'", specifier = ">=1.0.0" },
     { name = "email-validator", specifier = ">=2.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -864,7 +922,7 @@ requires-dist = [
     { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["playwright"]
+provides-extras = ["playwright", "e2b"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -968,6 +1026,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1058,6 +1138,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1901,6 +1990,53 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf-py"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py-ext", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ed/02fd902d9c51b7ff53dfc9a745eb11490722edfd30073af889e171f07b8e/protobuf_py-0.1.1.tar.gz", hash = "sha256:6bd08ac4d8f1661965bbe2685429d79043704cdd1ee720a7a89617331742240b", size = 133525, upload-time = "2026-06-24T19:02:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/00/1b3775aca1c70e3007e06ef5996f6bb9b3a32341eb0cce3ffb6effad8dec/protobuf_py-0.1.1-py3-none-any.whl", hash = "sha256:efc4f50f275ed6dae10a1f30bb81ad1a75368557b3ff22a532b7a472050368f1", size = 181656, upload-time = "2026-06-24T19:01:29.556Z" },
+]
+
+[[package]]
+name = "protobuf-py-ext"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/6dc9ccff1e8159eb9a144e6d3c4acfd2211cd4fcd20c34fe9155d17d6a7f/protobuf_py_ext-0.1.1.tar.gz", hash = "sha256:e85bfdfdb3ed50634db8ccc7429dd9286520109489c735463971a418707b4fef", size = 31912, upload-time = "2026-06-24T19:02:16.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/2b5d62a60a2e0d88ecde1ae98db3132bcd2672fb39c8d581b82b34ac0bd8/protobuf_py_ext-0.1.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:310039e03cb15181781a0b78017419f6d4ee302e988c3c70b87f1facdf05532d", size = 306008, upload-time = "2026-06-24T19:01:31.399Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d6/73c06bb4cac2e04c0adc154965fe8b6520224bd737fd7e73bba405056321/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ec8348d1ba045f79b2fedd14e40cca36f2a41b52f2c4fdf55a60c58add2353", size = 314769, upload-time = "2026-06-24T19:01:32.89Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c5/e4e6bc6096b66d1c82639a1b501147f16ee65d32567304b987d002e2c666/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:182798e4861aba72d05855bd06febe4926aa7265e6f444a1b8af5252beee4f7e", size = 328122, upload-time = "2026-06-24T19:01:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/1d792a40d0f0a0f914f1dfa8bb5e9573ca0ecd5fe5cecf80d77193212abd/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9eb25c3a329c0551cc86b209a5e5d8ecb8d834b9924a3aa019377853a703b6d3", size = 492338, upload-time = "2026-06-24T19:01:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/5ad329223c905e5c530cae38ae24cde3584d8ab7e09457f2a01afce80e60/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aaecbde82bef10c7c40578cbb61b7a19896bf7fa450972050a3bb302acb7d5d6", size = 541578, upload-time = "2026-06-24T19:01:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c7/01bd8a8bfe2df4b07aafac12ccfb7b7ebe2303f65296a9e02fcafa28ff3e/protobuf_py_ext-0.1.1-cp310-abi3-win_amd64.whl", hash = "sha256:6b0c615c48e95acc53cf33e9310eeaff8b30d2d7555bf93e7bca8fb4f40e9a5c", size = 251319, upload-time = "2026-06-24T19:01:38.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/914065538b5db54b6a920b5af38c1ef142252ea1eea711820435fa259fac/protobuf_py_ext-0.1.1-cp310-abi3-win_arm64.whl", hash = "sha256:72956cd0af5dee24b41c6f5ba5e42622d17e6d555002b5efc1634e27a1446de2", size = 241635, upload-time = "2026-06-24T19:01:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/0b5d73cab815fd50615cb87a02e04e8332f9e27380c890aba1459cf7e919/protobuf_py_ext-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6f0cd58620f415a3534d195358338f4999a774e12510f91c592b38d13d37388", size = 304903, upload-time = "2026-06-24T19:01:41.796Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/14c120b9ac36a0e11bb05e482fa6ae322de583a8e1068e4859035c289947/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21572764f625d829604fc4d83635f533f35775f11c6da142345b3f3c8d64bd09", size = 316148, upload-time = "2026-06-24T19:01:43.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7c00a1a9783c3ba74f6b2f5d2f049f09037bbd489c465c09a34f32fb611b/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f14f00c2678bfbe7ad46f057b9f9938c1677bcf39e405e163e272c6f9814b8", size = 326458, upload-time = "2026-06-24T19:01:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/81fa50c0d6c4d664e5be6d0a3c4f2c7edfef87ab12d0bac764abca1f2955/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1610865622e2e27568277ca63d8d2d23dcc55eaa767398865c21539ddf4ce24d", size = 493596, upload-time = "2026-06-24T19:01:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/3183cf6e4de62846c20549654a1d573dae51ca06aaf7fed06accdfab74f6/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8995efba9476e1ea18ef9873306871dba697308994bc2766558fec3387acc3de", size = 539656, upload-time = "2026-06-24T19:01:48.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/6c/09841f3dbe7c3d4b3f2779f8f2832ac23fb96ac8ab71674e91af732cf9ff/protobuf_py_ext-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba61d49dace8f874361583030a7c48139b42eb37c9ffbb1e7e8a227a51576f44", size = 305017, upload-time = "2026-06-24T19:01:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/52/43/e450b5e202f6715274acc9acd9f9769908cbdeab861a53c798fcbd467d35/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a9c2f026096ca4c595c89a297067ef371e241d3ff8e1f6d7c779aa8419cdca7", size = 316215, upload-time = "2026-06-24T19:01:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5c/23e79b35f1b5755b9bdc0c0c9b8cd8abababaef1a1639608d8a96bb61a9d/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf78707a040b9294e5e1ec4a1875f0046acfe52e92150cea27de4e9fc9db39bb", size = 326419, upload-time = "2026-06-24T19:01:52.93Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/de/5493de0ec12920a3b1dd72608ce0c1e8cdb7e0eb9e87accaecc5216df29e/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae4373845cbb85bdade3ef5368cc2f4b5f80bf173383afc1ab063f95644e5599", size = 493734, upload-time = "2026-06-24T19:01:54.301Z" },
+    { url = "https://files.pythonhosted.org/packages/98/89/31da55b414e6332aad11d858e9a86bd36fbb324f52fa3fc6d8f1c57840a9/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2a4cc478eef7a2acc1daaebcde479a3ac2396d47e6bdc7e776ca4c4147ba8b4c", size = 539703, upload-time = "2026-06-24T19:01:55.707Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/71/39f231838ef06476d46ac40dd814894277a732a3688c0a0c994850b3b62f/protobuf_py_ext-0.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:359dccdc1c3eafed2a913c570bb082b8df848a1d27d548ce8385f246a7d68be2", size = 302145, upload-time = "2026-06-24T19:01:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f1/01c81ff5f420600366a0e6a613ce2af20834534d2b3d7523f4f3b4ddb54f/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91c38b4a10a306366443273ee03ca554537a0965bf05b7ada8e7dbdee04cc93e", size = 314541, upload-time = "2026-06-24T19:01:58.745Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d8/1cbf5a0298ceddc0cdbb28bf1ecaf8bd3cff54ed4ced6a1392d5226172fc/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79eee3bcbb289d6ea114eb8fe3a1469c5b59bf53e207238469f567d9c53ba56f", size = 325092, upload-time = "2026-06-24T19:02:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/af/23/8b1694616044cbfec2d18d4c6fffb03e05089c8bdb5970c6bafd60cc7fd5/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:10992141a8282a71ac3e3530d1a489efb27618d84000b9a47918cf70e5816d9b", size = 491684, upload-time = "2026-06-24T19:02:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/99997a7a6cf6989c944d9183c5deb6a045c27460add0316c7b34763891b3/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4411ffe0e06a774b83c5c71c546ce097640a25f596c45f95f53d3e3148e3f22d", size = 538048, upload-time = "2026-06-24T19:02:03.362Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/9e99ecbb68e1d5b46016d821eb1cbba9a91e6b50e71e75faf0c1e6189f0d/protobuf_py_ext-0.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55a17d80ea419501ff221a6627523f38a431bb33e6aa3de81ae3a7f271c49c75", size = 296337, upload-time = "2026-06-24T19:02:04.787Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f2/305338a28225fb54b28d6c3f5948109b9088b329a2b6f77ca610c2bdcd34/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbb518b5638403ceaa08ac4fc7dac626f45ed9b856b3517de3906cf3de4d632", size = 308961, upload-time = "2026-06-24T19:02:06.185Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f9/416103c93677ff2ea407704ea64fa6de9e700dc030c48360a182d91ce373/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a4adc65ab6a5e4885c67fc808bcacb83d755d05b566d312a0e10c2a873f2ad4", size = 321895, upload-time = "2026-06-24T19:02:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/83/eb3e81bb2f83834b7deff4cee2d56eeb1adcbc847492a56b7f910ab257db/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e97f45c49676efacfb8e95bfcb1a002bc337e618a6780be1e55df2ba5ebd2f1e", size = 486091, upload-time = "2026-06-24T19:02:09.243Z" },
+    { url = "https://files.pythonhosted.org/packages/99/96/bd88fca38556b3105e4dd41d6a176e31dcc583fe979e830aeedd2f8c20ee/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:53a6b3590f6aa7f97b8ed60f62fef9b096babfeae82f7283fd3a4c405827d4f8", size = 534582, upload-time = "2026-06-24T19:02:11.227Z" },
+]
+
+[[package]]
 name = "pyahocorasick"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2070,6 +2206,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/59/97531fd9d0a06d54e84f5493775739b0c1d0d13ec704974d04fa423a3332/pyqwest-0.9.0.tar.gz", hash = "sha256:514dd0b37d7a1bcb978b5d6423d15f89cf7dcf8058ac2a37aa42cd30090de89e", size = 477462, upload-time = "2026-08-10T01:55:36.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/34/d556fa07d9bff21fc6c9c16738614c6336164b65d9ced1ce9f1c1044aaeb/pyqwest-0.9.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:517d2eb295d56ef1530cebe0cf290a66fa199c57955bd1c5f1dc592240fbb7d6", size = 5224594, upload-time = "2026-08-10T01:54:18.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3f/1d7d1a08ebf8838c0c85e99ab5db5c1aae457f76ee03b60c8f4fc4948e01/pyqwest-0.9.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:408dc692835363b6824bee61ee9e4c9a5bba9c08d75b903f82f9a802e41d1b30", size = 5100753, upload-time = "2026-08-10T01:54:20.669Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/22c4056b526baa4c2c953f4e99925ce0bb14e7747d66e6ac3448a34f76e5/pyqwest-0.9.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1abf1ab3a0c1b545651ab37a643acc7909c4e7644a63a2e4af36e3e230a0db5", size = 5619882, upload-time = "2026-08-10T01:54:22.468Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2c/8f1159a30bbc905b2fcbc386740a260e76ae64372feb263103438ef5201c/pyqwest-0.9.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b02e5c9ce57e079eb3716c464d3818ad2573d7743483c39526ad77ee95af806", size = 5564744, upload-time = "2026-08-10T01:54:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/fd/ff15034d7874fd208d606bd80c924fb0b1091db8159c892672168b656de1/pyqwest-0.9.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:98bdaa30a3a8d8c71506a33c084e485a243fbf51e77130bb39e0f249dd116142", size = 5779373, upload-time = "2026-08-10T01:54:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b5/eeafdeb65ad8fe9c39044aedcfc97610f4e5c7b5620ca9fe2d504f669108/pyqwest-0.9.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:10eba84f9d8512d23bd16dd60b1c77dab956470361559214981dda065df4ad1a", size = 5973306, upload-time = "2026-08-10T01:54:28.729Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/a8979dab5c591529f858d1505d09b3c8b6dec337921f15bed4858c55716e/pyqwest-0.9.0-cp310-abi3-win_amd64.whl", hash = "sha256:af4e859800b02cd1fcdd898af26a881c4a8ce9520f71f6cb0a5403523d2cbbdf", size = 4834706, upload-time = "2026-08-10T01:54:30.335Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9e/d070ca1ce3c202952770436172889a4b0556a564a490baf726f7bb895eba/pyqwest-0.9.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:abe322cc1b63947b493bc06028615e0d5de655928159227aab64f60a0eb0e27d", size = 5244745, upload-time = "2026-08-10T01:54:32.257Z" },
+    { url = "https://files.pythonhosted.org/packages/41/97/ebded0bb35a79f51bb2d1519e34922d79c8825f9e71b696bb20f387a08c2/pyqwest-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6b2dc6a9c583859d031941e1041b8e711afe0ad4c130628207731cef2b1a486", size = 5101044, upload-time = "2026-08-10T01:54:34.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2c/a7f117e793b4e27642807bf7230b9fa297ff1e1ac489fc260fc3d4350ae4/pyqwest-0.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:551e47714da72a72939958029eb37a754cecd974344471c4a2038583a66a5396", size = 5630841, upload-time = "2026-08-10T01:54:35.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/be47fc141529941352a848cd77da581803137b733993a51bf464f2c48915/pyqwest-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3be3d38ccdab3077bf1cfe90c346ce927f9b49c56dcdf20e060f5f2502d01021", size = 5572909, upload-time = "2026-08-10T01:54:37.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/fd/703635e12710ce7ef5e961f5e1b22c609aecc8f07eedd79477b48d1edb74/pyqwest-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:45d9d424da878b22604799d1ce2a0a5df054924487ee5a851ad08025e2076e5c", size = 5794049, upload-time = "2026-08-10T01:54:39.363Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/941aad56b108c743df9d41e124be82ecb6be0eba1007e945b6a39f5dd1a0/pyqwest-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e4420adcd2b756da706b31a04f095a521f6e440dab284b7a1b46c76e048c1f78", size = 5974542, upload-time = "2026-08-10T01:54:41.202Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/86/8445fe05b47322047347464a909ae95dba023bf8409b9967f66bda2905ad/pyqwest-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:25734bd9798bbfaa53c83d395649dd9ea9a791a64b9848734955cb78ad52c832", size = 4847034, upload-time = "2026-08-10T01:54:42.899Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/013fc3c94f0dc4eeca556431797da477d76ad43d69134837ba149468dcc3/pyqwest-0.9.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6e4c2afe6c7293d9e42cfdb0489b0b5f64002159c2dc9c45d9322c1b4ffb42cd", size = 5244793, upload-time = "2026-08-10T01:54:44.891Z" },
+    { url = "https://files.pythonhosted.org/packages/48/61/c685e0c595f3f1b7842a776c48aaf2b3f47270a61672967d9d38f7c5e7f6/pyqwest-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:67f153b94dfbb9aeabc38f20a1bada1acfd9361bec12db86268bd951be35a154", size = 5100715, upload-time = "2026-08-10T01:54:46.777Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a1/a28b2cd704d7dd37043f1e6b398798576c12293f3efae84f00e7f6a5625c/pyqwest-0.9.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9942ffa243c8c2243e3ce04e3e3ec9b4c119346c963fd0051cd989f0defecf6", size = 5628787, upload-time = "2026-08-10T01:54:48.488Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/6255c7f17cd00e39f1c4df3003cea2d2d087e483fb4c49a6535307cd21e0/pyqwest-0.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f8f9c880c19826fead1838e12b042865b15df3ec844928cc74188a8b740f761", size = 5571946, upload-time = "2026-08-10T01:54:50.181Z" },
+    { url = "https://files.pythonhosted.org/packages/37/71/344738bdb38bddbc07cb29e5b1287c08db9e53d6b322581492571bdef748/pyqwest-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:56040761f6ca7abb036c7d288863bf143a9b166d824d98a604908ef20c6906e0", size = 5792872, upload-time = "2026-08-10T01:54:52.045Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ee/c5c74e3afb6dd0a25bca23bb4757d1a7135fab09a0a054036e837d49dd11/pyqwest-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:02a51df744521e45eb5379bc325b91de4512ec64a9f4aba3248f9166ec4e5b88", size = 5974192, upload-time = "2026-08-10T01:54:53.818Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/302960836e3e43ca3051313ee3b767534d1610bd3b8033c7bbad41b06e1b/pyqwest-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:e9a0e3123aee446d5f6e57c43cae87b4dab4b1af3fa970d114d74d5d4b9d075c", size = 4847050, upload-time = "2026-08-10T01:54:56.155Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3e/a36940844325fbc59adf92116d3bcd1155cc2c72d1a390880886ca492bb4/pyqwest-0.9.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:fdab21bbedff4a21209135423f5f54f287a01dd6143cbd7aeab63d5d8c889654", size = 5246741, upload-time = "2026-08-10T01:54:57.697Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8d/efb9741449a81f2489f6929a7691a2145662c3650e06bcb139c64f543d0a/pyqwest-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:21a04ddf4497ef3c7fe36cdc473c094999b7710005d38bd8a0dfd4a3feace12f", size = 5102423, upload-time = "2026-08-10T01:54:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a8/0b667cf9c07e62861cfe24c09ad30357a9c2a0fc3863cfc5610af5b66e3e/pyqwest-0.9.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8c51c1a27ea529fffab90c127a045f0dfe1abc54d5b9ad5f4165e954439c9b2", size = 5627663, upload-time = "2026-08-10T01:55:01.036Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7c/1f88be3d35afe92b79e361aa40faf3904e3a7852e8638a9d3d5c00891ab3/pyqwest-0.9.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10f283ffc40a2774e0dc8fbb47e4a8f9f8a698a99feae3bf4ad75b340c98031b", size = 5572750, upload-time = "2026-08-10T01:55:03.163Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3e/98c1e151772e77dcf00cb8b1c070f2c8edcb15fe12fdee30c1022006ca8e/pyqwest-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f73d4a8e75b5860741fbd0623a0ce792a53336dbfec5f34736004acd5446843", size = 5790615, upload-time = "2026-08-10T01:55:04.758Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f1/12bb4b119cffb7fe5301b2d997ec9ffc1719637f6f4faf2ff2315e13b201/pyqwest-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e34d55a53492b44b82b690c2b11957fc35e99ebab4db2e9bcb2a1e2621d71b62", size = 5976516, upload-time = "2026-08-10T01:55:06.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/046dbf68ccedd816770fd212c6c2612372a6f0d7ecf2d8273480db460ddf/pyqwest-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:48c367150783f6866d0af43c209cc405f8287743d7b2472c7d757fda2478fd57", size = 4841470, upload-time = "2026-08-10T01:55:08.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/cd/38ff77d145385afd71b2dbd6eb116251ce3ffddbed0edde16c64394fbec2/pyqwest-0.9.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10fae206270355c993b49c49bf9778995167f5efe591807d50a8e682921d71ea", size = 5222689, upload-time = "2026-08-10T01:55:09.639Z" },
+    { url = "https://files.pythonhosted.org/packages/82/95/d8c6804eeb72b7b89842b58f1f05d5cfda5be410c4a22442d2574d510d39/pyqwest-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5f475129fb792593222a9ce0fefbbc10bda1544a7411f3946d771c9a61c50e61", size = 5085846, upload-time = "2026-08-10T01:55:11.569Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e7/04fe8962ec416be0199093ebdd326653a5a7b8f53ddfdb29af81756f7c08/pyqwest-0.9.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78f6f676d349535cb094e8e3bcf33863238a142fb7dcc7afb9e61749e2351047", size = 5613296, upload-time = "2026-08-10T01:55:13.315Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0c/7a11728155a34838d2e7c78fb24c937f2cd844ec791ef416030c52f4bb5e/pyqwest-0.9.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f460f5fcdae8cc46e6a679128836f6cd47fbf4bf73e5c9d6ea868e4a90b2e7ee", size = 5557492, upload-time = "2026-08-10T01:55:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d5/8c6e68f0e978b5257b309809fec00d946c1ed20dacef97f25c23de5b91a9/pyqwest-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cba6804151e973d27c99b9f02b3f0bcab7270c3f99725b508ada9c147365cabd", size = 5774204, upload-time = "2026-08-10T01:55:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/17/20/fed89b62d50b4efad2ebe78c3867e0e402f824726652034728a5dd0a342e/pyqwest-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bc9dfeca326918d70a5368114de0fc627d9f64fafa36563ab484ae58ffe42c0d", size = 5964506, upload-time = "2026-08-10T01:55:19.031Z" },
+    { url = "https://files.pythonhosted.org/packages/11/de/30575019efebae84502269d097e706e89a30631e3719218b053e4e0dc179/pyqwest-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384693adc0908f16324e5b508a3c25fb9a92b88f9bdf7ccb6820507db4a95888", size = 4809013, upload-time = "2026-08-10T01:55:21.042Z" },
 ]
 
 [[package]]
@@ -2614,6 +2796,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
     { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/43/30e407989e313677dbb9d5f045f966549a7254834571e342eaa4b55cc67b/wcmatch-11.0.1.tar.gz", hash = "sha256:1ea2b4fa678b8ca268253798d5963935df39132d47c3e241c0a0732224005e7d", size = 144662, upload-time = "2026-08-14T15:20:40.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl", hash = "sha256:fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b", size = 43449, upload-time = "2026-08-14T15:20:39.379Z" },
 ]
 
 [[package]]

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -22,10 +22,10 @@
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）
-  * **P3** ✅ SandboxBackend create/execute/destroy；local/docker；e2b PoC 默认禁用（ADR-03）（PR `#76`）
+  * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）
-  * **仍 gated** 离线 eval 完整套件 / E2B 真 SDK+benchmark / HITL destroy+restore / ADR Accept 签字 / Flag 彻底删遗留 concat
+  * **仍 gated** 完整离线 eval / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / Flag 彻底删遗留 concat / 全量 Load
 
 ---
 

--- a/docs/adr/ADR-03-sandbox-provider-strategy.md
+++ b/docs/adr/ADR-03-sandbox-provider-strategy.md
@@ -2,7 +2,7 @@
 
 * Status: **Proposed**（生产默认仍为 Docker；E2B 仅 PoC）
 * Date: 2026-08-16
-* Related: P3 Sandbox
+* Related: [sandbox-data-flow.md](./sandbox-data-flow.md), [../sandbox-e2b-benchmark.md](../sandbox-e2b-benchmark.md)
 
 ## Context
 

--- a/docs/adr/sandbox-data-flow.md
+++ b/docs/adr/sandbox-data-flow.md
@@ -1,0 +1,44 @@
+# Sandbox Data Flow (ADR-03)
+
+* Status: Reference for ADR-03 Proposed Go criteria
+* Date: 2026-08-16
+
+## Domestic production (DockerSandbox)
+
+```text
+Browser/API
+  → Worker (forge graph)
+    → DockerSandbox.create (local workspace dir)
+      → docker run --network=none (sandbox image)
+        → build/collect artifacts
+      → DockerSandbox.destroy (rm workspace)
+    → hosting store (object storage / local static)
+  → User play URL
+```
+
+**Egress:** game source / prompts / UGC stay on self-hosted Worker + Docker host.
+No third-party sandbox cloud.
+
+## E2B PoC path (disabled by default)
+
+```text
+Worker
+  → E2BSandbox.create  (requires sandbox_e2b_enabled=true + uv sync --extra e2b)
+    → E2B cloud VM (AsyncSandbox)
+      ← source files / build commands uploaded
+      → artifact bytes downloaded
+    → E2BSandbox.destroy / HITL destroy_for_hitl (kill remote)
+```
+
+**Egress risk:** source, prompts-adjacent build inputs, and logs may leave the domestic
+perimeter. Do **not** enable for production until ADR-03 Go criteria are Accepted.
+
+## HITL long wait
+
+```text
+active SandboxSession
+  → destroy_for_hitl (explicit kill; no billing idle session)
+  → checkpoint.sandbox_hitl metadata
+  → user resumes
+  → restore_after_hitl (create fresh session; no mandatory snapshot)
+```

--- a/docs/sandbox-e2b-benchmark.md
+++ b/docs/sandbox-e2b-benchmark.md
@@ -1,0 +1,26 @@
+# E2B vs Docker Benchmark Checklist
+
+* Status: Template（未跑真实对照前不得据此切生产）
+* Related: ADR-03
+
+## How to run PoC (non-prod)
+
+1. `cd backend && uv sync --extra e2b`
+2. Set `SANDBOX_E2B_ENABLED=true`, `E2B_API_KEY=...`, `SANDBOX_BACKEND=e2b`
+3. Prefer `E2B_ALLOW_INTERNET=false` unless the benchmark explicitly needs CDN fetch
+4. Record rows below; keep Docker baseline on the same machine/workload
+
+## Metrics table
+
+| Metric | Docker | E2B | Notes |
+| --- | --- | --- | --- |
+| Cold start (p50/p95) | | | session create → ready |
+| Build latency (p50/p95) | | | same fixture game |
+| Cost per 100 runs | | | vendor invoice / estimate |
+| Domestic network failure rate | | | timeouts / TLS |
+| Data egress confirmed? | N/A (local) | Y/N | see sandbox-data-flow.md |
+
+## Go / No-Go
+
+Do not set production `sandbox_backend=e2b` until ADR-03 is **Accepted** with this table filled
+and compliance review signed.


### PR DESCRIPTION
## Summary
- Wire a real E2B `AsyncSandbox` adapter behind optional extra `e2b` and disabled-by-default config (`sandbox_backend` / API key gates).
- Add HITL lifecycle helpers: destroy live sessions on pause, restore from checkpoint metadata after resume.
- Document sandbox data-flow and E2B Go/No-Go benchmark checklist; update ADR-03 and forge runtime plan progress.

## Test plan
- [x] `uv run pytest tests/test_e2b_and_hitl_lifecycle.py tests/test_sandbox_backend.py -q`
- [x] `uv run ruff check app/sandbox app/forge/graph.py app/core/config.py`
- [ ] Confirm Docker remains default production backend (ADR-03); E2B not enabled without keys/extra
- [ ] Manual: pause/resume HITL path clears and recreates sandbox session metadata as expected
