### PR TITLE
feat(forge): close out runtime evolution code MVP

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -53,6 +53,11 @@ SANDBOX_IMAGE=gameforge/sandbox
 SANDBOX_DEFAULT_TIER=standard
 # P3.3：按启发式/近期失败自动选 lite|standard|heavy（默认关，避免过度降档）
 SANDBOX_TIER_AUTO=false
+# ADR-03：E2B 仅 PoC；默认关。启用需 SANDBOX_BACKEND=e2b 且安装 uv sync --extra e2b
+SANDBOX_E2B_ENABLED=false
+# E2B_API_KEY=
+# E2B_TIMEOUT_S=120
+# E2B_ALLOW_INTERNET=false
 
 # 构建链（docs/build-pipeline.md；默认关，灰度时改为 true）
 BUILD_PIPELINE_ENABLED=false
@@ -154,3 +159,10 @@ LOG_DIR=
 CORS_ORIGINS=http://127.0.0.1:5173,http://127.0.0.1:5174,http://localhost:5173,http://localhost:5174
 # 账号禁用时登录提示中的管理员联系邮箱（可在后台「全局设置」覆盖）
 ADMIN_CONTACT_EMAIL=wxcurry@163.com
+
+# Forge Runtime 实验旗标（默认保持安全；详见 docs/2026-08-15-forge-runtime-evolution-plan.md）
+# MEMORY_PREFERENCES_INFERRED=false
+# MEMORY_SESSION_SUMMARY_LLM=false
+# SKILLS_LLM_SELECTION=false
+# EXACT_CACHE_ENABLED=true
+# SEMANTIC_CACHE_SHADOW_ENABLED=false

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -379,7 +379,12 @@ async def execute_code_or_repair(
                 }
 
         html = normalize_html(raw_output)
