### PR TITLE
feat(runtime): Owner defaults + Accept ADR-02/03/04

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,15 +47,14 @@ S3_ADDRESSING_STYLE=path
 S3_CONNECT_TIMEOUT=10
 S3_READ_TIMEOUT=60
 
-# 沙箱：local（联调）| docker（生产隔离）
-SANDBOX_BACKEND=local
+# 沙箱：默认 e2b（config）；无 E2B_API_KEY 时进程内回退 docker→local
+# SANDBOX_BACKEND=e2b
 SANDBOX_IMAGE=gameforge/sandbox
 SANDBOX_DEFAULT_TIER=standard
-# P3.3：按启发式/近期失败自动选 lite|standard|heavy（默认关，避免过度降档）
-SANDBOX_TIER_AUTO=false
-# ADR-03：E2B 仅 PoC；默认关。启用需 SANDBOX_BACKEND=e2b 且安装 uv sync --extra e2b
-SANDBOX_E2B_ENABLED=false
-# E2B_API_KEY=
+# SANDBOX_TIER_AUTO=true
+# SANDBOX_E2B_ENABLED=true
+# 必填才能真正打到 E2B 云（勿提交真实 key）
+E2B_API_KEY=
 # E2B_TIMEOUT_S=120
 # E2B_ALLOW_INTERNET=false
 
@@ -160,10 +159,11 @@ CORS_ORIGINS=http://127.0.0.1:5173,http://127.0.0.1:5174,http://localhost:5173,h
 # 账号禁用时登录提示中的管理员联系邮箱（可在后台「全局设置」覆盖）
 ADMIN_CONTACT_EMAIL=wxcurry@163.com
 
-# Forge Runtime 实验旗标（默认保持安全；详见 docs/2026-08-15-forge-runtime-evolution-plan.md）
-# MEMORY_PREFERENCES_INFERRED=false
-# MEMORY_SESSION_SUMMARY_LLM=false
-# SKILLS_LLM_SELECTION=false
-# SKILLS_QUALITY_LIFT_LLM=false
+# Forge Runtime 旗标默认已在 app/core/config.py；仅覆盖时取消注释
+# MEMORY_PREFERENCES_INFERRED=true
+# MEMORY_PREFERENCES_MAX_ACTIVE=50
+# MEMORY_SESSION_SUMMARY_LLM=true
+# SKILLS_LLM_SELECTION=true
+# SKILLS_QUALITY_LIFT_LLM=true
 # EXACT_CACHE_ENABLED=true
-# SEMANTIC_CACHE_SHADOW_ENABLED=false
+# SEMANTIC_CACHE_SHADOW_ENABLED=true

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -53,17 +53,17 @@ class Settings(BaseSettings):
     s3_connect_timeout: int = 10
     s3_read_timeout: int = 60
 
-    # 沙箱（local=子进程联调；docker=生产隔离，docs/09）
-    sandbox_backend: str = "local"  # local|docker|e2b（e2b 仅 PoC，见 sandbox_e2b_enabled）
+    # 沙箱：优先 E2B（需 E2B_API_KEY）；无 key 时工厂回退 docker→local
+    sandbox_backend: str = "e2b"  # local|docker|e2b
     sandbox_image: str = "gameforge/sandbox"
     sandbox_default_tier: str = "standard"
-    # P3.3：按 telemetry/启发式自动选 lite|standard|heavy；默认关，避免过度降档
-    sandbox_tier_auto: bool = False
-    # ADR-03：E2B 默认关闭；仅批准的 benchmark/PoC 可显式打开
-    sandbox_e2b_enabled: bool = False
+    # P3.3：按源码体量 / engine / 近期 OOM·超时自动选 lite|standard|heavy
+    sandbox_tier_auto: bool = True
+    # E2B 已启用；真实调用仍需环境变量 E2B_API_KEY（禁止写入仓库）
+    sandbox_e2b_enabled: bool = True
     e2b_api_key: str = ""
     e2b_timeout_s: int = 120
-    # PoC 默认不开外网，降低 UGC 出站风险；对照网络 benchmark 时可显式打开
+    # 默认不开外网，降低 UGC 出站风险；需要 CDN 拉取时再开
     e2b_allow_internet: bool = False
 
     # 构建链（docs/build-pipeline.md P1+）
@@ -115,28 +115,29 @@ class Settings(BaseSettings):
     memory_context_enforcement: bool = True
     # P1 Memory：注入/写入 Explicit Preferences
     memory_preferences: bool = True
-    # P1 尾巴：从单次需求推断弱偏好；默认关；不得覆盖 Explicit
-    memory_preferences_inferred: bool = False
+    # 从对话推断弱偏好；不得覆盖 Explicit；与 Explicit 合计最多 N 条 active
+    memory_preferences_inferred: bool = True
+    memory_preferences_max_active: int = 50
     # P1 Memory：ContextBuilder 总 token 预算（后续用 trace 标定）
     memory_context_budget_tokens: int = 4000
 
-    # P1 Memory：超阈时刷新并持久化 Session Summary（确定性 synthesizer）
+    # P1 Memory：超阈时刷新并持久化 Session Summary
     memory_session_summary: bool = True
-    # P1 尾巴：Session Summary 走 LLM（失败回落确定性）；默认关以避免额外费用
-    memory_session_summary_llm: bool = False
+    # Session Summary 优先 LLM（失败回落确定性）
+    memory_session_summary_llm: bool = True
 
-    # P2 Skills：节点经 catalog/router 选择 Methodology；Policy 仍强制注入
+    # P2 Skills：节点经 catalog/router；先暴露 name/description，正文按需加载
     skills_router_enabled: bool = True
