### PR TITLE
test(forge): P5 concurrent load smoke suite

### DIFF
--- a/backend/tests/test_p5_load_smoke.py
+++ b/backend/tests/test_p5_load_smoke.py
@@ -1,0 +1,99 @@
+"""P5 Load smoke：进程内并发压力（非全量压测 / 非 k6）。
+
+覆盖 Exact Cache 白名单 roundtrip、Skill 路由、tier telemetry 记录在 gather 下的正确性。
+全量 Load / Chaos 实验窗仍 gated。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import fakeredis.aioredis
+import pytest
+
+from app.core.config import settings
+from app.forge.cache.exact import exact_cache_get, exact_cache_set
+from app.forge.skills.router import resolve_skills_for_node
+from app.sandbox.tiers import (
+    TierSignals,
+    clear_tier_telemetry_for_tests,
+    recommend_tier,
+    record_sandbox_outcome,
+)
+
+
+@pytest.mark.asyncio
+async def test_exact_cache_whitelist_concurrent_roundtrip_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "exact_cache_enabled", True)
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+    async def one(i: int) -> None:
+        payload = {"prompt": f"engine-{i}", "n": i}
+        value = {"ok": True, "i": i}
+        assert await exact_cache_set(
+            r, node="engine_router", input_payload=payload, value=value
+        )
+        got = await exact_cache_get(r, node="engine_router", input_payload=payload)
+        assert got == value
+
+    await asyncio.gather(*(one(i) for i in range(48)))
+    assert (
+        await exact_cache_get(
+            r, node="engine_router", input_payload={"prompt": "engine-0", "n": 0}
+        )
+    )["i"] == 0
+    assert (
+        await exact_cache_get(
+            r, node="engine_router", input_payload={"prompt": "engine-47", "n": 47}
+        )
+    )["i"] == 47
+
+
+@pytest.mark.asyncio
+async def test_skill_router_concurrent_resolves_stable() -> None:
+    async def one(i: int) -> list[str]:
+        resolved = await asyncio.to_thread(
+            resolve_skills_for_node,
+            "art" if i % 2 == 0 else "code",
+            hints=(
+                {"style": "像素风"}
+                if i % 2 == 0
+                else {"engine_id": "phaser3" if i % 4 == 1 else "canvas"}
+            ),
+        )
+        return [s.id for s in resolved.methodology]
+
+    results = await asyncio.gather(*(one(i) for i in range(40)))
+    for i, ids in enumerate(results):
+        assert ids
+        if i % 2 == 0:
+            assert "art/pixel-art" in ids
+            assert all(not x.startswith(("billing/", "code/")) for x in ids)
+        else:
+            expect = "code/phaser3" if i % 4 == 1 else "code/canvas"
+            assert ids[0] == expect
+
+
+@pytest.mark.asyncio
+async def test_tier_telemetry_concurrent_record_and_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_tier_telemetry_for_tests()
+    monkeypatch.setattr(settings, "sandbox_default_tier", "standard")
+
+    async def spray(i: int) -> None:
+        def _record() -> None:
+            record_sandbox_outcome(
+                tier="standard",
+                ok=i % 5 != 0,
+                error="OOM killed" if i % 5 == 0 else None,
+            )
+
+        await asyncio.to_thread(_record)
+
+    await asyncio.gather(*(spray(i) for i in range(24)))
+    record_sandbox_outcome(tier="standard", ok=False, error="构建超时")
+    assert recommend_tier(TierSignals()) == "heavy"
+    clear_tier_telemetry_for_tests()

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -24,8 +24,8 @@
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）；**离线 eval 套件**（precision@1 / member hit / body reduction lift）
   * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
-  * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**
-  * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / 全量 Load
+  * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**；**Load smoke**（并发 Exact Cache / Skill / tier）
+  * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / **全量** Load·Chaos 实验窗
 
 ---
 
@@ -784,9 +784,11 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 * Observability：Memory / Skill / Sandbox / Cache span（Langfuse 等）
 * Migration cleanup、Feature flag 收敛、废弃路径删除
 * Chaos / Load / Security 测试
+
+**本仓库 Load smoke**：`tests/test_p5_load_smoke.py`（asyncio gather：Exact Cache 白名单隔离、Skill 路由稳定、tier telemetry 升级）。**全量** Load / 长时 Chaos 实验窗仍 gated。
 * 文档与 ADR 归档
 
-**MVP 进度（本仓库）**：plan/art/art_detail/code|repair/diagnose **唯一**经 `build_node_context`（遗留 concat 双路径已删）；`BuiltContext.fingerprint` + spans；Art/QA Methodology；`test_legacy_concat_removed.py` 守门。`memory_context_builder` 仅控制是否注入 recent turns。P4.5 Semantic、E2B 生产切换、真实 LLM A/B、全量 Load 仍 gated。
+**MVP 进度（本仓库）**：plan/art/art_detail/code|repair/diagnose **唯一**经 `build_node_context`；Load smoke 已补；P4.5 Semantic、E2B 生产切换、真实 LLM A/B、全量 Load 仍 gated。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `tests/test_p5_load_smoke.py` for in-process concurrent smoke (Exact Cache whitelist isolation, skill routing, tier telemetry).
- Document Load smoke vs full Load/Chaos still gated in the forge runtime plan.
- Local cleanup: deleted merged feature branches; work continues from latest `main`.

## Test plan
- [x] `uv run pytest tests/test_p5_load_smoke.py tests/test_p5_hardening.py -q`
- [x] `uv run ruff check tests/test_p5_load_smoke.py`