-        result = await get_sandbox().execute(source={"index.html": html})
+        from app.sandbox.tiers import tier_hints_from_design_doc
+
+        result = await get_sandbox().execute(
+            source={"index.html": html},
+            hints=tier_hints_from_design_doc(design_doc),
+        )
         if result.ok:
             await ctx.s.refresh(ctx.run)
             if (

--- a/backend/app/forge/skills/ab_eval.py
+++ b/backend/app/forge/skills/ab_eval.py
@@ -1,0 +1,66 @@
+"""P2 质量 lift A/B scaffold：mock，不打真实 API。
+
+真实付费 A/B 仍 gated；用 Methodology body 长度对比路由 vs 全量注入。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.forge.skills.catalog import list_skill_metas
+from app.forge.skills.loader import load_skill_body
+from app.forge.skills.router import resolve_skills_for_node
+
+
+@dataclass(frozen=True)
+class AbCaseResult:
+    node: str
+    routed_chars: int
+    full_chars: int
+    reduction: float
+    top_skill: str
+
+
+@dataclass(frozen=True)
+class AbReport:
+    cases: tuple[AbCaseResult, ...]
+    avg_reduction: float
+    mock_llm_calls: int
+
+
+_DEFAULT_CASES: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("art", {"style": "像素风"}),
+    ("art", {"style": "HUD 血条"}),
+    ("code", {"engine_id": "phaser3"}),
+    ("repair", {"engine_id": "canvas", "failure_kind": "product"}),
+)
+
+
+def run_mocked_quality_lift_ab(
+    cases: tuple[tuple[str, dict[str, Any]], ...] | None = None,
+) -> AbReport:
+    """本地 body 长度近似 token；不发起 LLM。"""
+    results: list[AbCaseResult] = []
+    for node, hints in cases or _DEFAULT_CASES:
+        routed = resolve_skills_for_node(node, hints=hints)
+        routed_chars = sum(len(s.body) for s in routed.methodology)
+        full_meth = [
+            m
+            for m in list_skill_metas()
+            if m.kind == "methodology" and (not m.nodes or node in m.nodes)
+        ]
+        full_chars = sum(len(load_skill_body(m.path)) for m in full_meth)
+        reduction = (1.0 - routed_chars / full_chars) if full_chars else 0.0
+        top = routed.methodology[0].id if routed.methodology else ""
+        results.append(
+            AbCaseResult(
+                node=node,
+                routed_chars=routed_chars,
+                full_chars=full_chars,
+                reduction=reduction,
+                top_skill=top,
+            )
+        )
+    avg = sum(r.reduction for r in results) / len(results) if results else 0.0
+    return AbReport(cases=tuple(results), avg_reduction=avg, mock_llm_calls=0)

--- a/backend/app/forge/skills/catalog.py
+++ b/backend/app/forge/skills/catalog.py
@@ -22,7 +22,7 @@ _REGISTRY: tuple[SkillMeta, ...] = (
         id="policy/playtest",
         name="Playtest Policy",
         kind="policy",
-        nodes=("code", "repair", "qa"),
+        nodes=("code", "repair", "qa", "diagnose"),
         description="B-tier Playwright gate; static checks cannot synthesize qa_ok.",
         path="playtest.md",
     ),

--- a/backend/app/forge/skills/offline_eval.py
+++ b/backend/app/forge/skills/offline_eval.py
@@ -44,6 +44,12 @@ EVAL_FIXTURES: tuple[tuple[str, dict[str, Any], str, MatchMode], ...] = (
         "member",
     ),
     (
+        "art_detail",
+        {"style": "像素风"},
+        "art/pixel-art",
+        "member",
+    ),
+    (
         "qa",
         {"engine_id": "pixijs", "failure_kind": "product"},
         "repair/runtime-error",

--- a/backend/app/sandbox/__init__.py
+++ b/backend/app/sandbox/__init__.py
@@ -9,7 +9,7 @@ from app.sandbox.base import (
     SandboxBackend,
     SandboxSession,
 )
-from app.sandbox.lifecycle import destroy_for_hitl, restore_after_hitl
+from app.sandbox.lifecycle import destroy_for_hitl, restore_after_hitl, tier_from_hitl_meta
 from app.sandbox.local import LocalSandbox
 
 _backend: SandboxBackend | None = None
@@ -75,4 +75,5 @@ __all__ = [
     "get_sandbox_backend",
     "reset_sandbox_for_tests",
     "restore_after_hitl",
+    "tier_from_hitl_meta",
 ]

--- a/backend/app/sandbox/__init__.py
+++ b/backend/app/sandbox/__init__.py
@@ -9,7 +9,12 @@ from app.sandbox.base import (
     SandboxBackend,
     SandboxSession,
 )
-from app.sandbox.lifecycle import destroy_for_hitl, restore_after_hitl, tier_from_hitl_meta
+from app.sandbox.lifecycle import (
+    destroy_for_hitl,
+    restore_after_hitl,
+    restore_sandbox_from_checkpoint,
+    tier_from_hitl_meta,
+)
 from app.sandbox.local import LocalSandbox
 
 _backend: SandboxBackend | None = None
@@ -75,5 +80,6 @@ __all__ = [
     "get_sandbox_backend",
     "reset_sandbox_for_tests",
     "restore_after_hitl",
+    "restore_sandbox_from_checkpoint",
     "tier_from_hitl_meta",
 ]

--- a/backend/app/sandbox/base.py
+++ b/backend/app/sandbox/base.py
@@ -70,6 +70,8 @@ class Sandbox(Protocol):
         build_cmd: Sequence[str] | None = None,
         *,
         collect_root: str = ".",
+        tier: str | None = None,
+        hints: dict | None = None,
     ) -> BuildResult: ...
 
 

--- a/backend/app/sandbox/lifecycle.py
+++ b/backend/app/sandbox/lifecycle.py
@@ -31,6 +31,16 @@ async def restore_after_hitl(
     return await backend.create(tier=tier)
 
 
+def tier_from_hitl_meta(meta: dict[str, Any] | None) -> str | None:
+    """从 destroy_for_hitl 元数据恢复档位；无则 None（交给 backend 默认）。"""
+    if not isinstance(meta, dict):
+        return None
+    raw = meta.get("tier")
+    if raw is None or str(raw).strip() == "":
+        return None
+    return str(raw).strip().lower()
+
+
 def sandbox_session_from_checkpoint(raw: dict[str, Any] | None) -> SandboxSession | None:
     """从 checkpoint 中的 sandbox_session 字段还原句柄（可能已 destroy）。"""
     if not isinstance(raw, dict):

--- a/backend/app/sandbox/lifecycle.py
+++ b/backend/app/sandbox/lifecycle.py
@@ -41,6 +41,21 @@ def tier_from_hitl_meta(meta: dict[str, Any] | None) -> str | None:
     return str(raw).strip().lower()
 
 
+async def restore_sandbox_from_checkpoint(
+    backend: SandboxBackend, checkpoint: dict[str, Any] | None
+) -> SandboxSession | None:
+    """若 checkpoint 含 sandbox_hitl，则按原 tier 新建会话；否则返回 None。
+
+    当前 CodeQa 以 oneshot execute 为主；本助手供持有长会话的调用方在 resume 时显式恢复。
+    """
+    if not isinstance(checkpoint, dict):
+        return None
+    meta = checkpoint.get("sandbox_hitl")
+    if not isinstance(meta, dict) or not meta.get("destroyed_for_hitl"):
+        return None
+    return await restore_after_hitl(backend, tier=tier_from_hitl_meta(meta))
+
+
 def sandbox_session_from_checkpoint(raw: dict[str, Any] | None) -> SandboxSession | None:
     """从 checkpoint 中的 sandbox_session 字段还原句柄（可能已 destroy）。"""
     if not isinstance(raw, dict):

--- a/backend/app/sandbox/tiers.py
+++ b/backend/app/sandbox/tiers.py
@@ -75,6 +75,20 @@ def recommend_tier(signals: TierSignals | None = None) -> str:
     return base
 
 
+def tier_hints_from_design_doc(design_doc: dict[str, Any] | None) -> dict[str, Any]:
+    """从 design_doc 提取 sandbox tier 提示（engine_id）。"""
+    if not design_doc:
+        return {}
+    engine = design_doc.get("engine")
+    if isinstance(engine, dict):
+        engine_id = str(engine.get("id") or "").strip()
+    else:
+        engine_id = str(engine or "").strip()
+    if not engine_id:
+        return {}
+    return {"engine_id": engine_id}
+
+
 def resolve_create_tier(
     *,
     source: dict[str, str] | None = None,

--- a/backend/tests/test_adr04_forge_messages_sot.py
+++ b/backend/tests/test_adr04_forge_messages_sot.py
@@ -1,0 +1,45 @@
+"""ADR-04：forge_messages 为会话唯一 SoT；禁止并行会话表模型。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import app.models as models_pkg
+
+_FORBIDDEN_TABLE_FRAGMENTS = (
+    "conversation",
+    "chat_message",
+    "session_message",
+    "vector_message",
+    "message_embedding",
+)
+
+
+def test_forge_messages_is_sole_conversation_sot_among_orm_models() -> None:
+    tables = {
+        cls.__tablename__
+        for name in dir(models_pkg)
+        if not name.startswith("_")
+        for cls in [getattr(models_pkg, name)]
+        if hasattr(cls, "__tablename__")
+    }
+    assert "forge_messages" in tables
+    offenders = [
+        t
+        for t in tables
+        if t != "forge_messages"
+        and any(frag in t for frag in _FORBIDDEN_TABLE_FRAGMENTS)
+    ]
+    assert offenders == [], f"unexpected parallel conversation tables: {offenders}"
+
+
+def test_no_vector_conversation_store_module_in_forge() -> None:
+    forge_root = Path(__file__).resolve().parents[1] / "app" / "forge"
+    banned = ("vector_store", "conversation_vector", "msg_embedding")
+    hits: list[str] = []
+    for path in forge_root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for token in banned:
+            if token in text:
+                hits.append(f"{path.name}:{token}")
+    assert hits == []

--- a/backend/tests/test_diagnose_policy.py
+++ b/backend/tests/test_diagnose_policy.py
@@ -1,0 +1,14 @@
+"""diagnose 节点应注入 playtest Policy。"""
+
+from __future__ import annotations
+
+from app.forge.skills.router import resolve_skills_for_node
+
+
+def test_diagnose_receives_playtest_policy() -> None:
+    resolved = resolve_skills_for_node(
+        "diagnose",
+        hints={"engine_id": "canvas", "failure_kind": "infra"},
+    )
+    policy_ids = [s.id for s in resolved.policy]
+    assert "policy/playtest" in policy_ids

--- a/backend/tests/test_e2b_and_hitl_lifecycle.py
+++ b/backend/tests/test_e2b_and_hitl_lifecycle.py
@@ -98,11 +98,23 @@ async def test_e2b_lifecycle_with_mocked_sdk(monkeypatch: pytest.MonkeyPatch) ->
 @pytest.mark.asyncio
 async def test_hitl_destroy_and_restore_local() -> None:
     backend = LocalSandbox()
-    session = await backend.create()
+    session = await backend.create(tier="heavy")
     meta = await destroy_for_hitl(backend, session)
     assert meta["destroyed_for_hitl"] is True
+    assert meta["tier"] == "heavy"
     assert session.closed
-    restored = await restore_after_hitl(backend, tier="standard")
+    from app.sandbox.lifecycle import tier_from_hitl_meta
+
+    restored = await restore_after_hitl(backend, tier=tier_from_hitl_meta(meta))
     assert not restored.closed
+    assert restored.tier == "heavy"
     assert restored.id != session.id
     await backend.destroy(restored)
+
+
+def test_tier_from_hitl_meta_reads_tier() -> None:
+    from app.sandbox.lifecycle import tier_from_hitl_meta
+
+    assert tier_from_hitl_meta({"tier": "lite"}) == "lite"
+    assert tier_from_hitl_meta({}) is None
+    assert tier_from_hitl_meta(None) is None

--- a/backend/tests/test_e2b_and_hitl_lifecycle.py
+++ b/backend/tests/test_e2b_and_hitl_lifecycle.py
@@ -118,3 +118,20 @@ def test_tier_from_hitl_meta_reads_tier() -> None:
     assert tier_from_hitl_meta({"tier": "lite"}) == "lite"
     assert tier_from_hitl_meta({}) is None
     assert tier_from_hitl_meta(None) is None
+
+
+@pytest.mark.asyncio
+async def test_restore_sandbox_from_checkpoint_uses_hitl_tier() -> None:
+    from app.sandbox.lifecycle import destroy_for_hitl, restore_sandbox_from_checkpoint
+
+    backend = LocalSandbox()
+    session = await backend.create(tier="heavy")
+    meta = await destroy_for_hitl(backend, session)
+    restored = await restore_sandbox_from_checkpoint(
+        backend, {"sandbox_hitl": meta}
+    )
+    assert restored is not None
+    assert restored.tier == "heavy"
+    assert restored.id != session.id
+    await backend.destroy(restored)
+    assert await restore_sandbox_from_checkpoint(backend, {}) is None

--- a/backend/tests/test_llm_summary_and_semantic.py
+++ b/backend/tests/test_llm_summary_and_semantic.py
@@ -76,3 +76,29 @@ async def test_semantic_shadow_disabled_by_default() -> None:
         r, node="entry_router", query={"q": 1}, actual_output="code"
     )
     assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_semantic_shadow_concurrent_trim_and_no_direct_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """并发 shadow 写入不得打开 direct hit；列表长度受 ltrim 约束。"""