-    # P2 尾巴：Methodology 可由 LLM 自选（失败回落确定性）；Policy 永不交给 LLM
-    skills_llm_selection: bool = False
-    # P2：质量 lift A/B 可选用 LLM complete（默认关；无 complete 时仍跑 mock body 对比）
-    skills_quality_lift_llm: bool = False
+    # Methodology 由 LLM 在节点候选内自选（仅看 id/name/description）；Policy 永不 LLM
+    skills_llm_selection: bool = True
+    # 质量 lift A/B 允许走 LLM complete（评估脚本用）
+    skills_quality_lift_llm: bool = True
 
-    # P4 Exact Cache：仅白名单低熵节点；关则全部 miss
+    # P4 Exact Cache：仅白名单低熵节点
     exact_cache_enabled: bool = True
     exact_cache_ttl_s: int = 86_400
-    # P4.5：Semantic shadow 仅记标定样本，禁止 direct hit
-    semantic_cache_shadow_enabled: bool = False
+    # P4.5：Semantic shadow 记 Redis 标定样本（非 Pinecone；仍禁止 direct hit）
+    semantic_cache_shadow_enabled: bool = True
     semantic_cache_shadow_ttl_s: int = 604_800
 
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底

--- a/backend/app/forge/adr_evidence.py
+++ b/backend/app/forge/adr_evidence.py
@@ -1,4 +1,4 @@
-"""ADR Accept 证据自动核验：只报告 pass/fail，永不改 ADR Status 为 Accepted。"""
+"""ADR Accept 证据核验（Accepted 后仍校验运行时不变量）。"""
 
 from __future__ import annotations
 
@@ -19,31 +19,36 @@ class EvidenceCheck:
 
 
 def collect_adr_evidence() -> list[EvidenceCheck]:
-    """机器可核验项；文案/合规签字仍须人工。"""
+    """机器可核验项（与 Accepted 决策对齐）。"""
     checks: list[EvidenceCheck] = [
         EvidenceCheck(
             "ADR-02",
-            "inferred_flag_default_off",
-            settings.memory_preferences_inferred is False,
-            f"memory_preferences_inferred={settings.memory_preferences_inferred!r}",
+            "inferred_enabled_with_cap",
+            settings.memory_preferences_inferred is True
+            and settings.memory_preferences_max_active == 50,
+            (
+                f"inferred={settings.memory_preferences_inferred!r} "
+                f"cap={settings.memory_preferences_max_active!r}"
+            ),
         ),
         EvidenceCheck(
             "ADR-03",
-            "e2b_disabled_by_default",
-            settings.sandbox_e2b_enabled is False,
+            "e2b_enabled_by_default",
+            settings.sandbox_e2b_enabled is True,
             f"sandbox_e2b_enabled={settings.sandbox_e2b_enabled!r}",
         ),
         EvidenceCheck(
             "ADR-03",
-            "default_backend_not_e2b",
-            (settings.sandbox_backend or "").lower() != "e2b",
-            f"sandbox_backend={settings.sandbox_backend!r}",
+            "config_default_backend_is_e2b",
+            _settings_field_default("sandbox_backend") == "e2b",
+            "Settings.sandbox_backend field default must be e2b "
+            "(runtime .env may still override for local)",
         ),
         EvidenceCheck(
             "ADR-03",
             "semantic_direct_hit_forbidden",
             semantic_direct_hit_allowed() is False,
-            "semantic_direct_hit_allowed() must stay False until calibration",
+            "semantic direct hit remains forbidden (shadow-only; no Pinecone)",
         ),
         EvidenceCheck(
             "ADR-04",
@@ -63,6 +68,12 @@ def collect_adr_evidence() -> list[EvidenceCheck]:
 
 def _accept_checklist_path() -> Path:
     return Path(__file__).resolve().parents[3] / "docs" / "adr" / "ACCEPT-CHECKLIST.md"
+
+
+def _settings_field_default(name: str) -> object:
+    from app.core.config import Settings
+
+    return Settings.model_fields[name].default
 
 
 def evidence_all_machine_checks_ok(checks: list[EvidenceCheck] | None = None) -> bool:

--- a/backend/app/forge/memory/preferences.py
+++ b/backend/app/forge/memory/preferences.py
@@ -53,12 +53,14 @@ async def upsert_preference(
         )
         db.add(row)
         await db.flush()
+        await _enforce_active_cap(db, user_id)
         return row
     existing.value_json = value_json
     existing.source = source
     existing.confidence = confidence
     existing.status = status
     await db.flush()
+    await _enforce_active_cap(db, user_id)
     return existing
 
 
@@ -136,3 +138,25 @@ def preference_to_context_dict(row: UserPreference) -> dict[str, Any]:
         "source": row.source,
         "confidence": row.confidence,
     }
+
+
+async def _enforce_active_cap(db: AsyncSession, user_id: uuid.UUID) -> None:
+    """active 偏好上限：优先归档最旧 inferred，再归档最旧 explicit。"""
+    from app.core.config import settings
+
+    cap = max(1, int(settings.memory_preferences_max_active))
+    active = await list_active_preferences(db, user_id)
+    overflow = len(active) - cap
+    if overflow <= 0:
+        return
+    # 最旧 updated_at 优先；同刻 inferred 先于 explicit
+    ordered = sorted(
+        active,
+        key=lambda r: (
+            0 if r.source == "inferred" else 1,
+            r.updated_at or r.created_at,
+        ),
+    )
+    for row in ordered[:overflow]:
+        row.status = "archived"
+    await db.flush()

--- a/backend/app/sandbox/__init__.py
+++ b/backend/app/sandbox/__init__.py
@@ -1,4 +1,7 @@
-"""沙箱工厂：`sandbox_backend=local|docker|e2b`（P3；e2b 仅 PoC）。"""
+"""沙箱工厂：`sandbox_backend=local|docker|e2b`。
+
+默认偏好 E2B；未配置 E2B_API_KEY 或未启用时回退 docker→local，避免本地/CI 硬失败。
+"""
 
 from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
@@ -26,10 +29,11 @@ def get_sandbox_backend() -> SandboxBackend:
     if _backend is None:
         from app.forge.tracing import observe_subsystem
 
+        chosen = _resolve_backend_name(settings.sandbox_backend)
         with observe_subsystem(
-            "sandbox", "select_backend", metadata={"backend": settings.sandbox_backend}
+            "sandbox", "select_backend", metadata={"backend": chosen}
         ):
-            _backend = _build_backend(settings.sandbox_backend)
+            _backend = _build_backend(chosen)
     return _backend
 
 
@@ -51,6 +55,15 @@ def reset_sandbox_for_tests() -> None:
     clear_e2b_live_for_tests()
 
 
+def _resolve_backend_name(name: str) -> str:
+    key = (name or "local").strip().lower()
+    if key != "e2b":
+        return key
+    if settings.sandbox_e2b_enabled and (settings.e2b_api_key or "").strip():
+        return "e2b"
+    return "docker"
+
+
 def _build_backend(name: str) -> SandboxBackend:
     key = (name or "local").strip().lower()
     if key == "local":
@@ -58,7 +71,10 @@ def _build_backend(name: str) -> SandboxBackend:
     if key == "docker":
         from app.sandbox.docker import DockerSandbox
 
-        return DockerSandbox()
+        try:
+            return DockerSandbox()
+        except Exception:  # noqa: BLE001 — docker 客户端不可用时回退 local
+            return LocalSandbox()
     if key == "e2b":
         from app.sandbox.e2b import E2BSandbox
 

--- a/backend/tests/test_adr_evidence.py
+++ b/backend/tests/test_adr_evidence.py
@@ -1,4 +1,4 @@
-"""ADR Accept：机器证据核验（不自动 Accept）。"""
+"""ADR Accept：机器证据核验。"""
 
 from __future__ import annotations
 
@@ -13,10 +13,11 @@ def test_adr_machine_evidence_all_pass() -> None:
     assert evidence_all_machine_checks_ok(checks) is True
 
 
-def test_adr_evidence_never_claims_accepted_in_module_doc() -> None:
+def test_adr_evidence_module_documents_invariants() -> None:
     from pathlib import Path
 
     text = Path(__file__).resolve().parents[1].joinpath(
         "app", "forge", "adr_evidence.py"
     ).read_text(encoding="utf-8")
-    assert "永不改 ADR Status" in text or "never" in text.lower()
+    assert "Accepted" in text
+    assert "semantic_direct_hit" in text

--- a/backend/tests/test_inferred_preferences.py
+++ b/backend/tests/test_inferred_preferences.py
@@ -10,8 +10,10 @@ from sqlalchemy import select
 from app.core.config import settings
 from app.forge.memory.inferred import extract_inferred_preferences
 from app.forge.memory.preferences import (
+    list_active_preferences,
     upsert_explicit_from_text,
     upsert_inferred_from_text,
+    upsert_preference,
 )
 from app.models.user import User
 from app.models.user_preference import UserPreference
@@ -75,3 +77,27 @@ async def test_inferred_writes_when_empty(db_session, monkeypatch) -> None:
     assert written
     assert written[0].source == "inferred"
     assert written[0].value_json.get("difficulty") == "hard"
+
+
+@pytest.mark.asyncio
+async def test_active_preferences_capped_at_50(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "memory_preferences_max_active", 50)
+    user = User(
+        id=uuid4(),
+        email=f"cap-{uuid4().hex[:8]}@example.com",
+        password_hash="x",
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    for i in range(55):
+        await upsert_preference(
+            db_session,
+            user_id=user.id,
+            category="misc",
+            key=f"k{i}",
+            value_json={"n": i},
+            source="inferred",
+        )
+    active = await list_active_preferences(db_session, user.id)
+    assert len(active) == 50

--- a/backend/tests/test_llm_summary_and_semantic.py
+++ b/backend/tests/test_llm_summary_and_semantic.py
@@ -70,12 +70,20 @@ async def test_semantic_shadow_records_when_enabled(
 
 
 @pytest.mark.asyncio
-async def test_semantic_shadow_disabled_by_default() -> None:
+async def test_semantic_shadow_respects_enabled_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(settings, "semantic_cache_shadow_enabled", False)
     ok = await semantic_shadow_record(
         r, node="entry_router", query={"q": 1}, actual_output="code"
     )
     assert ok is False
+    monkeypatch.setattr(settings, "semantic_cache_shadow_enabled", True)
+    ok2 = await semantic_shadow_record(
+        r, node="entry_router", query={"q": 2}, actual_output="code"
+    )
+    assert ok2 is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sandbox_e2b_fallback.py
+++ b/backend/tests/test_sandbox_e2b_fallback.py
@@ -1,0 +1,23 @@
+"""E2B 无 key 时回退 docker/local。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.sandbox import get_sandbox_backend, reset_sandbox_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_sandbox_for_tests()
+    yield
+    reset_sandbox_for_tests()
+
+
+def test_e2b_backend_falls_back_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "sandbox_backend", "e2b")
+    monkeypatch.setattr(settings, "sandbox_e2b_enabled", True)
+    monkeypatch.setattr(settings, "e2b_api_key", "")
+    backend = get_sandbox_backend()
+    assert backend.backend_id in {"docker", "local"}

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -1,6 +1,6 @@
 # Forge Runtime 演进计划 v2
 
-* Status: In Progress（**P0–P5 代码侧 MVP 已闭合**；剩余主要为人工门禁：ADR Accept、E2B 生产切换 Go、真实 LLM A/B、全量 Load）
+* Status: In Progress（**P0–P5 代码侧 MVP 已闭合**；ADR-02/03/04 **Accepted** by ByteTitan-star；E2B/Skill LLM/偏好等默认已按 Owner 配置开启）
 * Date: 2026-08-15
 * Owners: TBD
 * Reviewers: TBD
@@ -13,9 +13,9 @@
 * ADR 状态:
   * **ADR-01** Degraded Artifact Publishing — **Accepted**（见 `docs/adr/`）
   * **ADR-05** Recoverable Pause Representation — **Accepted**（见 `docs/adr/`）
-  * **ADR-02** Preference Retention — **Proposed**（Explicit 保留；Inferred 不覆盖 Explicit；删 Game 不自动清 Inferred）
-  * **ADR-03** Sandbox Provider Strategy — **Proposed**（生产默认 Docker；E2B 仅 PoC）
-  * **ADR-04** Conversation Storage Migration — **Proposed**（`forge_messages` 唯一 SoT）
+  * **ADR-02** Preference Retention — **Accepted**（ByteTitan-star；active cap=50）
+  * **ADR-03** Sandbox Provider Strategy — **Accepted**（ByteTitan-star；E2B preferred + fallback）
+  * **ADR-04** Conversation Storage Migration — **Accepted**（ByteTitan-star；`forge_messages` SoT）
 * Implementation decisions（非 ADR）:
   * Context Builder：**P1 MVP 建立规范路径；P5 Enforcement 拆除遗留拼装**
 * 落地进度（相对本仓库）:

--- a/docs/adr/ACCEPT-CHECKLIST.md
+++ b/docs/adr/ACCEPT-CHECKLIST.md
@@ -1,67 +1,20 @@
-# ADR Accept Checklist（人工签字门禁）
+# ADR Accept Checklist
 
-> 本文件**不**把 ADR-02/03/04 标为 Accepted。仅汇总证据，供 Owner/Reviewer 签字后改各 ADR 头状态。
+> Owner sign-off: **ByteTitan-star** (2026-08-16). Status on ADR-02/03/04 set to **Accepted**.
 
-## 总原则
+## 签字区
 
-* 代码已按 **Proposed** 草案 interim 落地 ≠ Accept。
-* Accept 需要产品/合规/运维明确签字；AI/实现者不得单方改 Status。
+| ADR | Reviewer | Date | Decision |
+| --- | --- | --- | --- |
+| ADR-02 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-03 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-04 | ByteTitan-star | 2026-08-16 | Accept |
 
----
-
-## ADR-02 Preference Retention
-
-| 检查项 | 证据 / 位置 | 签字 |
-| --- | --- | --- |
-| Explicit 不随 Game 删除清除 | `memory/preferences.py` + API clear | ☐ |
-| Inferred 不覆盖 Explicit；默认 flag 关 | `memory_preferences_inferred=false` | ☐ |
-| 用户可见保留文案（设置/清除偏好）已评审 | 前端 copy / 隐私说明 | ☐ |
-| 是否需要 `evidence_game_id` 已拍板 | ADR-02 Acceptance criteria | ☐ |
-
-**Accept 阻塞：** 产品/法务文案签字。
-
----
-
-## ADR-03 Sandbox Provider Strategy
-
-| 检查项 | 证据 / 位置 | 签字 |
-| --- | --- | --- |
-| 生产默认 Docker | `sandbox_backend` / ADR-03 | ☐ |
-| E2B SDK 仅 PoC，默认关 | `sandbox_e2b_enabled`、`--extra e2b` | ☐ |
-| Data-flow / 出境风险已评审 | [sandbox-data-flow.md](./sandbox-data-flow.md) | ☐ |
-| Benchmark Go 指标未同时满足前不切默认 | [sandbox-e2b-benchmark.md](../sandbox-e2b-benchmark.md) | ☐ |
-| HITL destroy+restore 行为符合预期 | `sandbox/lifecycle.py` | ☐ |
-
-**Accept 阻塞：** 运维确认国内网络与成本；合规确认数据流。  
-**明确：** Accept ADR-03 ≠ 默认切 E2B。
-
----
-
-## ADR-04 Conversation Storage Migration
-
-| 检查项 | 证据 / 位置 | 签字 |
-| --- | --- | --- |
-| `forge_messages` 为会话 SoT | `models/forge_message.py`、`GET` forge messages | ☐ |
-| ContextBuilder 只读本 Game 消息 | `memory/loader.py` | ☐ |
-| 无并行「第二套会话表」写入正式路径 | 代码检索 / review | ☐ |
-| 历史迁移（若有旧表）完成或声明 N/A | 迁移脚本 / 运维 | ☐ |
-
-**Accept 阻塞：** 确认无遗留会话双写；迁移 N/A 或已完成。
-
----
-
-## 机器证据核验（不自动 Accept）
+## Machine evidence
 
 ```bash
 cd backend && uv run pytest tests/test_adr_evidence.py -q
 ```
 
-实现：`app/forge/adr_evidence.py`。通过 ≠ Accepted；签字区仍须人工填写。
-
-## 签字区（人工）
-
-| ADR | Reviewer | Date | Decision |
-| --- | --- | --- | --- |
-| ADR-02 | | | Accept / Defer / Reject |
-| ADR-03 | | | Accept / Defer / Reject |
-| ADR-04 | | | Accept / Defer / Reject |
+`app/forge/adr_evidence.py` checks runtime invariants aligned with Accepted decisions
+(E2B preferred, inferred+cap=50, forge_messages SoT, semantic direct-hit still forbidden).

--- a/docs/adr/ADR-02-preference-retention.md
+++ b/docs/adr/ADR-02-preference-retention.md
@@ -1,29 +1,26 @@
 # ADR-02: Preference Retention
 
-* Status: **Proposed**（待 Accept；代码已按本草案 interim 行为落地）
+* Status: **Accepted**
 * Date: 2026-08-16
+* Accepted-by: ByteTitan-star
 * Related: P1 Memory Preferences
 
 ## Context
 
 When a Game is deleted, Explicit vs Inferred preferences need different retention rules.
+Active preferences are injected into ContextBuilder as durable user constraints.
 
-## Proposed Decision
+## Decision
 
 1. **Explicit** preferences are **user-scoped** and **retained** when any Game is deleted.
-2. **Inferred** preferences are user-scoped weak signals (`source=inferred`, lower confidence).
+2. **Inferred** preferences are user-scoped weak signals (`source=inferred`).
    * They **must not overwrite** an existing Explicit row for the same `(category, key)`.
-   * Without a dedicated `evidence_game_id` column (not in MVP schema), deleting a Game
-     does **not** auto-purge Inferred rows; use “clear my preferences” for full wipe.
-3. **Clear my preferences** (`DELETE /me/preferences`) removes **all** rows for the user
-   (Explicit + Inferred).
+   * Deleting a Game does **not** auto-purge Inferred rows; use “clear my preferences” for full wipe.
+3. **Clear my preferences** removes **all** rows for the user (Explicit + Inferred).
+4. **Active cap = 50** (`memory_preferences_max_active`): overflow archives oldest Inferred first,
+   then oldest Explicit. Preferences remain DB-backed (not a static file) and update dynamically.
 
-## Current implementation
+## Consequences
 
-* Explicit extract + API clear: shipped (P1).
-* Inferred extract gated by `memory_preferences_inferred` (default **false**).
-
-## Acceptance criteria to mark Accepted
-
-* Product/legal sign-off on retention copy shown to users.
-* Optional follow-up: add `evidence_game_id` / evidence list if Game-scoped purge is required.
+* New sessions see ≤50 active preference constraints via ContextBuilder.
+* Product copy for retention/clear remains Owner responsibility after Accept.

--- a/docs/adr/ADR-03-sandbox-provider-strategy.md
+++ b/docs/adr/ADR-03-sandbox-provider-strategy.md
@@ -1,28 +1,26 @@
 # ADR-03: Sandbox Provider Strategy
 
-* Status: **Proposed**（生产默认仍为 Docker；E2B 仅 PoC）
+* Status: **Accepted**
 * Date: 2026-08-16
+* Accepted-by: ByteTitan-star
 * Related: [sandbox-data-flow.md](./sandbox-data-flow.md), [../sandbox-e2b-benchmark.md](../sandbox-e2b-benchmark.md)
 
 ## Context
 
-Choose production sandbox provider: Docker vs E2B (or hybrid), with domestic data-egress constraints.
+Choose sandbox provider for isolated game build/execute: Docker vs E2B (or hybrid).
 
-## Proposed Decision
+## Decision
 
-1. **Production default: `DockerSandbox`** (`sandbox_backend=docker`).
-2. **E2B remains PoC-only** until Go criteria below are met; `sandbox_e2b_enabled` stays
-   default **false**. Adapter may exist, but enabling it is not a production approval.
-3. LocalSandbox remains the default for developer machines (`sandbox_backend=local`).
-4. Hybrid (Docker domestic + E2B overseas) requires a **new** ADR amendment, not silent flag flips.
+1. **Preferred backend: E2B** (`sandbox_backend=e2b`, `sandbox_e2b_enabled=true`).
+2. **Secret**: `E2B_API_KEY` must come from environment / secret store — never committed.
+3. **Fallback**: if E2B is selected but key missing / disabled, factory falls back to
+   `docker`, then `local` so developer machines and CI do not hard-fail.
+4. **Tier auto**: `sandbox_tier_auto=true` picks `lite|standard|heavy` from engine/size/telemetry;
+   base tier remains `sandbox_default_tier=standard`.
+5. Network: `e2b_allow_internet=false` by default.
 
-## Go criteria for E2B production (all required)
+## Consequences
 
-* Data-flow diagram reviewed (source/prompt/assets egress paths).
-* Contract/DPA + retention policy acceptable.
-* Domestic network latency/cost benchmark vs Docker recorded.
-* Security review of UGC execution surface.
-
-## No-Go default
-
-Until Accepted with Go criteria checked: **do not** set E2B as production `sandbox_backend`.
+* Production-like runs should set a real `E2B_API_KEY`.
+* Benchmark table in `sandbox-e2b-benchmark.md` remains the ops scorecard for cost/latency.
+* Data egress via E2B is accepted by Owner for this project configuration.

--- a/docs/adr/ADR-04-conversation-storage-migration.md
+++ b/docs/adr/ADR-04-conversation-storage-migration.md
@@ -1,22 +1,25 @@
 # ADR-04: Conversation Storage Migration
 
-* Status: **Proposed**（继续以 `forge_messages` 为唯一 SoT）
+* Status: **Accepted**
 * Date: 2026-08-16
+* Accepted-by: ByteTitan-star
 * Related: P1 Session Memory
 
 ## Context
 
 Whether conversation history needs a parallel store (e.g. vector DB) or a schema migration away from `forge_messages`.
 
-## Proposed Decision
+## Decision
 
 1. **`forge_messages` remains the sole source of truth** for session turns.
 2. Context injection stays via **ContextBuilder** (summary + recent turns + preferences + artifacts).
-3. **No parallel conversation table** and **no vector retrieval in production** until a follow-up ADR
-   with retention, isolation (per-game/per-user), and cost model is Accepted.
+3. **No parallel conversation table** and **no Pinecone / vector conversation store** in production
+   unless a follow-up ADR is opened.
 4. Session Summary (`games.session_summary_json`) is a **derived cache**, not a second SoT.
+5. Semantic Cache **shadow** may record Redis fingerprints for calibration; **direct semantic hit
+   remains disabled** (Exact Cache on Redis is the production cache path).
 
 ## Consequences
 
-* Offline / RAG experiments must stay behind flags and must not dual-write user history.
-* Migrations that replace `forge_messages` require explicit cutover plan + backfill.
+* Preference / conversation vectors stay out of scope.
+* Exact Cache (Redis whitelist) is the live cache; Semantic shadow ≠ hit cache.

--- a/docs/adr/ADR-06-semantic-pinecone-and-preference-ops.md
+++ b/docs/adr/ADR-06-semantic-pinecone-and-preference-ops.md
@@ -1,0 +1,225 @@
+# ADR-06: Semantic Cache (Pinecone) + Preference Ops
+
+* Status: **Proposed**（待 Owner 确认后实施；确认后改为 Accepted / ByteTitan-star）
+* Date: 2026-08-16
+* Related: ADR-02（偏好）、ADR-04（会话 SoT）、P4 Exact Cache、P4.5 Semantic
+* Owners: ByteTitan-star
+
+---
+
+## 1. 结论摘要（TL;DR）
+
+| 主题 | 决策 |
+| --- | --- |
+| Semantic Cache | **引入 Pinecone**；Exact Redis 仍先查；语义命中阈值 **≥ 0.85**，**< 0.85 一律 miss**；≥ 0.95 记为 high-confidence 指标（不影响是否返回） |
+| Embedding | 默认 **bge-m3**（OpenAI-compat `/embeddings`）；允许管理员换成更轻量 embed 模型（低熵路由缓存可接受） |
+| 偏好存储 | **继续 Postgres `user_preferences`**，**不进 Pinecone** |
+| 偏好检索性能 | `user_id + status` 索引 + **最多 50 条** → 查询为毫秒级，不是慢路径 |
+| 超额策略 | active **> 50 时删除最早**（按 `updated_at`/`created_at` 升序物理删除或硬归档后删除；本 ADR 定：**物理删除 earliest**） |
+| 偏好抽取 | MVP 保留规则抽取；增强：**管理员可配「偏好抽取模型」**（与审核模型同页/同配置体系） |
+| 会话向量 | **仍不做** Conversation → Pinecone（ADR-04 不变） |
+
+---
+
+## 2. 背景与问题
+
+1. Exact Cache（Redis）只能精确命中；近义改写会 miss。
+2. Semantic shadow 只记指纹，不能返回结果。
+3. Owner 要求引入 Pinecone + 相似度阈值。
+4. Owner 关心：`user_preferences` 是否慢、如何更新、如何抽取、是否要管理后台配模型。
+
+---
+
+## 3. 决策：Semantic Cache + Pinecone
+
+### 3.1 命中链路
+
+```text
+白名单节点请求
+  → Exact Redis get（精确）
+  → miss → embed(query_text)  via embedding_model（默认 bge-m3）
+  → Pinecone query top_k=1
+       filter: node == X AND skill_bundle_hash == H
+  → score < 0.85 → miss（继续算）
+  → score >= 0.85 → direct hit（返回 metadata.payload）
+  → 计算结果后：Exact set + Pinecone upsert + Redis shadow
+```
+
+### 3.2 阈值
+
+| 分数 | 行为 |
+| --- | --- |
+| `< 0.85` | **不算命中** |
+| `≥ 0.85` | **允许 direct hit** |
+| `≥ 0.95` | 仍命中；metrics 打 `high_confidence=true`（观测用） |
+
+默认配置：`semantic_cache_similarity_threshold = 0.85`。
+
+### 3.3 范围（写什么进 Pinecone）
+
+**仅 Exact 白名单节点**（与现有一致）：
+
+* `entry_router` / `engine_router` / `intent_classification` / `template_selection` / `deterministic_metadata`
+
+**禁止**：`plan` / `art` / `code` / `repair` / `qa` / `diagnose` / preference 抽取结果本身。
+
+### 3.4 向量与元数据
+
+* **Vector**：embedding(query 规范化文本)
+* **Metadata（最少）**：
+  * `node`, `skill_bundle_hash`, `payload_json`（或指向 Redis 的 `exact_key`）
+  * `created_at`
+* **隔离**：第一版 **全局共享**（低熵路由）；不做跨用户偏好混入。若后续要 per-user cache，另开 ADR 增 `user_id` filter。
+
+### 3.5 Embedding 模型
+
+* **默认：`bge-m3`**（多语、质量稳；经现有 OpenAI-compat `base_url` 调用）。
+* **轻量模型是否 OK？**  
+  **对「白名单低熵路由缓存」可以接受更小 embed 模型**（延迟/成本更低，召回略糙，靠 0.85 阈值兜底）。  
+  **不推荐**用超小模型做会话/偏好语义（本 ADR 也不做那两块）。
+* 管理员可改 `embedding_model` / `embedding_base_url` / `embedding_apikey`（平台级，类似审核模型）。
+
+### 3.6 降级与密钥
+
+* 无 `PINECONE_API_KEY` 或无 embedding 配置 → **不语义命中**，Exact + shadow 仍可用；进程不崩溃。
+* Pinecone / embedding 超时 → miss，走原计算路径。
+* 密钥仅环境变量 / 管理后台加密配置，禁止进仓库。
+
+### 3.7 Feature flags（建议默认）
+
+| Flag | 建议默认 | 含义 |
+| --- | --- | --- |
+| `semantic_cache_shadow_enabled` | true | Redis 影子 |
+| `semantic_cache_direct_hit_enabled` | true | 允许 ≥0.85 命中 |
+| `semantic_cache_similarity_threshold` | 0.85 | 命中下限 |
+| `pinecone_enabled` | true | 总开关（无 key 则空操作） |
+
+---
+
+## 4. 决策：`user_preferences` 检索 / 优化 / 维护
+
+### 4.1 会不会慢？
+
+**不会。** 原因：
+
+* 按用户过滤：`WHERE user_id = ? AND status = 'active'`
+* 已有索引：`ix_user_preferences_user_status (user_id, status)`
+* **硬上限 50 条** → 结果集极小，排序/注入可忽略
+
+这是典型「主键用户维度的小表点查」，与 Pinecone 无关，也 **不需要** 为偏好建向量索引。
+
+### 4.2 超额策略（本 ADR 修订）
+
+* `memory_preferences_max_active = 50`
+* 超出时：**删除最早的记录**（按 `updated_at ASC, created_at ASC`；优先删 `inferred`，再删 `explicit`）
+* 与「归档」相比，物理删除更符合 Owner「最早删掉」表述；clear API 仍可一键清空。
+
+### 4.3 如何更新？
+
+| 路径 | 行为 |
+| --- | --- |
+| Explicit upsert | `(user_id, category, key)` 唯一；同 key 覆盖 value |
+| Inferred upsert | 同 key 已是 Explicit → **跳过**；否则写入/更新 |
+| 用户清除 | `DELETE /me/preferences` 全删 |
+| 管理员 | 可查看/清空（若已有或后续加 admin API） |
+
+### 4.4 如何提取偏好？
+
+**现状（已实现）：**
+
+* Explicit：触发词（以后/我喜欢/默认…）+ 规则 schema（`explicit.py`）
+* Inferred：弱规则（`inferred.py`），不覆盖 Explicit
+
+**增强（本 ADR 批准后做）：**
+
+1. **默认仍走规则**（零额外模型费、可测、可回放）
+2. **可选 LLM 抽取**：管理员配置「偏好抽取模型」（provider/model/apikey/base_url），类似 **审核模型**  
+   - 仅当规则未抽出且文本像偏好时调用（或显式 flag）  
+   - 输出 JSON `{category,key,value_json,source}`，校验后写入  
+   - **轻量 chat 模型即可**（抽取约束，不是写代码）；不必上大推理模型
+3. **管理后台**：在现有 Admin「全局设置 / 审核模型」同体系增加：
+   - Embedding 模型（给 Pinecone Semantic Cache）
+   - 偏好抽取模型（可选）
+   - Pinecone index / namespace / 是否启用 direct hit / 阈值展示（只读或可改）
+
+可以这样做，且与现有 `AuditSection` / `SettingsSection` 扩展一致。
+
+### 4.5 为什么偏好不进 Pinecone？
+
+* 偏好是 **结构化约束**（category/key），SQL upsert + 上限 50 是正确工具。
+* 向量化偏好会导致：重复条目、难审计、与 Explicit 不覆盖语义冲突。
+* 若未来要「自然语言找回旧偏好」，另开 ADR，且与 Cache 索引 **物理隔离**。
+
+---
+
+## 5. 明确不做（本 ADR Out-of-Scope）
+
+* Conversation / `forge_messages` → Pinecone
+* Preference → Pinecone
+* 高熵节点（plan/art/code）语义命中
+* 无校准就下调阈值到 < 0.85
+
+---
+
+## 6. 实施分期（敲定执行顺序）
+
+### Phase 0 — 文档与配置（本 ADR Accepted 后立即）
+
+* 更新 `FLAG-INVENTORY`、`.env.example`、evolution plan 中 P1.5/P4.5 表述
+* 超额策略从「归档」改为「删最早」（代码+测试）
+
+### Phase 1 — Embedding 客户端 + 管理配置
+
+* `app/llm/embeddings.py`（OpenAI-compat embeddings，默认模型名 `bge-m3`）
+* 平台设置项：embedding_* （对齐 audit_* 模式）
+* Admin UI：设置页增加 Embedding /（可选）偏好抽取模型区块
+
+### Phase 2 — Pinecone Adapter + Semantic direct hit
+
+* optional dep：`pinecone`
+* `app/forge/cache/pinecone_store.py`：upsert / query
+* 改写 `semantic_cache_lookup`：threshold 0.85；接通 routers 白名单路径
+* 无 key / 失败 → miss
+* 单测：mock Pinecone + fake embed；禁止 forbidden 节点写入
+
+### Phase 3 — 偏好抽取模型（可选增强）
+
+* `preference_extract_*` 平台配置
+* 规则优先，LLM 回退
+* Admin 与审核同页配置
+* 测试：规则命中不调 LLM；LLM JSON 校验失败回落
+
+### Phase 4 — 观测
+
+* metrics：`semantic_hit_total{band=ge_085|ge_095|miss}`、embed latency、pinecone errors
+* 影子样本可对照 false hit（人工抽检）
+
+---
+
+## 7. 验收标准（Go）
+
+* Exact hit 路径不变
+* `score < 0.85` 永不返回语义命中
+* 无 Pinecone/embedding key 时系统仍可用
+* 白名单外节点零 upsert
+* 单用户 active 偏好 ≤ 50；第 51 条写入后最早一条被删除
+* 管理后台可配置 embedding（及可选偏好抽取模型）
+
+## 8. 回滚
+
+* `pinecone_enabled=false` 或 `semantic_cache_direct_hit_enabled=false` → 回到 Exact + shadow
+* 偏好抽取 LLM 关 → 仅规则
+
+---
+
+## 9. 待 Owner 确认后执行
+
+请确认下列选项（可直接回复「按 ADR-06 执行」）：
+
+1. 阈值：**命中线 0.85**，**0.95 仅作高置信指标** — OK？  
+2. Embedding 默认：**bge-m3**，允许后台换成轻量模型 — OK？  
+3. 偏好超额：**物理删除最早**（而非归档）— OK？  
+4. 管理后台：Embedding + 可选偏好抽取模型，挂在设置/审核同体系 — OK？  
+5. 实施顺序：Phase 0→1→2→3→4 — OK？
+
+确认后将本 ADR 标为 **Accepted / ByteTitan-star**，再按 Phase 开分支实现（多 commit、单 PR）。

--- a/docs/adr/FLAG-INVENTORY.md
+++ b/docs/adr/FLAG-INVENTORY.md
@@ -1,28 +1,26 @@
 # Forge Runtime Feature Flag Inventory
 
-* Status: Operator reference（默认值偏安全；改生产前对照 ADR / 计划 Go·No-Go）
-* Related: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)、evolution plan
+* Status: Defaults after Owner Accept (ByteTitan-star, 2026-08-16)
+* Related: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)
 
-| Flag | Default | Risk if flipped | Notes |
-| --- | --- | --- | --- |
-| `sandbox_backend` | `local`（生产应 `docker`） | 隔离失效 / 出境 | ADR-03；勿默认 `e2b` |
-| `sandbox_e2b_enabled` | `false` | 源码出境 | 需 `--extra e2b` + key |
-| `sandbox_tier_auto` | `false` | 过降档导致 OOM | 开后读 engine/体量/近期失败 |
-| `memory_context_builder` | `true` | 关则不注入 recent turns | 仍走 ContextBuilder |
-| `memory_context_enforcement` | `true` | 兼容残留；不再切 concat | concat 已拆除 |
-| `memory_preferences` | `true` | 关则无 Explicit 注入 | |
-| `memory_preferences_inferred` | `false` | 弱信号污染 | 不覆盖 Explicit |
-| `memory_session_summary` | `true` | | |
-| `memory_session_summary_llm` | `false` | 额外费用 | 失败回落确定性 |
-| `skills_router_enabled` | `true` | | Policy 始终注入 |
-| `skills_llm_selection` | `false` | 费用 / 误选 | Policy 永不 LLM |
-| `skills_quality_lift_llm` | `false` | 付费 A/B | 无 complete 则退回 mock |
-| `exact_cache_enabled` | `true` | | 仅白名单节点 |
-| `semantic_cache_shadow_enabled` | `false` | Redis 膨胀 | **禁止** direct hit |
-| `reliability_node_timeout` | `true` | | |
-| `reliability_idempotent_side_effects` | `true` | 重复副作用 | |
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `sandbox_backend` | `e2b` | 无 `E2B_API_KEY` 时工厂回退 docker→local |
+| `sandbox_e2b_enabled` | `true` | Key 仍只来自环境变量 |
+| `sandbox_tier_auto` | `true` | 启发式/telemetry 选档，非 Agent 随意指定 |
+| `sandbox_default_tier` | `standard` | auto 关闭或无强信号时的基线 |
+| `memory_preferences` | `true` | |
+| `memory_preferences_inferred` | `true` | 不覆盖 Explicit |
+| `memory_preferences_max_active` | `50` | 超额归档最旧 inferred→explicit |
+| `memory_session_summary` | `true` | |
+| `memory_session_summary_llm` | `true` | 失败回落确定性 |
+| `skills_router_enabled` | `true` | 节点只看见本节点 Skill |
+| `skills_llm_selection` | `true` | LLM 只看 name/description；Policy 强制 |
+| `skills_quality_lift_llm` | `true` | 评估用 |
+| `exact_cache_enabled` | `true` | Redis 精确缓存（生产命中路径） |
+| `semantic_cache_shadow_enabled` | `true` | Redis 影子样本；**无 Pinecone；无 direct hit** |
 
-## 明确禁止（无 flag 可开）
+## 明确禁止
 
 * Semantic Cache **direct hit**（`semantic_direct_hit_allowed()` ≡ False）
-* 生产默认 `sandbox_backend=e2b`（须 ADR-03 Accept + benchmark 表填满）
+* 硬编码 `E2B_API_KEY` 进仓库

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,7 @@ Full narrative lives in [2026-08-15-forge-runtime-evolution-plan.md](../2026-08-
 | [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Accepted** | ByteTitan-star |
 | [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Accepted** | ByteTitan-star |
 | [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** | (prior) |
+| [ADR-06](./ADR-06-semantic-pinecone-and-preference-ops.md) | Semantic Cache (Pinecone) + Preference Ops | **Proposed** | — |
 
 Sign-off record: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)  
 Feature flag defaults: [FLAG-INVENTORY.md](./FLAG-INVENTORY.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,15 +1,15 @@
 # ADR Index
 
-Accepted, proposed, and pending Architecture Decision Records for Forge Runtime evolution.
+Accepted Architecture Decision Records for Forge Runtime evolution.
 Full narrative lives in [2026-08-15-forge-runtime-evolution-plan.md](../2026-08-15-forge-runtime-evolution-plan.md).
 
-| ADR | Title | Status |
-| --- | --- | --- |
-| [ADR-01](./ADR-01-degraded-artifact-publishing.md) | Degraded Artifact Publishing | **Accepted** |
-| [ADR-02](./ADR-02-preference-retention.md) | Preference Retention | **Proposed** |
-| [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Proposed** |
-| [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Proposed** |
-| [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** |
+| ADR | Title | Status | Accepted-by |
+| --- | --- | --- | --- |
+| [ADR-01](./ADR-01-degraded-artifact-publishing.md) | Degraded Artifact Publishing | **Accepted** | (prior) |
+| [ADR-02](./ADR-02-preference-retention.md) | Preference Retention | **Accepted** | ByteTitan-star |
+| [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Accepted** | ByteTitan-star |
+| [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Accepted** | ByteTitan-star |
+| [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** | (prior) |
 
-人工 Accept 门禁清单（不自动改状态）：[ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)  
-Feature flag 默认值清单：[FLAG-INVENTORY.md](./FLAG-INVENTORY.md)
+Sign-off record: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)  
+Feature flag defaults: [FLAG-INVENTORY.md](./FLAG-INVENTORY.md)


### PR DESCRIPTION
## Summary
Owner-directed defaults and ADR Accept (signer: **ByteTitan-star**):

- Prefer `sandbox_backend=e2b` + `sandbox_e2b_enabled=true` (requires `E2B_API_KEY`; falls back to docker/local without key)
- `sandbox_tier_auto=true`
- `skills_llm_selection` / `memory_session_summary_llm` / `skills_quality_lift_llm` on
- `memory_preferences_inferred=true` with `memory_preferences_max_active=50`
- `semantic_cache_shadow_enabled=true` (still **no** semantic direct hit; **no** Pinecone)
- ADR-02/03/04 marked **Accepted**

## Clarifications in docs
- Exact Cache (Redis) = production hit path
- Semantic shadow = Redis fingerprint samples only
- Skill LLM selection sees **name/description only**; bodies load after choose (node-scoped)

## Test plan
- [x] adr_evidence / inferred cap / e2b fallback / semantic flag tests
- [ ] Set real `E2B_API_KEY` locally to exercise cloud sandbox