### PR TITLE
refactor(memory): remove legacy context concat dual paths

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -109,9 +109,9 @@ class Settings(BaseSettings):
     reliability_node_timeout: bool = True
     # P0 可靠性：副作用幂等（promote / usage 等）；关则跳过 Redis NX 门闩
     reliability_idempotent_side_effects: bool = True
-    # P1 Memory：ContextBuilder 规范路径；关则节点保持旧拼装
+    # P1 Memory：ContextBuilder 是否注入 recent turns；关则仍走 Builder，仅不带历史
     memory_context_builder: bool = True
-    # P5：正式 Node 强制经 build_node_context；开则禁用 plan/art/code 遗留 concat
+    # P5：遗留 concat 已拆除；flag 仅兼容配置，不再切换拼装路径
     memory_context_enforcement: bool = True
     # P1 Memory：注入/写入 Explicit Preferences
     memory_preferences: bool = True

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -21,7 +21,7 @@ from app.forge.build.integration import (
 )
 from app.forge.build.routing import routing_from_design_doc, should_use_vite_pipeline
 from app.forge.code_candidate import claim_candidate_version
-from app.forge.design_doc import coerce_design_doc, design_doc_to_text
+from app.forge.design_doc import coerce_design_doc
 from app.forge.engine_router import engine_scaffold
 from app.forge.events import publish_event
 from app.forge.prompts import (
@@ -88,7 +88,6 @@ async def execute_code_or_repair(
 
     with observe_phase("code"):
         design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
-        design_text = design_doc_to_text(design_doc)
         entry_req = state.get("entry_requirement")
         artifacts = state.get("artifacts") or []
         art_direction = state.get("art_direction") or {}
@@ -110,28 +109,23 @@ async def execute_code_or_repair(
         qa_diagnosis = state.get("qa_diagnosis") or ""
         attempt = int(state.get("attempt") or 0) + 1
 
-        # P5：Memory/设计稿经 ContextBuilder；assets/scaffold/repair 仍为任务载荷追加
-        from app.forge.memory.loader import build_node_context, use_context_builder
+        # P5：Memory/设计稿唯一经 ContextBuilder；assets/scaffold/repair 为任务载荷追加
+        from app.forge.memory.loader import build_node_context
 
         entry_block = (entry_req or "").strip() or "请按已确认设计稿实现可运行游戏。"
-        if use_context_builder():
-            if settings.memory_session_summary:
-                from app.forge.memory.refresh import refresh_session_summary_if_needed
+        if settings.memory_session_summary:
+            from app.forge.memory.refresh import refresh_session_summary_if_needed
 
-                await refresh_session_summary_if_needed(ctx.s, ctx.game)
-            built = await build_node_context(
-                ctx.s,
-                node="code" if attempt <= 1 and not entry_req else "repair",
-                game=ctx.game,
-                user_id=ctx.game.owner_id,
-                current_input=entry_block,
-                design_doc=design_doc,
-            )
-            base_user_msg = built.user_message
-        else:
-            base_user_msg = f"【已确认设计稿 JSON】\n{design_text}"
-            if entry_req:
-                base_user_msg += f"\n\n【本次实现变更要求】\n{entry_req}"
+            await refresh_session_summary_if_needed(ctx.s, ctx.game)
+        built = await build_node_context(
+            ctx.s,
+            node="code" if attempt <= 1 and not entry_req else "repair",
+            game=ctx.game,
+            user_id=ctx.game.owner_id,
+            current_input=entry_block,
+            design_doc=design_doc,
+        )
+        base_user_msg = built.user_message
         if art_direction:
             base_user_msg += (
                 "\n\n【已确认美术实现设计稿 JSON】\n"
@@ -630,31 +624,28 @@ async def execute_diagnose(
         async def _call(system: str, user_msg: str) -> str:
             return await llm(ctx, system, user_msg)
 
-        memory_prefix: str | None = None
-        from app.forge.memory.loader import build_node_context, use_context_builder
+        from app.forge.memory.loader import build_node_context
 
-        if use_context_builder():
-            if settings.memory_session_summary:
-                from app.forge.memory.refresh import refresh_session_summary_if_needed
+        if settings.memory_session_summary:
+            from app.forge.memory.refresh import refresh_session_summary_if_needed
 
-                await refresh_session_summary_if_needed(ctx.s, ctx.game)
-            built = await build_node_context(
-                ctx.s,
-                node="diagnose",
-                game=ctx.game,
-                user_id=ctx.game.owner_id,
-                current_input="请根据自动试玩证据诊断失败根因并给出可执行修复方案。",
-                design_doc=design_doc,
-            )
-            memory_prefix = built.user_message
+            await refresh_session_summary_if_needed(ctx.s, ctx.game)
+        built = await build_node_context(
+            ctx.s,
+            node="diagnose",
+            game=ctx.game,
+            user_id=ctx.game.owner_id,
+            current_input="请根据自动试玩证据诊断失败根因并给出可执行修复方案。",
+            design_doc=design_doc,
+        )
 
         diagnosis = await diagnose_playtest_failure(
             llm=_call,
-            design_doc=None if memory_prefix else design_doc,
+            design_doc=None,
             errors=errors,
             console_logs=console_logs,
             source_excerpt=qa_source,
-            memory_prefix=memory_prefix,
+            memory_prefix=built.user_message,
             failure_kind=str(state.get("failure_kind") or "product"),
         )
         return {

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -359,17 +359,8 @@ async def _compose_plan_input(
     await _refresh_session_summary(ctx)
     await _upsert_preferences_from_text(ctx, current_input)
     wrapped = _wrap_user_input(current_input)
-    from app.forge.memory.loader import build_node_context, use_context_builder
+    from app.forge.memory.loader import build_node_context
 
-    if not use_context_builder():
-        if design_doc is None:
-            return wrapped
-        return (
-            "【当前完整设计稿 JSON】\n"
-            f"{design_doc_to_text(design_doc)}\n\n"
-            "【用户修改意见】\n"
-            f"{wrapped}"
-        )
     # revise：设计稿用显式标签前置（对齐 PLAN_REVISE）；Memory 走 Builder
     built = await build_node_context(
         ctx.s,
@@ -411,12 +402,8 @@ async def _compose_art_input(
     else:
         prompt_input = current_input
     wrapped = _wrap_user_input(prompt_input)
-    from app.forge.memory.loader import build_node_context, use_context_builder
+    from app.forge.memory.loader import build_node_context
 
-    if not use_context_builder():
-        if not current_input.strip():
-            return design_block
-        return f"{design_block}\n\n【用户反馈】\n{wrapped}"
     built = await build_node_context(
         ctx.s,
         node="art",
@@ -445,10 +432,8 @@ async def _compose_art_detail_input(
         "【用户选定的美术方向】\n"
         f"{option_json}"
     )
-    from app.forge.memory.loader import build_node_context, use_context_builder
+    from app.forge.memory.loader import build_node_context
 
-    if not use_context_builder():
-        return task
     built = await build_node_context(
         ctx.s,
         node="art_detail",

--- a/backend/app/forge/memory/loader.py
+++ b/backend/app/forge/memory/loader.py
@@ -22,8 +22,12 @@ from app.models.game import Game
 
 
 def use_context_builder() -> bool:
-    """Builder 或 Enforcement 任一开启时，正式 Node 必须走 build_node_context。"""
-    return bool(settings.memory_context_builder or settings.memory_context_enforcement)
+    """正式 Node 一律经 ContextBuilder；保留函数供测试/兼容，恒为 True。
+
+    回滚粒度改为关闭单项 Memory 能力（summary / preferences / recent turns），
+    不再回退到节点内手写 concat。
+    """
+    return True
 
 
 async def build_node_context(

--- a/backend/tests/test_context_builder.py
+++ b/backend/tests/test_context_builder.py
@@ -119,12 +119,11 @@ def test_empty_optional_sections_still_build() -> None:
     assert built.fingerprint
 
 
-def test_use_context_builder_respects_enforcement(monkeypatch) -> None:
+def test_use_context_builder_always_on_after_concat_removal(monkeypatch) -> None:
+    """遗留 concat 已删：即使双 flag 关闭，正式路径仍视为必须走 Builder。"""
     from app.core.config import settings
     from app.forge.memory.loader import use_context_builder
 
     monkeypatch.setattr(settings, "memory_context_builder", False)
     monkeypatch.setattr(settings, "memory_context_enforcement", False)
-    assert use_context_builder() is False
-    monkeypatch.setattr(settings, "memory_context_enforcement", True)
     assert use_context_builder() is True

--- a/backend/tests/test_legacy_concat_removed.py
+++ b/backend/tests/test_legacy_concat_removed.py
@@ -1,0 +1,23 @@
+"""P5 cleanup：正式 Node 不得再保留 use_context_builder 双路径 concat。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1] / "app" / "forge"
+_TARGETS = (
+    _ROOT / "graph.py",
+    _ROOT / "code_qa_exec.py",
+)
+
+
+def test_no_legacy_context_builder_gate_in_compose_paths() -> None:
+    forbidden = (
+        "if not use_context_builder()",
+        "if use_context_builder():",
+    )
+    for path in _TARGETS:
+        text = path.read_text(encoding="utf-8")
+        for needle in forbidden:
+            assert needle not in text, f"{path.name} still gates on {needle!r}"
+        assert "build_node_context" in text

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -24,8 +24,8 @@
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）；**离线 eval 套件**（precision@1 / member hit / body reduction lift）
   * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
-  * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）
-  * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / Flag 彻底删遗留 concat / 全量 Load
+  * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**
+  * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / 全量 Load
 
 ---
 
@@ -786,7 +786,7 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 * Chaos / Load / Security 测试
 * 文档与 ADR 归档
 
-**MVP 进度（本仓库）**：`memory_context_enforcement` 默认开；`BuiltContext.fingerprint` + `observe_context_build`；plan/art/art_detail/code|repair/**diagnose** 经 `build_node_context`；Art/QA system prompt 接 Methodology；Skill/Sandbox/Cache 挂 `observe_subsystem`；`docs/adr/` 已归档 Accepted/Pending；`test_p5_hardening.py` 覆盖 secret scan 与 forbid-cache concurrency。P4.5 Semantic、E2B 生产切换、inferred preference、全量 Load 压测仍 gated。
+**MVP 进度（本仓库）**：plan/art/art_detail/code|repair/diagnose **唯一**经 `build_node_context`（遗留 concat 双路径已删）；`BuiltContext.fingerprint` + spans；Art/QA Methodology；`test_legacy_concat_removed.py` 守门。`memory_context_builder` 仅控制是否注入 recent turns。P4.5 Semantic、E2B 生产切换、真实 LLM A/B、全量 Load 仍 gated。
 
 ---
 


### PR DESCRIPTION
## Summary
- Delete `use_context_builder()` gated concat branches in `graph.py` and `code_qa_exec.py`.
- Keep `build_node_context` as the only formal Node assembly path; flags now only control sections (e.g. recent turns), not alternate prompts.
- Add `test_legacy_concat_removed.py` guardrail; update forge runtime plan progress.

## Test plan
- [x] `uv run pytest tests/test_context_builder.py tests/test_legacy_concat_removed.py tests/test_p5_hardening.py -q`
- [x] `uv run ruff check` on touched modules
- [ ] Smoke a forge plan/art turn after merge to confirm Builder-shaped prompts