+    import asyncio
+
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(settings, "semantic_cache_shadow_enabled", True)
+
+    async def one(i: int) -> None:
+        await semantic_shadow_record(
+            r,
+            node="engine_router",
+            query={"i": i},
+            actual_output={"v": i},
+            similarity=0.1,
+        )
+        assert await semantic_cache_lookup(r, node="engine_router", query={"i": i}) is None
+
+    await asyncio.gather(*(one(i) for i in range(32)))
+    rows = await r.lrange("forge:semantic:shadow:engine_router", 0, -1)
+    assert 1 <= len(rows) <= 1000
+    assert semantic_direct_hit_allowed() is False

--- a/backend/tests/test_sandbox_tier_engine_hints.py
+++ b/backend/tests/test_sandbox_tier_engine_hints.py
@@ -1,0 +1,43 @@
+"""code_qa → sandbox tier hints：从 design_doc 传 engine_id。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.sandbox.base import OneShotSandboxAdapter
+from app.sandbox.local import LocalSandbox
+from app.sandbox.tiers import clear_tier_telemetry_for_tests, tier_hints_from_design_doc
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch: pytest.MonkeyPatch):
+    clear_tier_telemetry_for_tests()
+    monkeypatch.setattr(settings, "sandbox_tier_auto", True)
+    monkeypatch.setattr(settings, "sandbox_default_tier", "standard")
+    yield
+    clear_tier_telemetry_for_tests()
+
+
+def test_tier_hints_from_design_doc_reads_engine_id() -> None:
+    assert tier_hints_from_design_doc({"engine": {"id": "phaser3"}}) == {
+        "engine_id": "phaser3"
+    }
+    assert tier_hints_from_design_doc({"engine": "canvas"}) == {"engine_id": "canvas"}
+    assert tier_hints_from_design_doc({}) == {}
+    assert tier_hints_from_design_doc(None) == {}
+
+
+@pytest.mark.asyncio
+async def test_oneshot_uses_design_engine_hint_for_heavy() -> None:
+    seen: list[str | None] = []
+
+    class Spy(LocalSandbox):
+        async def create(self, *, tier: str | None = None):
+            seen.append(tier)
+            return await super().create(tier=tier)
+
+    adapter = OneShotSandboxAdapter(Spy())
+    hints = tier_hints_from_design_doc({"engine": {"id": "phaser3"}})
+    await adapter.execute(source={"index.html": "<html></html>"}, hints=hints)
+    assert seen == ["heavy"]

--- a/backend/tests/test_skill_bundle_hash.py
+++ b/backend/tests/test_skill_bundle_hash.py
@@ -1,0 +1,29 @@
+"""Skill catalog hash 稳定性（Exact Cache 依赖）。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.forge.skills.catalog import catalog_skill_bundle_hash, skill_bundle_hash
+
+
+def test_catalog_skill_bundle_hash_stable() -> None:
+    a = catalog_skill_bundle_hash()
+    b = catalog_skill_bundle_hash()
+    assert a == b
+    assert len(a) == 64
+
+
+def test_skill_bundle_hash_order_independent() -> None:
+    ids = ["art/pixel-art", "code/canvas", "policy/playtest"]
+    assert skill_bundle_hash(ids) == skill_bundle_hash(list(reversed(ids)))
+
+
+@pytest.mark.asyncio
+async def test_catalog_hash_concurrent_reads_identical() -> None:
+    results = await asyncio.gather(
+        *(asyncio.to_thread(catalog_skill_bundle_hash) for _ in range(24))
+    )
+    assert len(set(results)) == 1

