### PR TITLE
feat(skills): offline routing eval suite (P2 Go/No-Go)

### DIFF
--- a/backend/app/forge/skills/offline_eval.py
+++ b/backend/app/forge/skills/offline_eval.py
@@ -1,0 +1,173 @@
+"""P2 离线 eval：selection precision 与相对全量 Methodology 注入的 quality lift。
+
+无 lift / precision 不达标则不应继续扩 catalog（见 runtime evolution 计划 P2 Go/No-Go）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from app.forge.skills.catalog import list_skill_metas
+from app.forge.skills.router import resolve_skills_for_node
+
+MatchMode = Literal["top", "member"]
+
+# (node, hints, expected_id, match_mode)
+EVAL_FIXTURES: tuple[tuple[str, dict[str, Any], str, MatchMode], ...] = (
+    ("art", {"style": "像素风"}, "art/pixel-art", "top"),
+    ("art", {"style": "pixel art"}, "art/pixel-art", "top"),
+    ("art", {"style": "HUD 血条分数"}, "art/hud-design", "top"),
+    ("art", {"style": "清晰 UI"}, "art/hud-design", "top"),
+    ("art", {"style": "构图对比"}, "art/visual-composition", "top"),
+    ("art", {"requirement": "默认视觉"}, "art/visual-composition", "top"),
+    ("code", {"engine_id": "canvas"}, "code/canvas", "top"),
+    ("code", {"engine_id": "phaser3"}, "code/phaser3", "top"),
+    ("code", {"engine_id": "pixijs"}, "code/pixijs", "top"),
+    ("repair", {"engine_id": "canvas", "failure_kind": "product"}, "code/canvas", "top"),
+    (
+        "repair",
+        {"engine_id": "canvas", "failure_kind": "product"},
+        "repair/runtime-error",
+        "member",
+    ),
+    (
+        "repair",
+        {"engine_id": "phaser3", "failure_kind": "build"},
+        "repair/gameplay-regression",
+        "member",
+    ),
+    (
+        "diagnose",
+        {"engine_id": "canvas", "failure_kind": "infra"},
+        "playtest/observation",
+        "member",
+    ),
+    (
+        "qa",
+        {"engine_id": "pixijs", "failure_kind": "product"},
+        "repair/runtime-error",
+        "member",
+    ),
+    ("art", {"methodology_ids": ["art/pixel-art"]}, "art/pixel-art", "top"),
+)
+
+
+@dataclass(frozen=True)
+class EvalReport:
+    case_count: int
+    precision_at_1: float
+    expected_hit_rate: float
+    avg_body_reduction: float
+    policy_coverage: float
+    cross_scope_violations: int
+    avg_routed_methodology: float
+    avg_full_methodology: float
+    top_case_count: int
+    member_case_count: int
+
+
+def evaluate_routing(
+    fixtures: (
+        tuple[tuple[str, dict[str, Any], str, MatchMode], ...]
+        | list[tuple[str, dict[str, Any], str, MatchMode]]
+        | None
+    ) = None,
+) -> EvalReport:
+    """对固定 fixtures 跑确定性路由，产出 precision 与 body 压缩指标。"""
+    cases = list(fixtures or EVAL_FIXTURES)
+    if not cases:
+        return EvalReport(0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0.0, 0, 0)
+
+    top_hits = 0
+    top_n = 0
+    member_hits = 0
+    member_n = 0
+    policy_ok = 0
+    reductions: list[float] = []
+    routed_counts: list[int] = []
+    full_counts: list[int] = []
+    violations = 0
+
+    for node, hints, expected, mode in cases:
+        resolved = resolve_skills_for_node(node, hints=hints)
+        meth_ids = [s.id for s in resolved.methodology]
+        top = meth_ids[0] if meth_ids else ""
+        if mode == "top":
+            top_n += 1
+            if top == expected:
+                top_hits += 1
+        else:
+            member_n += 1
+            if expected in meth_ids:
+                member_hits += 1
+
+        expected_policy = _has_policy_for_node(node)
+        if not expected_policy or resolved.policy:
+            policy_ok += 1
+
+        full_n = _full_methodology_count(node)
+        routed_n = len(resolved.methodology)
+        full_counts.append(full_n)
+        routed_counts.append(routed_n)
+        if full_n > 0:
+            reductions.append(1.0 - (routed_n / full_n))
+
+        if _normalize_art(node):
+            for sid in [*meth_ids, *[s.id for s in resolved.policy]]:
+                if sid.startswith(("code/", "repair/", "billing/", "sandbox/")):
+                    violations += 1
+
+    n = len(cases)
+    return EvalReport(
+        case_count=n,
+        precision_at_1=(top_hits / top_n) if top_n else 0.0,
+        expected_hit_rate=(member_hits / member_n) if member_n else 1.0,
+        avg_body_reduction=(sum(reductions) / len(reductions)) if reductions else 0.0,
+        policy_coverage=policy_ok / n,
+        cross_scope_violations=violations,
+        avg_routed_methodology=(sum(routed_counts) / n) if n else 0.0,
+        avg_full_methodology=(sum(full_counts) / n) if n else 0.0,
+        top_case_count=top_n,
+        member_case_count=member_n,
+    )
+
+
+def routing_beats_full_injection(report: EvalReport, *, min_reduction: float = 0.25) -> bool:
+    """Go 条件：有显著 body 压缩且 precision 可用。"""
+    return (
+        report.case_count >= 12
+        and report.precision_at_1 >= 0.95
+        and report.expected_hit_rate >= 0.95
+        and report.avg_body_reduction >= min_reduction
+        and report.cross_scope_violations == 0
+    )
+
+
+def _normalize_art(node: str) -> bool:
+    return (node or "").strip().lower() in {
+        "art",
+        "art_options",
+        "revise_art_options",
+        "art_detail",
+    }
+
+
+def _has_policy_for_node(node: str) -> bool:
+    from app.forge.skills.router import _node_allowed, _normalize_node
+
+    node_key = _normalize_node(node)
+    return any(
+        m.kind == "policy" and _node_allowed(m, node_key) for m in list_skill_metas()
+    )
+
+
+def _full_methodology_count(node: str) -> int:
+    from app.forge.skills.router import _node_allowed, _normalize_node
+
+    node_key = _normalize_node(node)
+    return sum(
+        1
+        for m in list_skill_metas()
+        if m.kind == "methodology" and _node_allowed(m, node_key)
+    )

--- a/backend/tests/test_llm_skill_selection.py
+++ b/backend/tests/test_llm_skill_selection.py
@@ -62,20 +62,12 @@ async def test_llm_select_falls_back_on_bad_json(monkeypatch: pytest.MonkeyPatch
 
 
 def test_offline_eval_deterministic_precision_on_fixtures() -> None:
-    """轻量 offline eval：确定性路由在固定 fixtures 上的 precision@1。"""
-    fixtures = [
-        ("art", {"style": "像素风"}, "art/pixel-art"),
-        ("code", {"engine_id": "phaser3"}, "code/phaser3"),
-        ("repair", {"engine_id": "canvas", "failure_kind": "product"}, "repair/runtime-error"),
-    ]
-    hits = 0
-    for node, hints, expected in fixtures:
-        resolved = resolve_skills_for_node(node, hints=hints)
-        top = resolved.methodology[0].id if resolved.methodology else ""
-        if top == expected or expected in {s.id for s in resolved.methodology}:
-            hits += 1
-    precision = hits / len(fixtures)
-    assert precision >= 1.0
+    """轻量 offline eval：委托完整套件（见 test_skills_offline_eval）。"""
+    from app.forge.skills.offline_eval import EVAL_FIXTURES, evaluate_routing
+
+    report = evaluate_routing(EVAL_FIXTURES)
+    assert report.precision_at_1 >= 0.95
+    assert report.expected_hit_rate >= 0.95
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skills_offline_eval.py
+++ b/backend/tests/test_skills_offline_eval.py
@@ -1,0 +1,28 @@
+"""P2 离线 eval：Skill routing precision 与相对全量注入的 quality lift。"""
+
+from __future__ import annotations
+
+from app.forge.skills.offline_eval import (
+    EVAL_FIXTURES,
+    evaluate_routing,
+    routing_beats_full_injection,
+)
+
+
+def test_offline_eval_precision_at_least_095() -> None:
+    report = evaluate_routing(EVAL_FIXTURES)
+    assert report.case_count >= 12
+    assert report.precision_at_1 >= 0.95
+    assert report.expected_hit_rate >= 0.95
+
+
+def test_offline_eval_quality_lift_vs_full_injection() -> None:
+    report = evaluate_routing(EVAL_FIXTURES)
+    assert report.avg_body_reduction >= 0.25
+    assert routing_beats_full_injection(report)
+
+
+def test_offline_eval_policy_always_present_never_cross_scope() -> None:
+    report = evaluate_routing(EVAL_FIXTURES)
+    assert report.policy_coverage == 1.0
+    assert report.cross_scope_violations == 0

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -21,11 +21,11 @@
 * 落地进度（相对本仓库）:
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
-  * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）
+  * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）；**离线 eval 套件**（precision@1 / member hit / body reduction lift）
   * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）
-  * **仍 gated** 完整离线 eval / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / Flag 彻底删遗留 concat / 全量 Load
+  * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / Flag 彻底删遗留 concat / 全量 Load
 
 ---
 
@@ -655,6 +655,8 @@ Art 不得看见 billing / sandbox admin / 内部 security runbook。
 * Policy 始终注入；Methodology 可选
 * Skill 变更使依赖其的 cache key 失效（若已上 Exact Cache）
 * 离线 eval：selection precision / quality lift；无 lift 则停扩 catalog
+
+**本仓库**：`forge/skills/offline_eval.py` + `tests/test_skills_offline_eval.py`（≥12 fixtures；precision@1 / member hit / vs 全量注入 body reduction；Art 跨域违规=0）。真实 LLM A/B quality-lift 仍 gated。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `offline_eval.py` with ≥12 fixtures covering art/code/repair/diagnose/qa routing.
- Report precision@1, member hit rate, policy coverage (when applicable), cross-scope violations, and body reduction vs full methodology injection.
- Update forge runtime plan: deterministic offline eval landed; real LLM A/B quality-lift remains gated.

## Test plan
- [x] `uv run pytest tests/test_skills_offline_eval.py tests/test_llm_skill_selection.py -q`
- [x] `uv run ruff check app/forge/skills/offline_eval.py`
- [ ] Skim fixtures when adding new methodology skills; expand cases before catalog growth
