### PR TITLE
feat(sandbox): telemetry-based tier recommendation (P3.3)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,6 +51,8 @@ S3_READ_TIMEOUT=60
 SANDBOX_BACKEND=local
 SANDBOX_IMAGE=gameforge/sandbox
 SANDBOX_DEFAULT_TIER=standard
+# P3.3：按启发式/近期失败自动选 lite|standard|heavy（默认关，避免过度降档）
+SANDBOX_TIER_AUTO=false
 
 # 构建链（docs/build-pipeline.md；默认关，灰度时改为 true）
 BUILD_PIPELINE_ENABLED=false

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -57,6 +57,8 @@ class Settings(BaseSettings):
     sandbox_backend: str = "local"  # local|docker|e2b（e2b 仅 PoC，见 sandbox_e2b_enabled）
     sandbox_image: str = "gameforge/sandbox"
     sandbox_default_tier: str = "standard"
+    # P3.3：按 telemetry/启发式自动选 lite|standard|heavy；默认关，避免过度降档
+    sandbox_tier_auto: bool = False
     # ADR-03：E2B 默认关闭；仅批准的 benchmark/PoC 可显式打开
     sandbox_e2b_enabled: bool = False
     e2b_api_key: str = ""

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -36,6 +36,11 @@ SANDBOX_RUNS = Counter(
     "Sandbox executions",
     ["backend", "status"],
 )
+SANDBOX_TIER_RUNS = Counter(
+    "gameforge_sandbox_tier_executions_total",
+    "Sandbox executions by resource tier",
+    ["backend", "tier", "status"],
+)
 
 
 class PrometheusMiddleware(BaseHTTPMiddleware):

--- a/backend/app/sandbox/base.py
+++ b/backend/app/sandbox/base.py
@@ -85,11 +85,23 @@ class OneShotSandboxAdapter:
         build_cmd: Sequence[str] | None = None,
         *,
         collect_root: str = ".",
+        tier: str | None = None,
+        hints: dict | None = None,
     ) -> BuildResult:
-        session = await self._backend.create()
+        from app.sandbox.tiers import record_sandbox_outcome, resolve_create_tier
+
+        chosen = resolve_create_tier(source=source, hints=hints, explicit=tier)
+        session = await self._backend.create(tier=chosen)
         try:
-            return await self._backend.execute(
+            result = await self._backend.execute(
                 session, source, build_cmd, collect_root=collect_root
             )
+            record_sandbox_outcome(
+                tier=session.tier,
+                ok=result.ok,
+                error=result.error,
+                backend=session.backend_id,
+            )
+            return result
         finally:
             await self._backend.destroy(session)

--- a/backend/app/sandbox/docker.py
+++ b/backend/app/sandbox/docker.py
@@ -23,6 +23,7 @@ from app.sandbox.base import BuildResult, SandboxSession
 from app.sandbox.collect import collect_artifact_files
 
 _TIERS: dict[str, dict] = {
+    "lite": {"mem_limit": "256m", "nano_cpus": 500_000_000, "timeout_s": 45},
     "standard": {"mem_limit": "512m", "nano_cpus": 1_000_000_000, "timeout_s": 60},
     "heavy": {"mem_limit": "1g", "nano_cpus": 2_000_000_000, "timeout_s": 120},
 }
@@ -88,11 +89,21 @@ class DockerSandbox:
         collect_root: str = ".",
         tier: str | None = None,
     ) -> BuildResult:
-        session = await self.create(tier=tier)
+        from app.sandbox.tiers import record_sandbox_outcome, resolve_create_tier
+
+        chosen = resolve_create_tier(source=source, explicit=tier)
+        session = await self.create(tier=chosen)
         try:
-            return await self.execute(
+            result = await self.execute(
                 session, source, build_cmd, collect_root=collect_root
             )
+            record_sandbox_outcome(
+                tier=session.tier,
+                ok=result.ok,
+                error=result.error,
+                backend=self.backend_id,
+            )
+            return result
         finally:
             await self.destroy(session)
 

--- a/backend/app/sandbox/tiers.py
+++ b/backend/app/sandbox/tiers.py
@@ -1,0 +1,113 @@
+"""P3.3：sandbox tier 推荐与进程内 telemetry。
+
+原则（计划原文）：以 telemetry 为准，避免为省几十 MB 过度调度。
+默认不自动选档；开启后优先升级（OOM/超时/大体量），仅在强信号下降到 lite。
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.core.config import settings
+
+KNOWN_TIERS = ("lite", "standard", "heavy")
+_HEAVY_ENGINES = frozenset({"vite", "phaser3", "pixi", "pixijs", "three", "threejs"})
+_LITE_ENGINES = frozenset({"canvas", "vanilla", "html"})
+_UPGRADE_MARKERS = ("oom", "out of memory", "超时", "timeout", "killed", "memory")
+
+# 进程内环形缓冲：供同进程后续 create 参考（非跨实例 SoT）
+_OUTCOMES: deque[tuple[str, bool, str]] = deque(maxlen=64)
+
+
+@dataclass(frozen=True)
+class TierSignals:
+    source: dict[str, str] | None = None
+    hints: dict[str, Any] | None = field(default=None)
+
+
+def clear_tier_telemetry_for_tests() -> None:
+    _OUTCOMES.clear()
+
+
+def record_sandbox_outcome(
+    *,
+    tier: str,
+    ok: bool,
+    error: str | None = None,
+    backend: str | None = None,
+) -> None:
+    """记录一次执行结果；供 recommend_tier 与 Prometheus 使用。"""
+    err = (error or "").strip()
+    _OUTCOMES.append((tier or "standard", bool(ok), err.lower()))
+    try:
+        from app.core.metrics import SANDBOX_TIER_RUNS
+
+        status = "ok" if ok else "fail"
+        SANDBOX_TIER_RUNS.labels(backend or "unknown", tier or "standard", status).inc()
+    except Exception:  # noqa: BLE001 — metrics 不可用时不影响主路径
+        pass
+
+
+def recommend_tier(signals: TierSignals | None = None) -> str:
+    """根据信号与近期失败推荐档位；始终返回 KNOWN_TIERS 之一。"""
+    signals = signals or TierSignals()
+    base = _normalize(settings.sandbox_default_tier)
+    if _recent_resource_pressure():
+        return "heavy"
+
+    source_bytes = _source_bytes(signals.source)
+    file_count = len(signals.source or {})
+    engine = str((signals.hints or {}).get("engine_id") or "").strip().lower()
+
+    if source_bytes >= 500_000 or file_count >= 30 or engine in _HEAVY_ENGINES:
+        return "heavy"
+
+    if (
+        engine in _LITE_ENGINES
+        and source_bytes <= 32_000
+        and file_count <= 5
+        and not _recent_resource_pressure()
+    ):
+        return "lite"
+
+    return base
+
+
+def resolve_create_tier(
+    *,
+    source: dict[str, str] | None = None,
+    hints: dict[str, Any] | None = None,
+    explicit: str | None = None,
+) -> str | None:
+    """OneShot/create 入口：flag 关返回 explicit（可 None）；开则推荐。"""
+    if explicit:
+        return _normalize(explicit)
+    if not settings.sandbox_tier_auto:
+        return None
+    return recommend_tier(TierSignals(source=source, hints=hints))
+
+
+def _recent_resource_pressure() -> bool:
+    if not _OUTCOMES:
+        return False
+    window = list(_OUTCOMES)[-16:]
+    hits = 0
+    for _tier, ok, err in window:
+        if ok:
+            continue
+        if any(m in err for m in _UPGRADE_MARKERS):
+            hits += 1
+    return hits >= 1
+
+
+def _source_bytes(source: dict[str, str] | None) -> int:
+    if not source:
+        return 0
+    return sum(len(v.encode("utf-8")) for v in source.values())
+
+
+def _normalize(tier: str | None) -> str:
+    key = (tier or "standard").strip().lower()
+    return key if key in KNOWN_TIERS else "standard"

--- a/backend/tests/test_sandbox_tier_telemetry.py
+++ b/backend/tests/test_sandbox_tier_telemetry.py
@@ -1,0 +1,91 @@
+"""P3.3：sandbox tier 推荐（telemetry 启发式；默认不自动调度）。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.sandbox.base import OneShotSandboxAdapter
+from app.sandbox.local import LocalSandbox
+from app.sandbox.tiers import (
+    TierSignals,
+    clear_tier_telemetry_for_tests,
+    recommend_tier,
+    record_sandbox_outcome,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_tier_state(monkeypatch: pytest.MonkeyPatch):
+    clear_tier_telemetry_for_tests()
+    monkeypatch.setattr(settings, "sandbox_default_tier", "standard")
+    monkeypatch.setattr(settings, "sandbox_tier_auto", False)
+    yield
+    clear_tier_telemetry_for_tests()
+
+
+def test_recommend_defaults_to_configured_tier() -> None:
+    assert recommend_tier(TierSignals()) == "standard"
+
+
+def test_recommend_upgrades_on_oom_or_timeout_history() -> None:
+    record_sandbox_outcome(tier="standard", ok=False, error="OOM killed")
+    record_sandbox_outcome(tier="standard", ok=False, error="构建超时")
+    assert recommend_tier(TierSignals()) == "heavy"
+
+
+def test_recommend_heavy_for_large_source_or_vite_hint() -> None:
+    big = {"a.js": "x" * 600_000}
+    assert recommend_tier(TierSignals(source=big)) == "heavy"
+    assert recommend_tier(TierSignals(hints={"engine_id": "vite"})) == "heavy"
+
+
+def test_recommend_lite_only_when_small_and_safe() -> None:
+    small = {"index.html": "<html></html>"}
+    assert (
+        recommend_tier(TierSignals(source=small, hints={"engine_id": "canvas"}))
+        == "lite"
+    )
+    # 有失败历史时不降档
+    record_sandbox_outcome(tier="standard", ok=False, error="timeout")
+    assert (
+        recommend_tier(TierSignals(source=small, hints={"engine_id": "canvas"}))
+        == "heavy"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flag_off_oneshot_uses_backend_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "sandbox_tier_auto", False)
+    seen: list[str | None] = []
+
+    class Spy(LocalSandbox):
+        async def create(self, *, tier: str | None = None):
+            seen.append(tier)
+            return await super().create(tier=tier)
+
+    adapter = OneShotSandboxAdapter(Spy())
+    await adapter.execute(source={"index.html": "<html></html>"})
+    assert seen == [None]
+
+
+@pytest.mark.asyncio
+async def test_flag_on_oneshot_passes_recommended_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "sandbox_tier_auto", True)
+    seen: list[str | None] = []
+
+    class Spy(LocalSandbox):
+        async def create(self, *, tier: str | None = None):
+            seen.append(tier)
+            return await super().create(tier=tier)
+
+    adapter = OneShotSandboxAdapter(Spy())
+    await adapter.execute(
+        source={"index.html": "<html></html>"},
+        hints={"engine_id": "canvas"},
+    )
+    assert seen == ["lite"]

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -22,7 +22,7 @@
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）
-  * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；data-flow / benchmark 清单
+  * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）
   * **仍 gated** 完整离线 eval / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / Flag 彻底删遗留 concat / 全量 Load
@@ -702,6 +702,8 @@ Prompt、design_doc、源码、素材是否出境 → Data Flow Diagram → 才�
 ## P3.3 Tier
 
 候选 lite/standard/heavy（或四档）；以 telemetry 为准，避免为省几十 MB 过度调度。
+
+**本仓库 MVP**：`sandbox/tiers.py` + Docker `lite` 档；`sandbox_tier_auto`（默认关）时 OneShot 按源码体量 / engine hint / 近期 OOM·超时 推荐；Prometheus `gameforge_sandbox_tier_executions_total`；进程内环形缓冲非跨实例 SoT。
 
 ## P3.4 复用
 


### PR DESCRIPTION
## Summary
- Add `sandbox/tiers.py` with conservative lite/standard/heavy recommendation from source size, engine hints, and recent OOM/timeout outcomes.
- Wire OneShot + Docker oneshot create paths; add Docker `lite` limits and `gameforge_sandbox_tier_executions_total`.
- Gate with `sandbox_tier_auto` (default false); update forge runtime plan P3.3 progress.

## Test plan
- [x] `uv run pytest tests/test_sandbox_tier_telemetry.py tests/test_sandbox_backend.py -q`
- [x] `uv run ruff check app/sandbox app/core/config.py app/core/metrics.py`
- [ ] Confirm default path unchanged when `SANDBOX_TIER_AUTO=false`
- [ ] Optional: enable flag in staging and inspect `/metrics` tier labels