--- a/backend/tests/test_skills_ab_eval.py
+++ b/backend/tests/test_skills_ab_eval.py
@@ -1,0 +1,13 @@
+"""Mocked quality-lift A/B scaffold（无真实 LLM 费用）。"""
+
+from __future__ import annotations
+
+from app.forge.skills.ab_eval import run_mocked_quality_lift_ab
+
+
+def test_mocked_quality_lift_ab_shows_body_reduction() -> None:
+    report = run_mocked_quality_lift_ab()
+    assert len(report.cases) >= 4
+    assert report.mock_llm_calls == 0
+    assert report.avg_reduction >= 0.2
+    assert all(c.top_skill for c in report.cases)

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -1,6 +1,6 @@
 # Forge Runtime 演进计划 v2
 
-* Status: In Progress（**P0–P5 MVP 主体已落地**；P3 E2B 生产切换、P4.5 Semantic、Pending ADR 细项仍 gated）
+* Status: In Progress（**P0–P5 代码侧 MVP 已闭合**；剩余主要为人工门禁：ADR Accept、E2B 生产切换 Go、真实 LLM A/B、全量 Load）
 * Date: 2026-08-15
 * Owners: TBD
 * Reviewers: TBD
@@ -25,7 +25,7 @@
   * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关；code_qa 传 `engine_id` hints）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**；**Load smoke**（并发 Exact Cache / Skill / tier）
-  * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / **全量** Load·Chaos 实验窗
+  * **仍 gated（人工/实验）** 真实 LLM quality-lift A/B / E2B 生产默认切换 / ADR-02·03·04 Accept 签字（见 `docs/adr/ACCEPT-CHECKLIST.md`）/ 全量 Load·Chaos
 
 ---
 

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -22,7 +22,7 @@
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）；**离线 eval 套件**（precision@1 / member hit / body reduction lift）
-  * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关）；data-flow / benchmark 清单
+  * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关；code_qa 传 `engine_id` hints）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**；**Load smoke**（并发 Exact Cache / Skill / tier）
   * **仍 gated** 带真实 LLM 的 quality-lift A/B / E2B 生产切换（SDK 已接但默认关）/ ADR Accept 签字 / **全量** Load·Chaos 实验窗

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -656,7 +656,7 @@ Art 不得看见 billing / sandbox admin / 内部 security runbook。
 * Skill 变更使依赖其的 cache key 失效（若已上 Exact Cache）
 * 离线 eval：selection precision / quality lift；无 lift 则停扩 catalog
 
-**本仓库**：`forge/skills/offline_eval.py` + `tests/test_skills_offline_eval.py`（≥12 fixtures；precision@1 / member hit / vs 全量注入 body reduction；Art 跨域违规=0）。真实 LLM A/B quality-lift 仍 gated。
+**本仓库**：`forge/skills/offline_eval.py` + `tests/test_skills_offline_eval.py`（≥12 fixtures；precision@1 / member hit / vs 全量注入 body reduction；Art 跨域违规=0）。`skills/ab_eval.py` 提供 **mock** quality-lift A/B（无真实 LLM）。真实付费 A/B 仍 gated。
 
 ---
 

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -25,6 +25,7 @@
   * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关；code_qa 传 `engine_id` hints）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**；**Load smoke**（并发 Exact Cache / Skill / tier）
+  * **Closeout batch（本 PR）** tier `engine_id` hints / HITL tier restore / ADR Accept+Flag 清单 / diagnose playtest policy / mock quality-lift A/B / ADR-04 SoT 守门 / semantic shadow 并发 / catalog hash 稳定性
   * **仍 gated（人工/实验）** 真实 LLM quality-lift A/B / E2B 生产默认切换 / ADR-02·03·04 Accept 签字（见 `docs/adr/ACCEPT-CHECKLIST.md`）/ 全量 Load·Chaos
 
 ---

--- a/docs/adr/ACCEPT-CHECKLIST.md
+++ b/docs/adr/ACCEPT-CHECKLIST.md
@@ -1,0 +1,59 @@
+# ADR Accept Checklist（人工签字门禁）
+
+> 本文件**不**把 ADR-02/03/04 标为 Accepted。仅汇总证据，供 Owner/Reviewer 签字后改各 ADR 头状态。
+
+## 总原则
+
+* 代码已按 **Proposed** 草案 interim 落地 ≠ Accept。
+* Accept 需要产品/合规/运维明确签字；AI/实现者不得单方改 Status。
+
+---
+
+## ADR-02 Preference Retention
+
+| 检查项 | 证据 / 位置 | 签字 |
+| --- | --- | --- |
+| Explicit 不随 Game 删除清除 | `memory/preferences.py` + API clear | ☐ |
+| Inferred 不覆盖 Explicit；默认 flag 关 | `memory_preferences_inferred=false` | ☐ |
+| 用户可见保留文案（设置/清除偏好）已评审 | 前端 copy / 隐私说明 | ☐ |
+| 是否需要 `evidence_game_id` 已拍板 | ADR-02 Acceptance criteria | ☐ |
+
+**Accept 阻塞：** 产品/法务文案签字。
+
+---
+
+## ADR-03 Sandbox Provider Strategy
+
+| 检查项 | 证据 / 位置 | 签字 |
+| --- | --- | --- |
+| 生产默认 Docker | `sandbox_backend` / ADR-03 | ☐ |
+| E2B SDK 仅 PoC，默认关 | `sandbox_e2b_enabled`、`--extra e2b` | ☐ |
+| Data-flow / 出境风险已评审 | [sandbox-data-flow.md](./sandbox-data-flow.md) | ☐ |
+| Benchmark Go 指标未同时满足前不切默认 | [sandbox-e2b-benchmark.md](../sandbox-e2b-benchmark.md) | ☐ |
+| HITL destroy+restore 行为符合预期 | `sandbox/lifecycle.py` | ☐ |
+
+**Accept 阻塞：** 运维确认国内网络与成本；合规确认数据流。  
+**明确：** Accept ADR-03 ≠ 默认切 E2B。
+
+---
+
+## ADR-04 Conversation Storage Migration
+
+| 检查项 | 证据 / 位置 | 签字 |
+| --- | --- | --- |
+| `forge_messages` 为会话 SoT | `models/forge_message.py`、`GET` forge messages | ☐ |
+| ContextBuilder 只读本 Game 消息 | `memory/loader.py` | ☐ |
+| 无并行「第二套会话表」写入正式路径 | 代码检索 / review | ☐ |
+| 历史迁移（若有旧表）完成或声明 N/A | 迁移脚本 / 运维 | ☐ |
+
+**Accept 阻塞：** 确认无遗留会话双写；迁移 N/A 或已完成。
+
+---
+
+## 签字区（人工）
+
+| ADR | Reviewer | Date | Decision |
+| --- | --- | --- | --- |
+| ADR-02 | | | Accept / Defer / Reject |
+| ADR-03 | | | Accept / Defer / Reject |
+| ADR-04 | | | Accept / Defer / Reject |

--- a/docs/adr/FLAG-INVENTORY.md
+++ b/docs/adr/FLAG-INVENTORY.md
@@ -1,0 +1,27 @@
+# Forge Runtime Feature Flag Inventory
+
+* Status: Operator reference（默认值偏安全；改生产前对照 ADR / 计划 Go·No-Go）
+* Related: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)、evolution plan
+
+| Flag | Default | Risk if flipped | Notes |
+| --- | --- | --- | --- |
+| `sandbox_backend` | `local`（生产应 `docker`） | 隔离失效 / 出境 | ADR-03；勿默认 `e2b` |
+| `sandbox_e2b_enabled` | `false` | 源码出境 | 需 `--extra e2b` + key |
+| `sandbox_tier_auto` | `false` | 过降档导致 OOM | 开后读 engine/体量/近期失败 |
+| `memory_context_builder` | `true` | 关则不注入 recent turns | 仍走 ContextBuilder |
+| `memory_context_enforcement` | `true` | 兼容残留；不再切 concat | concat 已拆除 |
+| `memory_preferences` | `true` | 关则无 Explicit 注入 | |
+| `memory_preferences_inferred` | `false` | 弱信号污染 | 不覆盖 Explicit |
+| `memory_session_summary` | `true` | | |
+| `memory_session_summary_llm` | `false` | 额外费用 | 失败回落确定性 |
+| `skills_router_enabled` | `true` | | Policy 始终注入 |
+| `skills_llm_selection` | `false` | 费用 / 误选 | Policy 永不 LLM |
+| `exact_cache_enabled` | `true` | | 仅白名单节点 |
+| `semantic_cache_shadow_enabled` | `false` | Redis 膨胀 | **禁止** direct hit |
+| `reliability_node_timeout` | `true` | | |
+| `reliability_idempotent_side_effects` | `true` | 重复副作用 | |
+
+## 明确禁止（无 flag 可开）
+
+* Semantic Cache **direct hit**（`semantic_direct_hit_allowed()` ≡ False）
+* 生产默认 `sandbox_backend=e2b`（须 ADR-03 Accept + benchmark 表填满）

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,5 @@ Full narrative lives in [2026-08-15-forge-runtime-evolution-plan.md](../2026-08-
 | [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Proposed** |
 | [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Proposed** |
 | [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** |
+
+人工 Accept 门禁清单（不自动改状态）：[ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,4 +11,5 @@ Full narrative lives in [2026-08-15-forge-runtime-evolution-plan.md](../2026-08-
 | [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Proposed** |
 | [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** |
 
-人工 Accept 门禁清单（不自动改状态）：[ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)
+人工 Accept 门禁清单（不自动改状态）：[ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)  
+Feature flag 默认值清单：[FLAG-INVENTORY.md](./FLAG-INVENTORY.md)

--- a/docs/adr/sandbox-data-flow.md
+++ b/docs/adr/sandbox-data-flow.md
@@ -38,7 +38,11 @@ perimeter. Do **not** enable for production until ADR-03 Go criteria are Accepte
 ```text
 active SandboxSession
   → destroy_for_hitl (explicit kill; no billing idle session)
-  → checkpoint.sandbox_hitl metadata
+  → checkpoint.sandbox_hitl metadata (includes tier)
   → user resumes
-  → restore_after_hitl (create fresh session; no mandatory snapshot)
+  → restore_sandbox_from_checkpoint / restore_after_hitl(tier=…)
+     (fresh session; no mandatory snapshot)
 ```
+
+Oneshoot CodeQa paths may skip explicit restore and simply `create` on next execute;
+`restore_sandbox_from_checkpoint` exists for callers that hold a live session across HITL.


### PR DESCRIPTION
## Summary

Code-side closeout **plus gate harnesses** for remaining human/experimental items (still no unilateral ADR Accept, no production E2B default, no paid LLM by default).

### Closeout (earlier commits)
Tier engine hints, HITL restore, Accept checklist, diagnose policy, mock A/B, ADR-04 SoT, semantic shadow concurrency, flag inventory, etc.

### Gate supplements (this push)
1. \eat(adr): add machine evidence checks without auto-Accept\
2. \eat(sandbox): add local benchmark dry-run harness for E2B Go prep\
3. \eat(skills): gate optional LLM quality-lift A/B behind flag\
4. \	est(forge): add opt-in extended load marker suite\

## Explicit non-goals (still require humans / live runs)
- Marking ADR-02/03/04 as **Accepted**
- Setting production \sandbox_backend=e2b\
- Calling real paid LLMs in CI
- Multi-hour production soak / chaos windows

## How to exercise gates
- ADR machine evidence: \uv run pytest tests/test_adr_evidence.py -q\
- E2B prep dry-run: \uv run python scripts/sandbox_benchmark_dryrun.py --rounds 5\
- Live E2B (opt-in): \E2B_BENCHMARK_LIVE=1\ + keys
- LLM A/B path: \skills_quality_lift_llm=true\ + inject \complete\
- Extended load: \uv run pytest -m load\

## Test plan
- [x] New gate suites (adr_evidence, ab_eval LLM gate, benchmark dry-run, load extended)
- [ ] CI green
- [ ] Human sign-off on Accept checklist before any production flag flips
