### PR TITLE
feat(cache): ADR-06 Pinecone semantic bands + LLM preference extract

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -167,3 +167,41 @@ ADMIN_CONTACT_EMAIL=wxcurry@163.com
 # SKILLS_QUALITY_LIFT_LLM=true
 # EXACT_CACHE_ENABLED=true
 # SEMANTIC_CACHE_SHADOW_ENABLED=true
+
+# --- ADR-06 Semantic Cache（Pinecone）+ 偏好抽取 ---
+# Exact Redis 仍优先；Semantic：<0.85 miss；[0.85,0.95) 轻量 LLM 确认；>=0.95 直接返回
+# SEMANTIC_CACHE_DIRECT_HIT_ENABLED=true
+# SEMANTIC_CACHE_SOFT_THRESHOLD=0.85
+# SEMANTIC_CACHE_HARD_THRESHOLD=0.95
+
+# Embedding：OpenAI-compat POST {base}/embeddings；无 APIKEY/BASE_URL → 语义命中空操作
+# 默认推荐轻量中文 bge-small-zh-v1.5；召回不够可换 bge-m3 / multilingual-e5-small
+EMBEDDING_ENABLED=true
+EMBEDDING_PROVIDER=openai_compat
+EMBEDDING_MODEL=bge-small-zh-v1.5
+EMBEDDING_APIKEY=
+EMBEDDING_BASE_URL=
+# EMBEDDING_TIMEOUT_S=30
+
+# Pinecone：需 API_KEY + HOST（控制台 Index Host）；缺一则仅 Exact + Redis shadow
+PINECONE_ENABLED=true
+PINECONE_API_KEY=
+PINECONE_HOST=
+PINECONE_INDEX=gameforge-semantic
+PINECONE_NAMESPACE=default
+# PINECONE_CLOUD=aws
+# PINECONE_REGION=us-east-1
+
+# 偏好自动抽取：与 AUDIT_* 同体系字段；仅轻量 chat，禁止规则正式路径
+# PREFERENCE_EXTRACT_MODEL 为空 → 不自动写偏好（用户仍可走 /me/preferences API）
+PREFERENCE_EXTRACT_ENABLED=true
+PREFERENCE_EXTRACT_PROVIDER=openai_compat
+PREFERENCE_EXTRACT_MODEL=
+PREFERENCE_EXTRACT_APIKEY=
+PREFERENCE_EXTRACT_BASE_URL=
+
+# 语义软命中确认 LLM（空 model 时回退 PREFERENCE_EXTRACT_*）
+SEMANTIC_CONFIRM_PROVIDER=openai_compat
+SEMANTIC_CONFIRM_MODEL=
+SEMANTIC_CONFIRM_APIKEY=
+SEMANTIC_CONFIRM_BASE_URL=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -136,9 +136,43 @@ class Settings(BaseSettings):
     # P4 Exact Cache：仅白名单低熵节点
     exact_cache_enabled: bool = True
     exact_cache_ttl_s: int = 86_400
-    # P4.5：Semantic shadow 记 Redis 标定样本（非 Pinecone；仍禁止 direct hit）
+    # P4.5 / ADR-06：Semantic shadow + Pinecone 分层命中
     semantic_cache_shadow_enabled: bool = True
     semantic_cache_shadow_ttl_s: int = 604_800
+    semantic_cache_direct_hit_enabled: bool = True
+    # < soft miss；[soft, hard) LLM 确认；>= hard 直接返回
+    semantic_cache_soft_threshold: float = 0.85
+    semantic_cache_hard_threshold: float = 0.95
+
+    # Embedding（OpenAI-compat /embeddings）；默认轻量中文 bge-small-zh-v1.5
+    embedding_enabled: bool = True
+    embedding_provider: str = "openai_compat"
+    embedding_model: str = "bge-small-zh-v1.5"
+    embedding_apikey: str = ""
+    embedding_base_url: str = ""
+    embedding_timeout_s: int = 30
+
+    # Pinecone（无 api_key+host 则语义命中空操作；REST，不强制 pinecone SDK）
+    pinecone_enabled: bool = True
+    pinecone_api_key: str = ""
+    pinecone_host: str = ""  # 例：xxxx.svc.aped-xxxx.pinecone.io
+    pinecone_index: str = "gameforge-semantic"
+    pinecone_namespace: str = "default"
+    pinecone_cloud: str = "aws"
+    pinecone_region: str = "us-east-1"
+
+    # 偏好抽取：仅轻量 chat；未配置 model 则不自动写偏好（禁止规则正式路径）
+    preference_extract_enabled: bool = True
+    preference_extract_provider: str = "openai_compat"
+    preference_extract_model: str = ""
+    preference_extract_apikey: str = ""
+    preference_extract_base_url: str = ""
+
+    # 语义软命中确认 LLM（空则回退 preference_extract_*）
+    semantic_confirm_provider: str = "openai_compat"
+    semantic_confirm_model: str = ""
+    semantic_confirm_apikey: str = ""
+    semantic_confirm_base_url: str = ""
 
     art_max_retries: int = 2  # 美术 LLM 尝试次数，耗尽后走内置素材兜底
     # 封面截图：QA 通过后用 Playwright 截当前 candidate。Worker 必须具备 Chromium。

--- a/backend/app/forge/adr_evidence.py
+++ b/backend/app/forge/adr_evidence.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from app.core.config import settings
-from app.forge.cache.semantic import semantic_direct_hit_allowed
 from app.models.forge_message import ForgeMessage
 
 
@@ -45,10 +44,20 @@ def collect_adr_evidence() -> list[EvidenceCheck]:
             "(runtime .env may still override for local)",
         ),
         EvidenceCheck(
-            "ADR-03",
-            "semantic_direct_hit_forbidden",
-            semantic_direct_hit_allowed() is False,
-            "semantic direct hit remains forbidden (shadow-only; no Pinecone)",
+            "ADR-06",
+            "semantic_soft_hard_thresholds",
+            settings.semantic_cache_soft_threshold == 0.85
+            and settings.semantic_cache_hard_threshold == 0.95,
+            (
+                f"soft={settings.semantic_cache_soft_threshold!r} "
+                f"hard={settings.semantic_cache_hard_threshold!r}"
+            ),
+        ),
+        EvidenceCheck(
+            "ADR-06",
+            "embedding_default_bge_small",
+            _settings_field_default("embedding_model") == "bge-small-zh-v1.5",
+            f"embedding_model default={_settings_field_default('embedding_model')!r}",
         ),
         EvidenceCheck(
             "ADR-04",

--- a/backend/app/forge/cache/__init__.py
+++ b/backend/app/forge/cache/__init__.py
@@ -16,6 +16,7 @@ from app.forge.cache.routers import (
 )
 from app.forge.cache.semantic import (
     semantic_cache_lookup,
+    semantic_cache_store,
     semantic_direct_hit_allowed,
     semantic_shadow_record,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "list_templates_cached",
     "normalize_engine_id_cached",
     "semantic_cache_lookup",
+    "semantic_cache_store",
     "semantic_direct_hit_allowed",
     "semantic_shadow_record",
 ]

--- a/backend/app/forge/cache/pinecone_store.py
+++ b/backend/app/forge/cache/pinecone_store.py
@@ -1,0 +1,219 @@
+"""Pinecone REST 封装 + 进程内 mock（ADR-06；无 SDK 硬依赖）。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+
+from app.core.config import settings
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class VectorMatch:
+    id: str
+    score: float
+    metadata: dict[str, Any]
+
+
+class PineconeStore(Protocol):
+    async def upsert(
+        self,
+        *,
+        vector_id: str,
+        values: list[float],
+        metadata: dict[str, Any],
+    ) -> None: ...
+
+    async def query(
+        self,
+        *,
+        values: list[float],
+        top_k: int = 1,
+        filter: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]: ...
+
+
+class InMemoryPineconeStore:
+    """测试与本地无 Pinecone 时的余弦相似度 mock。"""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, tuple[list[float], dict[str, Any]]] = {}
+
+    async def upsert(
+        self,
+        *,
+        vector_id: str,
+        values: list[float],
+        metadata: dict[str, Any],
+    ) -> None:
+        self._rows[vector_id] = (list(values), dict(metadata))
+
+    async def query(
+        self,
+        *,
+        values: list[float],
+        top_k: int = 1,
+        filter: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        scored: list[VectorMatch] = []
+        for vid, (vec, meta) in self._rows.items():
+            if filter and not _meta_matches(meta, filter):
+                continue
+            score = _cosine(values, vec)
+            scored.append(VectorMatch(id=vid, score=score, metadata=meta))
+        scored.sort(key=lambda m: m.score, reverse=True)
+        return scored[: max(1, top_k)]
+
+
+class HttpPineconeStore:
+    """Pinecone data-plane REST（需 host + api_key）。"""
+
+    def __init__(self, *, host: str, api_key: str, namespace: str) -> None:
+        self._host = host.rstrip("/").removeprefix("https://").removeprefix("http://")
+        self._api_key = api_key
+        self._namespace = namespace
+
+    async def upsert(
+        self,
+        *,
+        vector_id: str,
+        values: list[float],
+        metadata: dict[str, Any],
+    ) -> None:
+        url = f"https://{self._host}/vectors/upsert"
+        body = {
+            "namespace": self._namespace,
+            "vectors": [
+                {
+                    "id": vector_id,
+                    "values": values,
+                    "metadata": _json_safe_meta(metadata),
+                }
+            ],
+        }
+        await self._post(url, body)
+
+    async def query(
+        self,
+        *,
+        values: list[float],
+        top_k: int = 1,
+        filter: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        url = f"https://{self._host}/query"
+        body: dict[str, Any] = {
+            "namespace": self._namespace,
+            "vector": values,
+            "topK": max(1, top_k),
+            "includeMetadata": True,
+        }
+        if filter:
+            body["filter"] = filter
+        data = await self._post(url, body)
+        matches = data.get("matches") if isinstance(data, dict) else None
+        if not isinstance(matches, list):
+            return []
+        out: list[VectorMatch] = []
+        for m in matches:
+            if not isinstance(m, dict):
+                continue
+            meta = m.get("metadata") if isinstance(m.get("metadata"), dict) else {}
+            out.append(
+                VectorMatch(
+                    id=str(m.get("id") or ""),
+                    score=float(m.get("score") or 0.0),
+                    metadata=meta,
+                )
+            )
+        return out
+
+    async def _post(self, url: str, body: dict[str, Any]) -> dict[str, Any]:
+        headers = {
+            "Api-Key": self._api_key,
+            "content-type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+                resp = await client.post(url, headers=headers, json=body)
+                resp.raise_for_status()
+                data = resp.json()
+                return data if isinstance(data, dict) else {}
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("pinecone request failed: %s", type(exc).__name__)
+            return {}
+
+
+_override: PineconeStore | None | object = object()
+
+
+def set_pinecone_store_override(store: PineconeStore | None) -> None:
+    """测试注入；传 None 表示强制空操作。"""
+    global _override
+    _override = store
+
+
+def reset_pinecone_store_override() -> None:
+    global _override
+    _override = object()
+
+
+def pinecone_configured() -> bool:
+    return bool(
+        settings.pinecone_enabled
+        and settings.pinecone_api_key.strip()
+        and settings.pinecone_host.strip()
+    )
+
+
+def get_pinecone_store() -> PineconeStore | None:
+    if _override is not object():
+        return _override  # type: ignore[return-value]
+    if not pinecone_configured():
+        return None
+    return HttpPineconeStore(
+        host=settings.pinecone_host.strip(),
+        api_key=settings.pinecone_api_key.strip(),
+        namespace=settings.pinecone_namespace or "default",
+    )
+
+
+def make_vector_id(*, node: str, skill_bundle_hash: str, query_text: str) -> str:
+    raw = f"{node}|{skill_bundle_hash}|{query_text}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:40]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b) or not a:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na <= 0 or nb <= 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _meta_matches(meta: dict[str, Any], filt: dict[str, Any]) -> bool:
+    return all(meta.get(k) == v for k, v in filt.items())
+
+
+def _json_safe_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """Pinecone metadata 仅允许标量；result 以 JSON 字符串存。"""
+    out: dict[str, Any] = {}
+    for k, v in meta.items():
+        if isinstance(v, (str, int, float, bool)) or v is None:
+            out[k] = v if v is not None else ""
+        else:
+            out[k] = json.dumps(v, ensure_ascii=False, default=str)
+    if "created_at" not in out:
+        out["created_at"] = int(time.time())
+    return out

--- a/backend/app/forge/cache/routers.py
+++ b/backend/app/forge/cache/routers.py
@@ -1,4 +1,4 @@
-"""白名单节点的 Exact Cache 包装（同步纯函数 + Redis get/set）。"""
+"""白名单节点的 Exact Cache 包装（同步纯函数 + Redis get/set + Semantic）。"""
 
 from __future__ import annotations
 
@@ -8,6 +8,11 @@ import redis.asyncio as redis
 
 from app.enums import EntryPhase
 from app.forge.cache.exact import exact_cache_get, exact_cache_set
+from app.forge.cache.semantic import (
+    semantic_cache_lookup,
+    semantic_cache_store,
+    semantic_shadow_record,
+)
 from app.forge.engine_router import normalize_engine_id
 from app.forge.entry_router import classify_entry_phase
 from app.forge.skills.catalog import catalog_skill_bundle_hash
@@ -17,6 +22,44 @@ from app.forge.templates.loader import get_template, list_templates
 def _skill_hash() -> str:
     """Skill 变更后 key 失效（进程内 catalog 缓存；部署重启后生效）。"""
     return catalog_skill_bundle_hash()
+
+
+async def _lookup_caches(
+    r: redis.Redis,
+    *,
+    node: str,
+    payload: Any,
+    skill_h: str,
+) -> Any | None:
+    hit = await exact_cache_get(
+        r, node=node, input_payload=payload, skill_bundle_hash=skill_h
+    )
+    if hit is not None:
+        return hit
+    return await semantic_cache_lookup(
+        r, node=node, query=payload, skill_bundle_hash=skill_h
+    )
+
+
+async def _store_caches(
+    r: redis.Redis,
+    *,
+    node: str,
+    payload: Any,
+    value: Any,
+    skill_h: str,
+) -> None:
+    await exact_cache_set(
+        r,
+        node=node,
+        input_payload=payload,
+        value=value,
+        skill_bundle_hash=skill_h,
+    )
+    await semantic_cache_store(
+        node=node, query=payload, result=value, skill_bundle_hash=skill_h
+    )
+    await semantic_shadow_record(r, node=node, query=payload, actual_output=value)
 
 
 async def classify_entry_phase_cached(
@@ -30,8 +73,8 @@ async def classify_entry_phase_cached(
         "has_prior_version": bool(has_prior_version),
     }
     skill_h = _skill_hash()
-    hit = await exact_cache_get(
-        r, node="entry_router", input_payload=payload, skill_bundle_hash=skill_h
+    hit = await _lookup_caches(
+        r, node="entry_router", payload=payload, skill_h=skill_h
     )
     if isinstance(hit, str):
         try:
@@ -39,17 +82,8 @@ async def classify_entry_phase_cached(
         except ValueError:
             pass
     result = classify_entry_phase(requirement, has_prior_version=has_prior_version)
-    await exact_cache_set(
-        r,
-        node="entry_router",
-        input_payload=payload,
-        value=result.value,
-        skill_bundle_hash=skill_h,
-    )
-    from app.forge.cache.semantic import semantic_shadow_record
-
-    await semantic_shadow_record(
-        r, node="entry_router", query=payload, actual_output=result.value
+    await _store_caches(
+        r, node="entry_router", payload=payload, value=result.value, skill_h=skill_h
     )
     return result
 
@@ -57,18 +91,14 @@ async def classify_entry_phase_cached(
 async def normalize_engine_id_cached(r: redis.Redis, value: object) -> str:
     payload = {"value": value if isinstance(value, str) else repr(value)}
     skill_h = _skill_hash()
-    hit = await exact_cache_get(
-        r, node="engine_router", input_payload=payload, skill_bundle_hash=skill_h
+    hit = await _lookup_caches(
+        r, node="engine_router", payload=payload, skill_h=skill_h
     )
     if isinstance(hit, str) and hit:
         return hit
     result = normalize_engine_id(value)
-    await exact_cache_set(
-        r,
-        node="engine_router",
-        input_payload=payload,
-        value=result,
-        skill_bundle_hash=skill_h,
+    await _store_caches(
+        r, node="engine_router", payload=payload, value=result, skill_h=skill_h
     )
     return result
 
@@ -84,18 +114,14 @@ async def get_template_cached(
         "require_verified": bool(require_verified),
     }
     skill_h = _skill_hash()
-    hit = await exact_cache_get(
-        r, node="template_selection", input_payload=payload, skill_bundle_hash=skill_h
+    hit = await _lookup_caches(
+        r, node="template_selection", payload=payload, skill_h=skill_h
     )
     if isinstance(hit, dict) and hit.get("template_id"):
         return hit
     result = get_template(template_id, require_verified=require_verified)
-    await exact_cache_set(
-        r,
-        node="template_selection",
-        input_payload=payload,
-        value=result,
-        skill_bundle_hash=skill_h,
+    await _store_caches(
+        r, node="template_selection", payload=payload, value=result, skill_h=skill_h
     )
     return result
 
@@ -107,17 +133,13 @@ async def list_templates_cached(
 ) -> list[dict[str, Any]]:
     payload = {"verified_only": bool(verified_only), "op": "list"}
     skill_h = _skill_hash()
-    hit = await exact_cache_get(
-        r, node="template_selection", input_payload=payload, skill_bundle_hash=skill_h
+    hit = await _lookup_caches(
+        r, node="template_selection", payload=payload, skill_h=skill_h
     )
     if isinstance(hit, list):
         return hit
     result = list_templates(verified_only=verified_only)
-    await exact_cache_set(
-        r,
-        node="template_selection",
-        input_payload=payload,
-        value=result,
-        skill_bundle_hash=skill_h,
+    await _store_caches(
+        r, node="template_selection", payload=payload, value=result, skill_h=skill_h
     )
     return result

--- a/backend/app/forge/cache/semantic.py
+++ b/backend/app/forge/cache/semantic.py
@@ -1,9 +1,10 @@
-"""P4.5 Semantic Cache：仅 shadow / 标定，禁止未校准 direct hit。"""
+"""ADR-06 Semantic Cache：Pinecone 分层命中 + Redis shadow。"""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import time
 from typing import Any
 
@@ -11,11 +12,24 @@ import redis.asyncio as redis
 
 from app.core.config import settings
 from app.forge.cache.exact import is_cacheable_node
+from app.forge.cache.pinecone_store import (
+    get_pinecone_store,
+    make_vector_id,
+)
+from app.llm.embeddings import embed_one
+
+log = logging.getLogger(__name__)
 
 
 def semantic_direct_hit_allowed() -> bool:
-    """Go/No-Go：未完成 calibration 前永远 False。"""
-    return False
+    """分层命中总开关；无 Pinecone/embed 时 lookup 仍会 miss。"""
+    return bool(settings.semantic_cache_direct_hit_enabled)
+
+
+def normalize_query_text(query: Any) -> str:
+    if isinstance(query, str):
+        return query.strip()
+    return json.dumps(query, ensure_ascii=False, sort_keys=True, default=str)
 
 
 async def semantic_cache_lookup(
@@ -23,14 +37,76 @@ async def semantic_cache_lookup(
     *,
     node: str,
     query: Any,
+    skill_bundle_hash: str = "",
 ) -> Any | None:
-    """生产路径查找：在标定完成前一律 miss（禁止 false direct-hit）。"""
-    _ = (r, query)
+    """按相似度分层：miss / soft(LLM 确认) / hard(直接返回)。"""
+    _ = r
     if not is_cacheable_node(node):
         return None
     if not semantic_direct_hit_allowed():
         return None
-    return None
+    store = get_pinecone_store()
+    if store is None:
+        return None
+    query_text = normalize_query_text(query)
+    if not query_text:
+        return None
+    vector = await embed_one(query_text)
+    if vector is None:
+        return None
+    filt: dict[str, Any] = {"node": node}
+    if skill_bundle_hash:
+        filt["skill_bundle_hash"] = skill_bundle_hash
+    matches = await store.query(values=vector, top_k=1, filter=filt)
+    if not matches:
+        return None
+    top = matches[0]
+    soft = float(settings.semantic_cache_soft_threshold)
+    hard = float(settings.semantic_cache_hard_threshold)
+    if top.score < soft:
+        return None
+    result = _parse_result_meta(top.metadata)
+    if result is None:
+        return None
+    if top.score >= hard:
+        return result
+    confirmed = await _confirm_soft_hit(
+        node=node, query_text=query_text, cached_result=result, score=top.score
+    )
+    return confirmed
+
+
+async def semantic_cache_store(
+    *,
+    node: str,
+    query: Any,
+    result: Any,
+    skill_bundle_hash: str = "",
+) -> bool:
+    """计算完成后写入 Pinecone（Exact 由调用方单独 set）。"""
+    if not is_cacheable_node(node):
+        return False
+    if not semantic_direct_hit_allowed():
+        return False
+    store = get_pinecone_store()
+    if store is None:
+        return False
+    query_text = normalize_query_text(query)
+    vector = await embed_one(query_text)
+    if vector is None:
+        return False
+    vid = make_vector_id(
+        node=node, skill_bundle_hash=skill_bundle_hash, query_text=query_text
+    )
+    meta = {
+        "node": node,
+        "skill_bundle_hash": skill_bundle_hash or "",
+        "query_text": query_text[:2000],
+        "result": result,
+        "created_at": int(time.time()),
+    }
+    await store.upsert(vector_id=vid, values=vector, metadata=meta)
+    return True
 
 
 async def semantic_shadow_record(
@@ -61,6 +137,95 @@ async def semantic_shadow_record(
         await r.ltrim(key, 0, 999)
         await r.expire(key, settings.semantic_cache_shadow_ttl_s)
     return True
+
+
+def _parse_result_meta(meta: dict[str, Any]) -> Any | None:
+    raw = meta.get("result")
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+    return raw
+
+
+async def _confirm_soft_hit(
+    *,
+    node: str,
+    query_text: str,
+    cached_result: Any,
+    score: float,
+) -> Any | None:
+    """[soft, hard) 带：轻量 LLM 确认/适配一次。"""
+    provider, model, apikey, base_url = _confirm_llm_cfg()
+    if not model or not apikey:
+        log.info("semantic soft-hit skipped: confirm LLM not configured")
+        return None
+    from app.enums import LLMProvider
+    from app.llm.provider import complete
+
+    system = (
+        "你是缓存确认器。根据当前 query 与候选缓存结果，输出该节点应返回的最终 JSON。"
+        '格式：{"ok":true,"result":...} 或 {"ok":false}。只输出 JSON。'
+    )
+    user_msg = json.dumps(
+        {
+            "node": node,
+            "score": score,
+            "query": query_text,
+            "cached_result": cached_result,
+        },
+        ensure_ascii=False,
+        default=str,
+    )
+    try:
+        content, _usage = await complete(
+            LLMProvider(provider),
+            apikey,
+            model,
+            system,
+            user_msg,
+            base_url or None,
+            max_tokens=512,
+        )
+    except Exception as exc:  # noqa: BLE001 — 软命中失败则 miss
+        log.warning("semantic confirm LLM failed: %s", type(exc).__name__)
+        return None
+    return _parse_confirm_content(content)
+
+
+def _confirm_llm_cfg() -> tuple[str, str, str, str]:
+    if settings.semantic_confirm_model.strip():
+        return (
+            settings.semantic_confirm_provider,
+            settings.semantic_confirm_model.strip(),
+            settings.semantic_confirm_apikey.strip()
+            or settings.preference_extract_apikey.strip(),
+            settings.semantic_confirm_base_url.strip()
+            or settings.preference_extract_base_url.strip(),
+        )
+    return (
+        settings.preference_extract_provider,
+        settings.preference_extract_model.strip(),
+        settings.preference_extract_apikey.strip(),
+        settings.preference_extract_base_url.strip(),
+    )
+
+def _parse_confirm_content(content: str) -> Any | None:
+    text = content.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.startswith("json"):
+            text = text[4:].strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or not data.get("ok"):
+        return None
+    return data.get("result")
 
 
 def _hash_payload(value: Any) -> str:

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -339,17 +339,12 @@ async def _refresh_session_summary(ctx: _Ctx) -> None:
 
 
 async def _upsert_preferences_from_text(ctx: _Ctx, text: str) -> None:
-    """写入 Explicit；可选写入 Inferred（不覆盖 Explicit）。"""
+    """LLM 抽取偏好（未配置抽取模型则跳过）。"""
     if not text.strip():
         return
-    if settings.memory_preferences:
-        from app.forge.memory.preferences import upsert_explicit_from_text
+    from app.forge.memory.preferences import upsert_preferences_from_text
 
-        await upsert_explicit_from_text(ctx.s, user_id=ctx.game.owner_id, text=text)
-    if settings.memory_preferences_inferred:
-        from app.forge.memory.preferences import upsert_inferred_from_text
-
-        await upsert_inferred_from_text(ctx.s, user_id=ctx.game.owner_id, text=text)
+    await upsert_preferences_from_text(ctx.s, user_id=ctx.game.owner_id, text=text)
 
 
 async def _compose_plan_input(

--- a/backend/app/forge/memory/llm_extract.py
+++ b/backend/app/forge/memory/llm_extract.py
@@ -1,0 +1,91 @@
+"""偏好 LLM 抽取（ADR-06）：正式路径禁止规则引擎。"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.core.config import settings
+
+log = logging.getLogger(__name__)
+
+_SYSTEM = (
+    "你是用户游戏创作偏好抽取器。从用户消息中抽取长期偏好（非一次性本次需求）。\n"
+    '只输出 JSON：{"preferences":[{"category":str,"key":str,'
+    '"value_json":object,"source":"explicit"|"inferred","confidence":0-1}]}\n'
+    '无偏好时 {"preferences":[]}。\n'
+    "explicit=用户明确声明长期偏好；inferred=弱信号推断。不要编造。"
+)
+
+
+def preference_extract_configured() -> bool:
+    return bool(
+        settings.preference_extract_enabled
+        and settings.preference_extract_model.strip()
+        and settings.preference_extract_apikey.strip()
+    )
+
+
+async def extract_preferences_via_llm(text: str) -> list[dict[str, Any]]:
+    """调用轻量 chat；未配置或失败返回 []（不写偏好）。"""
+    raw = (text or "").strip()
+    if not raw or not preference_extract_configured():
+        return []
+    from app.enums import LLMProvider
+    from app.llm.provider import complete
+
+    try:
+        content, _usage = await complete(
+            LLMProvider(settings.preference_extract_provider),
+            settings.preference_extract_apikey.strip(),
+            settings.preference_extract_model.strip(),
+            _SYSTEM,
+            raw,
+            settings.preference_extract_base_url.strip() or None,
+            max_tokens=512,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("preference extract LLM failed: %s", type(exc).__name__)
+        return []
+    return _parse_preferences(content)
+
+
+def _parse_preferences(content: str) -> list[dict[str, Any]]:
+    text = content.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.startswith("json"):
+            text = text[4:].strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    rows = data.get("preferences") if isinstance(data, dict) else None
+    if not isinstance(rows, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        category = str(item.get("category") or "").strip()
+        key = str(item.get("key") or "").strip()
+        value_json = item.get("value_json")
+        if not category or not key or not isinstance(value_json, dict):
+            continue
+        source = str(item.get("source") or "inferred").strip().lower()
+        if source not in ("explicit", "inferred"):
+            source = "inferred"
+        conf = float(item.get("confidence") or (0.8 if source == "explicit" else 0.4))
+        conf = max(0.0, min(1.0, conf))
+        out.append(
+            {
+                "category": category,
+                "key": key,
+                "value_json": value_json,
+                "source": source,
+                "confidence": conf,
+                "status": "active",
+            }
+        )
+    return out

--- a/backend/app/forge/memory/preferences.py
+++ b/backend/app/forge/memory/preferences.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.user_preference import UserPreference
 
 
@@ -76,35 +77,20 @@ async def clear_preferences(db: AsyncSession, user_id: uuid.UUID) -> int:
     return count
 
 
-async def upsert_explicit_from_text(
+async def upsert_preferences_from_text(
     db: AsyncSession, *, user_id: uuid.UUID, text: str
 ) -> list[UserPreference]:
-    from app.forge.memory.explicit import extract_explicit_preferences
+    """正式路径：仅 LLM 抽取；未配置模型则不写。inferred 不覆盖 explicit。"""
+    if not settings.memory_preferences:
+        return []
+    from app.forge.memory.llm_extract import extract_preferences_via_llm
 
+    items = await extract_preferences_via_llm(text)
     written: list[UserPreference] = []
-    for item in extract_explicit_preferences(text):
-        row = await upsert_preference(
-            db,
-            user_id=user_id,
-            category=str(item["category"]),
-            key=str(item["key"]),
-            value_json=dict(item["value_json"]),
-            source=str(item.get("source") or "explicit"),
-            confidence=float(item.get("confidence") or 0.8),
-            status=str(item.get("status") or "active"),
-        )
-        written.append(row)
-    return written
-
-
-async def upsert_inferred_from_text(
-    db: AsyncSession, *, user_id: uuid.UUID, text: str
-) -> list[UserPreference]:
-    """写入 Inferred；若同 category/key 已是 Explicit 则跳过，避免降级覆盖。"""
-    from app.forge.memory.inferred import extract_inferred_preferences
-
-    written: list[UserPreference] = []
-    for item in extract_inferred_preferences(text):
+    for item in items:
+        source = str(item.get("source") or "inferred")
+        if source == "inferred" and not settings.memory_preferences_inferred:
+            continue
         category = str(item["category"])
         key = str(item["key"])
         existing = await db.scalar(
@@ -114,7 +100,11 @@ async def upsert_inferred_from_text(
                 UserPreference.key == key,
             )
         )
-        if existing is not None and existing.source == "explicit":
+        if (
+            source == "inferred"
+            and existing is not None
+            and existing.source == "explicit"
+        ):
             continue
         row = await upsert_preference(
             db,
@@ -122,12 +112,26 @@ async def upsert_inferred_from_text(
             category=category,
             key=key,
             value_json=dict(item["value_json"]),
-            source="inferred",
+            source=source,
             confidence=float(item.get("confidence") or 0.4),
             status=str(item.get("status") or "active"),
         )
         written.append(row)
     return written
+
+
+async def upsert_explicit_from_text(
+    db: AsyncSession, *, user_id: uuid.UUID, text: str
+) -> list[UserPreference]:
+    """兼容旧调用：走 LLM 正式路径（不再用规则引擎）。"""
+    return await upsert_preferences_from_text(db, user_id=user_id, text=text)
+
+
+async def upsert_inferred_from_text(
+    db: AsyncSession, *, user_id: uuid.UUID, text: str
+) -> list[UserPreference]:
+    """兼容旧调用：走 LLM 正式路径。"""
+    return await upsert_preferences_from_text(db, user_id=user_id, text=text)
 
 
 def preference_to_context_dict(row: UserPreference) -> dict[str, Any]:
@@ -141,15 +145,12 @@ def preference_to_context_dict(row: UserPreference) -> dict[str, Any]:
 
 
 async def _enforce_active_cap(db: AsyncSession, user_id: uuid.UUID) -> None:
-    """active 偏好上限：优先归档最旧 inferred，再归档最旧 explicit。"""
-    from app.core.config import settings
-
+    """active 偏好上限：物理删除最早 inferred，再删最早 explicit。"""
     cap = max(1, int(settings.memory_preferences_max_active))
     active = await list_active_preferences(db, user_id)
     overflow = len(active) - cap
     if overflow <= 0:
         return
-    # 最旧 updated_at 优先；同刻 inferred 先于 explicit
     ordered = sorted(
         active,
         key=lambda r: (
@@ -158,5 +159,5 @@ async def _enforce_active_cap(db: AsyncSession, user_id: uuid.UUID) -> None:
         ),
     )
     for row in ordered[:overflow]:
-        row.status = "archived"
+        await db.delete(row)
     await db.flush()

--- a/backend/app/forge/skills/llm_select.py
+++ b/backend/app/forge/skills/llm_select.py
@@ -47,6 +47,9 @@ async def select_methodology_ids_via_llm(
     except Exception:  # noqa: BLE001 选路失败必须可回落
         return None
     filtered = [i for i in ids if i in allow][:max_skills]
+    # 空列表视为选路失败（常见于 mock/错 prompt 返回其它 JSON），回落确定性路由
+    if not filtered:
+        return None
     return filtered
 
 

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -1,0 +1,64 @@
+"""OpenAI-compat Embedding 客户端（ADR-06）。无 key/base_url 时返回 None。"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+import httpx
+
+from app.core.config import settings
+
+log = logging.getLogger(__name__)
+
+
+def embedding_configured() -> bool:
+    return bool(
+        settings.embedding_enabled
+        and settings.embedding_apikey.strip()
+        and settings.embedding_base_url.strip()
+        and settings.embedding_model.strip()
+    )
+
+
+async def embed_texts(texts: Sequence[str]) -> list[list[float]] | None:
+    """批量 embed；未配置或失败返回 None（调用方视为 semantic miss）。"""
+    if not embedding_configured():
+        return None
+    cleaned = [t.strip() for t in texts if isinstance(t, str) and t.strip()]
+    if not cleaned:
+        return None
+    base = settings.embedding_base_url.rstrip("/")
+    url = f"{base}/embeddings"
+    headers = {
+        "authorization": f"Bearer {settings.embedding_apikey.strip()}",
+        "content-type": "application/json",
+    }
+    body = {"model": settings.embedding_model.strip(), "input": cleaned}
+    timeout = httpx.Timeout(settings.embedding_timeout_s)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, headers=headers, json=body)
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.HTTPError, ValueError, KeyError) as exc:
+        log.warning("embedding request failed: %s", type(exc).__name__)
+        return None
+    items = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(items, list) or len(items) != len(cleaned):
+        log.warning("embedding response shape mismatch")
+        return None
+    out: list[list[float]] = []
+    for item in sorted(items, key=lambda x: int(x.get("index", 0))):
+        vec = item.get("embedding")
+        if not isinstance(vec, list) or not vec:
+            return None
+        out.append([float(v) for v in vec])
+    return out
+
+
+async def embed_one(text: str) -> list[float] | None:
+    rows = await embed_texts([text])
+    if not rows:
+        return None
+    return rows[0]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -323,7 +323,7 @@ async def _env(tmp_path: Path) -> AsyncIterator[dict[str, str]]:
     settings.hosting_root = str(tmp_path)
     # hosting 强制 local：.env 切到 s3 时测试产物（含 60MB 配额用例）会泄进真实 OSS
     settings.hosting_backend = "local"
-    # sandbox 强制 local：默认 e2b 无 key 会回退 docker；CI runner 有 Docker 会走真容器导致 HITL 流卡住
+    # sandbox 强制 local：默认 e2b 无 key 回退 docker；CI 有 Docker 会卡住 HITL
     settings.sandbox_backend = "local"
     from app.sandbox import reset_sandbox_for_tests
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -248,6 +248,8 @@ def _fake_llm(monkeypatch: pytest.MonkeyPatch):
 
     def _decide(system: str):
         """按 system prompt 决定返回内容 + usage。流式/非流式共用。"""
+        if "Skill 路由器" in system or "skill_ids" in system:
+            return '{"skill_ids":[]}', Usage(5, 2)
         if "方向提案" in system or "上一轮两个视觉方向" in system:
             return _valid_art_options_json(), Usage(10, 5)
         if "前端动效负责人" in system:
@@ -314,12 +316,18 @@ async def _env(tmp_path: Path) -> AsyncIterator[dict[str, str]]:
     _orig_messaging = settings.messaging_backend
     _orig_admin_contact = settings.admin_contact_email
     _orig_log_dir = settings.log_dir
+    _orig_sandbox_backend = settings.sandbox_backend
     # langfuse：.env 可能带真实 key，测试全程禁用，避免 observe_* 触发云上报
     _orig_langfuse_pub = settings.langfuse_public_key
     _orig_langfuse_sec = settings.langfuse_secret_key
     settings.hosting_root = str(tmp_path)
     # hosting 强制 local：.env 切到 s3 时测试产物（含 60MB 配额用例）会泄进真实 OSS
     settings.hosting_backend = "local"
+    # sandbox 强制 local：默认 e2b 无 key 会回退 docker；CI runner 有 Docker 会走真容器导致 HITL 流卡住
+    settings.sandbox_backend = "local"
+    from app.sandbox import reset_sandbox_for_tests
+
+    reset_sandbox_for_tests()
     settings.messaging_backend = "memory"
     settings.admin_contact_email = ""
     settings.log_dir = "-"
@@ -350,6 +358,10 @@ async def _env(tmp_path: Path) -> AsyncIterator[dict[str, str]]:
     settings.hosting_root = _orig_hosting
     settings.hosting_backend = _orig_hosting_backend
     reset_hosting_for_tests()
+    settings.sandbox_backend = _orig_sandbox_backend
+    from app.sandbox import reset_sandbox_for_tests
+
+    reset_sandbox_for_tests()
     settings.messaging_backend = _orig_messaging
     settings.admin_contact_email = _orig_admin_contact
     settings.log_dir = _orig_log_dir

--- a/backend/tests/test_adr_evidence.py
+++ b/backend/tests/test_adr_evidence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from app.forge.adr_evidence import collect_adr_evidence, evidence_all_machine_checks_ok
 
 
@@ -11,13 +13,18 @@ def test_adr_machine_evidence_all_pass() -> None:
     failed = [c for c in checks if not c.ok]
     assert failed == [], f"ADR evidence failed: {failed}"
     assert evidence_all_machine_checks_ok(checks) is True
+    ids = {c.check_id for c in checks}
+    assert "semantic_soft_hard_thresholds" in ids
+    assert "embedding_default_bge_small" in ids
 
 
 def test_adr_evidence_module_documents_invariants() -> None:
-    from pathlib import Path
-
-    text = Path(__file__).resolve().parents[1].joinpath(
-        "app", "forge", "adr_evidence.py"
-    ).read_text(encoding="utf-8")
-    assert "Accepted" in text
-    assert "semantic_direct_hit" in text
+    text = (
+        Path(__file__)
+        .resolve()
+        .parents[1]
+        .joinpath("app", "forge", "adr_evidence.py")
+        .read_text(encoding="utf-8")
+    )
+    assert "ADR-06" in text
+    assert "semantic_soft_hard_thresholds" in text

--- a/backend/tests/test_inferred_preferences.py
+++ b/backend/tests/test_inferred_preferences.py
@@ -1,25 +1,26 @@
-"""Inferred 偏好：弱信号抽取且不覆盖 Explicit。"""
+"""Inferred / LLM 偏好路径与物理删除上限。"""
 
 from __future__ import annotations
 
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.core.config import settings
 from app.forge.memory.inferred import extract_inferred_preferences
+from app.forge.memory.llm_extract import extract_preferences_via_llm
 from app.forge.memory.preferences import (
     list_active_preferences,
-    upsert_explicit_from_text,
-    upsert_inferred_from_text,
     upsert_preference,
+    upsert_preferences_from_text,
 )
 from app.models.user import User
 from app.models.user_preference import UserPreference
 
 
 def test_inferred_extracts_pixel_without_explicit_marker() -> None:
+    """遗留规则模块仍可单测；正式路径已切 LLM。"""
     prefs = extract_inferred_preferences("做一个像素风跑酷")
     assert len(prefs) == 1
     assert prefs[0]["source"] == "inferred"
@@ -32,19 +33,52 @@ def test_inferred_skips_when_explicit_marker_present() -> None:
 
 
 @pytest.mark.asyncio
-async def test_inferred_does_not_overwrite_explicit(db_session, monkeypatch) -> None:
+async def test_upsert_via_llm_does_not_overwrite_explicit(
+    db_session, monkeypatch
+) -> None:
+    monkeypatch.setattr(settings, "memory_preferences", True)
     monkeypatch.setattr(settings, "memory_preferences_inferred", True)
+
+    calls = {"n": 0}
+
+    async def fake_extract(text: str):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [
+                {
+                    "category": "visual",
+                    "key": "style",
+                    "value_json": {"style": "pixel"},
+                    "source": "explicit",
+                    "confidence": 0.9,
+                }
+            ]
+        return [
+            {
+                "category": "visual",
+                "key": "style",
+                "value_json": {"style": "cartoon"},
+                "source": "inferred",
+                "confidence": 0.4,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "app.forge.memory.llm_extract.extract_preferences_via_llm", fake_extract
+    )
     user = User(
         id=uuid4(),
-        email=f"inf-{uuid4().hex[:8]}@example.com",
+        email=f"llm-{uuid4().hex[:8]}@example.com",
         password_hash="x",
         email_verified=True,
     )
     db_session.add(user)
     await db_session.flush()
 
-    await upsert_explicit_from_text(db_session, user_id=user.id, text="以后都用像素风")
-    await upsert_inferred_from_text(
+    await upsert_preferences_from_text(
+        db_session, user_id=user.id, text="以后都用像素风"
+    )
+    await upsert_preferences_from_text(
         db_session, user_id=user.id, text="这次改成卡通风格试试"
     )
     row = await db_session.scalar(
@@ -60,27 +94,48 @@ async def test_inferred_does_not_overwrite_explicit(db_session, monkeypatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_inferred_writes_when_empty(db_session, monkeypatch) -> None:
-    monkeypatch.setattr(settings, "memory_preferences_inferred", True)
+async def test_upsert_preferences_noop_without_model(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "preference_extract_model", "")
+    monkeypatch.setattr(settings, "preference_extract_apikey", "")
     user = User(
         id=uuid4(),
-        email=f"inf2-{uuid4().hex[:8]}@example.com",
+        email=f"noop-{uuid4().hex[:8]}@example.com",
         password_hash="x",
         email_verified=True,
     )
     db_session.add(user)
     await db_session.flush()
-
-    written = await upsert_inferred_from_text(
-        db_session, user_id=user.id, text="做一个硬核平台跳跃"
+    written = await upsert_preferences_from_text(
+        db_session, user_id=user.id, text="以后都用像素风"
     )
-    assert written
-    assert written[0].source == "inferred"
-    assert written[0].value_json.get("difficulty") == "hard"
+    assert written == []
 
 
 @pytest.mark.asyncio
-async def test_active_preferences_capped_at_50(db_session, monkeypatch) -> None:
+async def test_llm_extract_parser_unit(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "preference_extract_enabled", True)
+    monkeypatch.setattr(settings, "preference_extract_model", "tiny")
+    monkeypatch.setattr(settings, "preference_extract_apikey", "sk-test")
+    monkeypatch.setattr(settings, "preference_extract_provider", "openai_compat")
+    monkeypatch.setattr(settings, "preference_extract_base_url", "http://localhost:9")
+
+    async def fake_complete(*_a, **_k):
+        return (
+            '{"preferences":[{"category":"visual","key":"style",'
+            '"value_json":{"style":"pixel"},"source":"explicit","confidence":0.9}]}',
+            None,
+        )
+
+    monkeypatch.setattr("app.llm.provider.complete", fake_complete)
+    rows = await extract_preferences_via_llm("以后都用像素风")
+    assert len(rows) == 1
+    assert rows[0]["source"] == "explicit"
+
+
+@pytest.mark.asyncio
+async def test_active_preferences_physically_deleted_over_cap(
+    db_session, monkeypatch
+) -> None:
     monkeypatch.setattr(settings, "memory_preferences_max_active", 50)
     user = User(
         id=uuid4(),
@@ -101,3 +156,9 @@ async def test_active_preferences_capped_at_50(db_session, monkeypatch) -> None:
         )
     active = await list_active_preferences(db_session, user.id)
     assert len(active) == 50
+    total = await db_session.scalar(
+        select(func.count())
+        .select_from(UserPreference)
+        .where(UserPreference.user_id == user.id)
+    )
+    assert total == 50

--- a/backend/tests/test_llm_summary_and_semantic.py
+++ b/backend/tests/test_llm_summary_and_semantic.py
@@ -1,4 +1,4 @@
-"""P1 LLM summary 与 P4.5 Semantic shadow。"""
+"""P1 LLM summary 与 ADR-06 Semantic 分层命中。"""
 
 from __future__ import annotations
 
@@ -6,14 +6,40 @@ import fakeredis.aioredis
 import pytest
 
 from app.core.config import settings
+from app.forge.cache.pinecone_store import (
+    InMemoryPineconeStore,
+    reset_pinecone_store_override,
+    set_pinecone_store_override,
+)
 from app.forge.cache.semantic import (
     semantic_cache_lookup,
+    semantic_cache_store,
     semantic_direct_hit_allowed,
     semantic_shadow_record,
 )
 from app.forge.memory.context_builder import ContextTurn
 from app.forge.memory.llm_summary import synthesize_summary_via_llm
 from app.forge.memory.summary import synthesize_summary_from_turns
+
+
+@pytest.fixture
+def memory_pinecone(monkeypatch: pytest.MonkeyPatch):
+    store = InMemoryPineconeStore()
+    set_pinecone_store_override(store)
+    monkeypatch.setattr(settings, "semantic_cache_direct_hit_enabled", True)
+    monkeypatch.setattr(settings, "semantic_cache_soft_threshold", 0.85)
+    monkeypatch.setattr(settings, "semantic_cache_hard_threshold", 0.95)
+
+    async def fake_embed(text: str):
+        # 稳定伪向量：字符 ordinal 归一化
+        vals = [((ord(c) % 97) / 97.0) for c in (text or "x")[:32]]
+        while len(vals) < 8:
+            vals.append(0.1)
+        return vals[:8]
+
+    monkeypatch.setattr("app.forge.cache.semantic.embed_one", fake_embed)
+    yield store
+    reset_pinecone_store_override()
 
 
 @pytest.mark.asyncio
@@ -43,14 +69,110 @@ async def test_llm_summary_falls_back_on_bad_json() -> None:
     assert out["current_goal"] == expected["current_goal"]
 
 
-def test_semantic_direct_hit_always_blocked() -> None:
+def test_semantic_direct_hit_follows_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "semantic_cache_direct_hit_enabled", True)
+    assert semantic_direct_hit_allowed() is True
+    monkeypatch.setattr(settings, "semantic_cache_direct_hit_enabled", False)
     assert semantic_direct_hit_allowed() is False
 
 
 @pytest.mark.asyncio
-async def test_semantic_lookup_never_hits() -> None:
+async def test_semantic_lookup_miss_below_soft(
+    memory_pinecone, monkeypatch: pytest.MonkeyPatch
+) -> None:
     r = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    assert await semantic_cache_lookup(r, node="entry_router", query={"a": 1}) is None
+    store = memory_pinecone
+    await semantic_cache_store(
+        node="entry_router",
+        query={"requirement": "做个射击游戏", "has_prior_version": False},
+        result="greenfield",
+        skill_bundle_hash="h1",
+    )
+
+    async def fake_query(*, values, top_k=1, filter=None):
+        matches = await InMemoryPineconeStore.query(
+            store, values=values, top_k=top_k, filter=filter
+        )
+        if not matches:
+            return []
+        from app.forge.cache.pinecone_store import VectorMatch
+
+        m = matches[0]
+        return [VectorMatch(id=m.id, score=0.84, metadata=m.metadata)]
+
+    monkeypatch.setattr(store, "query", fake_query)
+    hit = await semantic_cache_lookup(
+        r,
+        node="entry_router",
+        query={"requirement": "zzz", "has_prior_version": True},
+        skill_bundle_hash="h1",
+    )
+    assert hit is None
+
+
+@pytest.mark.asyncio
+async def test_semantic_hard_hit_returns_cached(memory_pinecone) -> None:
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    payload = {"requirement": "做一个像素跑酷", "has_prior_version": False}
+    await semantic_cache_store(
+        node="entry_router",
+        query=payload,
+        result="greenfield",
+        skill_bundle_hash="h1",
+    )
+    hit = await semantic_cache_lookup(
+        r, node="entry_router", query=payload, skill_bundle_hash="h1"
+    )
+    assert hit == "greenfield"
+
+
+@pytest.mark.asyncio
+async def test_semantic_soft_hit_uses_confirm_llm(
+    memory_pinecone, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = memory_pinecone
+    base = {"requirement": "做一个像素跑酷游戏", "has_prior_version": False}
+    await semantic_cache_store(
+        node="entry_router",
+        query=base,
+        result="greenfield",
+        skill_bundle_hash="h1",
+    )
+
+    async def fake_query(*, values, top_k=1, filter=None):
+        matches = await InMemoryPineconeStore.query(
+            store, values=values, top_k=top_k, filter=filter
+        )
+        if not matches:
+            return []
+        # 强制落在 soft 带
+        from app.forge.cache.pinecone_store import VectorMatch
+
+        m = matches[0]
+        return [VectorMatch(id=m.id, score=0.90, metadata=m.metadata)]
+
+    monkeypatch.setattr(store, "query", fake_query)
+    monkeypatch.setattr(settings, "semantic_confirm_model", "tiny")
+    monkeypatch.setattr(settings, "semantic_confirm_apikey", "sk-test")
+    monkeypatch.setattr(settings, "semantic_confirm_base_url", "http://localhost:9")
+    monkeypatch.setattr(settings, "semantic_confirm_provider", "openai_compat")
+
+    async def fake_complete(*_a, **_k):
+        return ('{"ok":true,"result":"greenfield"}', None)
+
+    monkeypatch.setattr("app.llm.provider.complete", fake_complete)
+
+    near = {"requirement": "做一个像素跑酷", "has_prior_version": False}
+    hit = await semantic_cache_lookup(
+        r, node="entry_router", query=near, skill_bundle_hash="h1"
+    )
+    assert hit == "greenfield"
+
+
+@pytest.mark.asyncio
+async def test_semantic_lookup_skips_forbidden_node(memory_pinecone) -> None:
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
     assert await semantic_cache_lookup(r, node="code", query={"a": 1}) is None
 
 
@@ -84,29 +206,3 @@ async def test_semantic_shadow_respects_enabled_flag(
         r, node="entry_router", query={"q": 2}, actual_output="code"
     )
     assert ok2 is True
-
-
-@pytest.mark.asyncio
-async def test_semantic_shadow_concurrent_trim_and_no_direct_hit(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """并发 shadow 写入不得打开 direct hit；列表长度受 ltrim 约束。"""
-    import asyncio
-
-    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(settings, "semantic_cache_shadow_enabled", True)
-
-    async def one(i: int) -> None:
-        await semantic_shadow_record(
-            r,
-            node="engine_router",
-            query={"i": i},
-            actual_output={"v": i},
-            similarity=0.1,
-        )
-        assert await semantic_cache_lookup(r, node="engine_router", query={"i": i}) is None
-
-    await asyncio.gather(*(one(i) for i in range(32)))
-    rows = await r.lrange("forge:semantic:shadow:engine_router", 0, -1)
-    assert 1 <= len(rows) <= 1000
-    assert semantic_direct_hit_allowed() is False

--- a/backend/tests/test_sandbox_backend.py
+++ b/backend/tests/test_sandbox_backend.py
@@ -58,11 +58,13 @@ def test_factory_rejects_unknown_backend() -> None:
     settings.sandbox_backend = "local"
 
 
-def test_factory_accepts_e2b_name_but_create_still_gated() -> None:
+def test_factory_e2b_falls_back_when_disabled() -> None:
+    """sandbox_backend=e2b 但未启用时回退 docker→local（ADR-03），不再返回 E2B 实例。"""
     reset_sandbox_for_tests()
     settings.sandbox_backend = "e2b"
     settings.sandbox_e2b_enabled = False
     backend = get_sandbox_backend()
-    assert isinstance(backend, E2BSandbox)
+    assert not isinstance(backend, E2BSandbox)
+    assert backend.backend_id in {"docker", "local"}
     reset_sandbox_for_tests()
     settings.sandbox_backend = "local"

--- a/docs/adr/ADR-06-semantic-pinecone-and-preference-ops.md
+++ b/docs/adr/ADR-06-semantic-pinecone-and-preference-ops.md
@@ -1,225 +1,107 @@
 # ADR-06: Semantic Cache (Pinecone) + Preference Ops
 
-* Status: **Proposed**（待 Owner 确认后实施；确认后改为 Accepted / ByteTitan-star）
+* Status: **Accepted**
 * Date: 2026-08-16
-* Related: ADR-02（偏好）、ADR-04（会话 SoT）、P4 Exact Cache、P4.5 Semantic
-* Owners: ByteTitan-star
+* Accepted-by: ByteTitan-star
+* Related: ADR-02、ADR-04、P4 Exact / P4.5 Semantic
 
 ---
 
-## 1. 结论摘要（TL;DR）
+## 1. TL;DR
 
 | 主题 | 决策 |
 | --- | --- |
-| Semantic Cache | **引入 Pinecone**；Exact Redis 仍先查；语义命中阈值 **≥ 0.85**，**< 0.85 一律 miss**；≥ 0.95 记为 high-confidence 指标（不影响是否返回） |
-| Embedding | 默认 **bge-m3**（OpenAI-compat `/embeddings`）；允许管理员换成更轻量 embed 模型（低熵路由缓存可接受） |
-| 偏好存储 | **继续 Postgres `user_preferences`**，**不进 Pinecone** |
-| 偏好检索性能 | `user_id + status` 索引 + **最多 50 条** → 查询为毫秒级，不是慢路径 |
-| 超额策略 | active **> 50 时删除最早**（按 `updated_at`/`created_at` 升序物理删除或硬归档后删除；本 ADR 定：**物理删除 earliest**） |
-| 偏好抽取 | MVP 保留规则抽取；增强：**管理员可配「偏好抽取模型」**（与审核模型同页/同配置体系） |
-| 会话向量 | **仍不做** Conversation → Pinecone（ADR-04 不变） |
+| Semantic Cache | Pinecone + Exact Redis；**存「节点结果 payload」** 而非整段聊天 transcript |
+| 相似度分层 | `<0.85` miss；`[0.85, 0.95)` **丢给轻量 LLM 再推理一次**；`≥0.95` **直接返回缓存结果** |
+| Embedding | 默认推荐 **`bge-small-zh-v1.5`**（轻量、中英够用）；需要更高召回可换 **`bge-m3`**（env 配置） |
+| 偏好表 | Postgres；索引点查；**≤50 物理删除最早** |
+| 偏好抽取 | **只用轻量 chat 模型**（禁止规则抽取作为正式路径）；配置项对齐审核模型体系，**本阶段以 `.env` 配置为准** |
+| 会话向量 | 仍不做 |
 
 ---
 
-## 2. 背景与问题
+## 2. 缓存到底存什么？语义检索如何返回？
 
-1. Exact Cache（Redis）只能精确命中；近义改写会 miss。
-2. Semantic shadow 只记指纹，不能返回结果。
-3. Owner 要求引入 Pinecone + 相似度阈值。
-4. Owner 关心：`user_preferences` 是否慢、如何更新、如何抽取、是否要管理后台配模型。
+### 2.1 存储对象（要想清楚的核心）
 
----
+Semantic / Exact 缓存的是 **白名单「低熵节点」的结构化结果**，不是整轮 Agent 对话：
 
-## 3. 决策：Semantic Cache + Pinecone
+| node | 存什么（`result`） | 语义检索命中后返回什么 |
+| --- | --- | --- |
+| `entry_router` | `EntryPhase` 字符串 | 同左 |
+| `engine_router` | `engine_id` 字符串 | 同左 |
+| `template_selection` | template dict / list | 同左 |
+| `intent_classification` / `deterministic_metadata` | 既有 JSON 结果 | 同左 |
 
-### 3.1 命中链路
+Pinecone **vector** = `embed(规范化 query 文本)`  
+Pinecone **metadata**（最少）=
 
-```text
-白名单节点请求
-  → Exact Redis get（精确）
-  → miss → embed(query_text)  via embedding_model（默认 bge-m3）
-  → Pinecone query top_k=1
-       filter: node == X AND skill_bundle_hash == H
-  → score < 0.85 → miss（继续算）
-  → score >= 0.85 → direct hit（返回 metadata.payload）
-  → 计算结果后：Exact set + Pinecone upsert + Redis shadow
+```json
+{
+  "node": "entry_router",
+  "skill_bundle_hash": "<sha>",
+  "query_text": "<normalized>",
+  "result": "<json-serializable payload>",
+  "created_at": 1710000000
+}
 ```
 
-### 3.2 阈值
+Redis Exact 仍存同一 `result`（精确 key）。  
+Redis Shadow 仍只记 hash 指纹（标定用）。
 
-| 分数 | 行为 |
-| --- | --- |
-| `< 0.85` | **不算命中** |
-| `≥ 0.85` | **允许 direct hit** |
-| `≥ 0.95` | 仍命中；metrics 打 `high_confidence=true`（观测用） |
+**不存**：完整 LLM 聊天消息流、plan/art/code 正文、用户隐私长文。
 
-默认配置：`semantic_cache_similarity_threshold = 0.85`。
+### 2.2 返回策略（Owner 敲定）
 
-### 3.3 范围（写什么进 Pinecone）
+```text
+Exact Redis hit? → 直接返回 result
+else:
+  embed + Pinecone top1 (filter: node + skill_bundle_hash)
+  score < 0.85 → miss → 正常计算 → Exact set + Pinecone upsert + shadow
+  0.85 ≤ score < 0.95 → 将 (current_query, cached_result, node) 交给「确认 LLM」推理一次
+                         → 解析 JSON result → 返回（失败则 miss 重算）
+  score ≥ 0.95 → 直接返回 metadata.result（不再调 LLM）
+```
 
-**仅 Exact 白名单节点**（与现有一致）：
+「确认 LLM」= 平台配置的轻量 chat（可与偏好抽取共用或分开 env）；输入短、输出必须是该节点允许的 JSON/枚举。
 
-* `entry_router` / `engine_router` / `intent_classification` / `template_selection` / `deterministic_metadata`
+---
 
-**禁止**：`plan` / `art` / `code` / `repair` / `qa` / `diagnose` / preference 抽取结果本身。
+## 3. Embedding 选型
 
-### 3.4 向量与元数据
-
-* **Vector**：embedding(query 规范化文本)
-* **Metadata（最少）**：
-  * `node`, `skill_bundle_hash`, `payload_json`（或指向 Redis 的 `exact_key`）
-  * `created_at`
-* **隔离**：第一版 **全局共享**（低熵路由）；不做跨用户偏好混入。若后续要 per-user cache，另开 ADR 增 `user_id` filter。
-
-### 3.5 Embedding 模型
-
-* **默认：`bge-m3`**（多语、质量稳；经现有 OpenAI-compat `base_url` 调用）。
-* **轻量模型是否 OK？**  
-  **对「白名单低熵路由缓存」可以接受更小 embed 模型**（延迟/成本更低，召回略糙，靠 0.85 阈值兜底）。  
-  **不推荐**用超小模型做会话/偏好语义（本 ADR 也不做那两块）。
-* 管理员可改 `embedding_model` / `embedding_base_url` / `embedding_apikey`（平台级，类似审核模型）。
-
-### 3.6 降级与密钥
-
-* 无 `PINECONE_API_KEY` 或无 embedding 配置 → **不语义命中**，Exact + shadow 仍可用；进程不崩溃。
-* Pinecone / embedding 超时 → miss，走原计算路径。
-* 密钥仅环境变量 / 管理后台加密配置，禁止进仓库。
-
-### 3.7 Feature flags（建议默认）
-
-| Flag | 建议默认 | 含义 |
+| 模型 | 定位 | 建议 |
 | --- | --- | --- |
-| `semantic_cache_shadow_enabled` | true | Redis 影子 |
-| `semantic_cache_direct_hit_enabled` | true | 允许 ≥0.85 命中 |
-| `semantic_cache_similarity_threshold` | 0.85 | 命中下限 |
-| `pinecone_enabled` | true | 总开关（无 key 则空操作） |
+| **`bge-small-zh-v1.5`** | 轻量、中文友好、维度小、便宜快 | **默认推荐**（路由缓存足够） |
+| `bge-m3` | 更强多语/长文 | 召回不够时再换 |
+| `multilingual-e5-small` | 另一轻量多语选项 | 备选 |
+| `text-embedding-3-small` | OpenAI 托管 | 有 OpenAI 账时可用 |
+
+结论：缓存策略 **轻量 embed 即可**；默认写 `bge-small-zh-v1.5`，Owner 在 env 自行改。
 
 ---
 
-## 4. 决策：`user_preferences` 检索 / 优化 / 维护
+## 4. 偏好：检索 / 删除 / 抽取
 
-### 4.1 会不会慢？
-
-**不会。** 原因：
-
-* 按用户过滤：`WHERE user_id = ? AND status = 'active'`
-* 已有索引：`ix_user_preferences_user_status (user_id, status)`
-* **硬上限 50 条** → 结果集极小，排序/注入可忽略
-
-这是典型「主键用户维度的小表点查」，与 Pinecone 无关，也 **不需要** 为偏好建向量索引。
-
-### 4.2 超额策略（本 ADR 修订）
-
-* `memory_preferences_max_active = 50`
-* 超出时：**删除最早的记录**（按 `updated_at ASC, created_at ASC`；优先删 `inferred`，再删 `explicit`）
-* 与「归档」相比，物理删除更符合 Owner「最早删掉」表述；clear API 仍可一键清空。
-
-### 4.3 如何更新？
-
-| 路径 | 行为 |
-| --- | --- |
-| Explicit upsert | `(user_id, category, key)` 唯一；同 key 覆盖 value |
-| Inferred upsert | 同 key 已是 Explicit → **跳过**；否则写入/更新 |
-| 用户清除 | `DELETE /me/preferences` 全删 |
-| 管理员 | 可查看/清空（若已有或后续加 admin API） |
-
-### 4.4 如何提取偏好？
-
-**现状（已实现）：**
-
-* Explicit：触发词（以后/我喜欢/默认…）+ 规则 schema（`explicit.py`）
-* Inferred：弱规则（`inferred.py`），不覆盖 Explicit
-
-**增强（本 ADR 批准后做）：**
-
-1. **默认仍走规则**（零额外模型费、可测、可回放）
-2. **可选 LLM 抽取**：管理员配置「偏好抽取模型」（provider/model/apikey/base_url），类似 **审核模型**  
-   - 仅当规则未抽出且文本像偏好时调用（或显式 flag）  
-   - 输出 JSON `{category,key,value_json,source}`，校验后写入  
-   - **轻量 chat 模型即可**（抽取约束，不是写代码）；不必上大推理模型
-3. **管理后台**：在现有 Admin「全局设置 / 审核模型」同体系增加：
-   - Embedding 模型（给 Pinecone Semantic Cache）
-   - 偏好抽取模型（可选）
-   - Pinecone index / namespace / 是否启用 direct hit / 阈值展示（只读或可改）
-
-可以这样做，且与现有 `AuditSection` / `SettingsSection` 扩展一致。
-
-### 4.5 为什么偏好不进 Pinecone？
-
-* 偏好是 **结构化约束**（category/key），SQL upsert + 上限 50 是正确工具。
-* 向量化偏好会导致：重复条目、难审计、与 Explicit 不覆盖语义冲突。
-* 若未来要「自然语言找回旧偏好」，另开 ADR，且与 Cache 索引 **物理隔离**。
+* 检索：`user_id + status=active` + 索引 → ≤50 行，快。
+* 超额：**物理删除最早**（先 inferred，再 explicit）。
+* 抽取：**禁止规则作为正式路径**；仅轻量 chat 模型抽取 JSON 偏好。  
+  - 未配置 `PREFERENCE_EXTRACT_MODEL` → **不自动抽取**（不写偏好）。  
+  - Explicit / Inferred 由模型输出 `source` 字段区分；服务端仍强制：不得用 inferred 覆盖已有 explicit。
+* 配置：与审核模型同体系字段风格；**本阶段只保证 `.env.example` 完整**，管理后台 UI 可随后补。
 
 ---
 
-## 5. 明确不做（本 ADR Out-of-Scope）
+## 5. Flags / Env（默认开启能力，密钥自备）
 
-* Conversation / `forge_messages` → Pinecone
-* Preference → Pinecone
-* 高熵节点（plan/art/code）语义命中
-* 无校准就下调阈值到 < 0.85
+见 `backend/.env.example`：`PINECONE_*`、`EMBEDDING_*`、`PREFERENCE_EXTRACT_*`、`SEMANTIC_CACHE_*`。
 
 ---
 
-## 6. 实施分期（敲定执行顺序）
+## 6. 实施顺序（已确认）
 
-### Phase 0 — 文档与配置（本 ADR Accepted 后立即）
+Phase 0 配置与偏好删除策略 → 1 Embedding 客户端 → 2 Pinecone + 分层命中 → 3 LLM 偏好抽取（替换规则路径）→ 4 metrics。
 
-* 更新 `FLAG-INVENTORY`、`.env.example`、evolution plan 中 P1.5/P4.5 表述
-* 超额策略从「归档」改为「删最早」（代码+测试）
+## 7. 回滚
 
-### Phase 1 — Embedding 客户端 + 管理配置
-
-* `app/llm/embeddings.py`（OpenAI-compat embeddings，默认模型名 `bge-m3`）
-* 平台设置项：embedding_* （对齐 audit_* 模式）
-* Admin UI：设置页增加 Embedding /（可选）偏好抽取模型区块
-
-### Phase 2 — Pinecone Adapter + Semantic direct hit
-
-* optional dep：`pinecone`
-* `app/forge/cache/pinecone_store.py`：upsert / query
-* 改写 `semantic_cache_lookup`：threshold 0.85；接通 routers 白名单路径
-* 无 key / 失败 → miss
-* 单测：mock Pinecone + fake embed；禁止 forbidden 节点写入
-
-### Phase 3 — 偏好抽取模型（可选增强）
-
-* `preference_extract_*` 平台配置
-* 规则优先，LLM 回退
-* Admin 与审核同页配置
-* 测试：规则命中不调 LLM；LLM JSON 校验失败回落
-
-### Phase 4 — 观测
-
-* metrics：`semantic_hit_total{band=ge_085|ge_095|miss}`、embed latency、pinecone errors
-* 影子样本可对照 false hit（人工抽检）
-
----
-
-## 7. 验收标准（Go）
-
-* Exact hit 路径不变
-* `score < 0.85` 永不返回语义命中
-* 无 Pinecone/embedding key 时系统仍可用
-* 白名单外节点零 upsert
-* 单用户 active 偏好 ≤ 50；第 51 条写入后最早一条被删除
-* 管理后台可配置 embedding（及可选偏好抽取模型）
-
-## 8. 回滚
-
-* `pinecone_enabled=false` 或 `semantic_cache_direct_hit_enabled=false` → 回到 Exact + shadow
-* 偏好抽取 LLM 关 → 仅规则
-
----
-
-## 9. 待 Owner 确认后执行
-
-请确认下列选项（可直接回复「按 ADR-06 执行」）：
-
-1. 阈值：**命中线 0.85**，**0.95 仅作高置信指标** — OK？  
-2. Embedding 默认：**bge-m3**，允许后台换成轻量模型 — OK？  
-3. 偏好超额：**物理删除最早**（而非归档）— OK？  
-4. 管理后台：Embedding + 可选偏好抽取模型，挂在设置/审核同体系 — OK？  
-5. 实施顺序：Phase 0→1→2→3→4 — OK？
-
-确认后将本 ADR 标为 **Accepted / ByteTitan-star**，再按 Phase 开分支实现（多 commit、单 PR）。
+* `SEMANTIC_CACHE_DIRECT_HIT_ENABLED=false` 或无 Pinecone key → 仅 Exact + shadow  
+* 无偏好抽取模型 → 不写自动偏好

--- a/docs/adr/FLAG-INVENTORY.md
+++ b/docs/adr/FLAG-INVENTORY.md
@@ -1,7 +1,7 @@
 # Forge Runtime Feature Flag Inventory
 
 * Status: Defaults after Owner Accept (ByteTitan-star, 2026-08-16)
-* Related: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)
+* Related: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)、[ADR-06](./ADR-06-semantic-pinecone-and-preference-ops.md)
 
 | Flag | Default | Notes |
 | --- | --- | --- |
@@ -10,17 +10,26 @@
 | `sandbox_tier_auto` | `true` | 启发式/telemetry 选档，非 Agent 随意指定 |
 | `sandbox_default_tier` | `standard` | auto 关闭或无强信号时的基线 |
 | `memory_preferences` | `true` | |
-| `memory_preferences_inferred` | `true` | 不覆盖 Explicit |
-| `memory_preferences_max_active` | `50` | 超额归档最旧 inferred→explicit |
+| `memory_preferences_inferred` | `true` | 不覆盖 Explicit；正式路径仅 LLM 抽取 |
+| `memory_preferences_max_active` | `50` | 超额**物理删除**最早 inferred→explicit |
 | `memory_session_summary` | `true` | |
 | `memory_session_summary_llm` | `true` | 失败回落确定性 |
 | `skills_router_enabled` | `true` | 节点只看见本节点 Skill |
 | `skills_llm_selection` | `true` | LLM 只看 name/description；Policy 强制 |
 | `skills_quality_lift_llm` | `true` | 评估用 |
 | `exact_cache_enabled` | `true` | Redis 精确缓存（生产命中路径） |
-| `semantic_cache_shadow_enabled` | `true` | Redis 影子样本；**无 Pinecone；无 direct hit** |
+| `semantic_cache_shadow_enabled` | `true` | Redis 影子样本（标定） |
+| `semantic_cache_direct_hit_enabled` | `true` | 允许分层命中；无 Pinecone/embed 则空操作 |
+| `semantic_cache_soft_threshold` | `0.85` | 低于此 miss |
+| `semantic_cache_hard_threshold` | `0.95` | ≥ 此直接返回；中间带需 LLM 确认 |
+| `embedding_enabled` | `true` | 无 key/base_url → 不 embed |
+| `embedding_model` | `bge-small-zh-v1.5` | 轻量默认；可换 `bge-m3` |
+| `pinecone_enabled` | `true` | 需 `PINECONE_API_KEY` + `PINECONE_HOST` |
+| `preference_extract_enabled` | `true` | 无 `PREFERENCE_EXTRACT_MODEL` → 不自动抽取 |
 
 ## 明确禁止
 
-* Semantic Cache **direct hit**（`semantic_direct_hit_allowed()` ≡ False）
-* 硬编码 `E2B_API_KEY` 进仓库
+* 规则引擎作为偏好抽取**正式路径**（`explicit.py` / `inferred.py` 仅保留单元测试/遗留，生产走 LLM）
+* 硬编码 `E2B_API_KEY` / `PINECONE_API_KEY` / Embedding key 进仓库
+* 高熵节点（plan/art/code/…）语义 direct hit
+* 会话 transcript / 偏好表写入 Pinecone（v1）

--- a/docs/superpowers/plans/2026-08-16-adr06-pinecone-preference.md
+++ b/docs/superpowers/plans/2026-08-16-adr06-pinecone-preference.md
@@ -1,0 +1,55 @@
+# ADR-06 实现计划：Pinecone Semantic Cache + LLM 偏好抽取
+
+> **面向 AI 代理的工作者：** 按 Phase 顺序实现；每步可测；English Conventional Commits。
+
+**目标：** 落地 Accepted ADR-06：分层语义命中、Pinecone 存储节点 result、LLM-only 偏好抽取、超额物理删除。
+
+**技术栈：** FastAPI、Redis Exact、Pinecone（optional extra）、OpenAI-compat embeddings、平台 env 配置。
+
+---
+
+## 文件
+
+| 文件 | 职责 |
+| --- | --- |
+| `backend/app/core/config.py` | 新 flags / 默认值 |
+| `backend/.env.example` | Owner 自配模板 |
+| `backend/app/llm/embeddings.py` | embed 客户端 |
+| `backend/app/forge/cache/pinecone_store.py` | upsert/query 适配（可 mock） |
+| `backend/app/forge/cache/semantic.py` | 分层 lookup + confirm LLM |
+| `backend/app/forge/cache/routers.py` | Exact miss 后接 semantic |
+| `backend/app/forge/memory/preferences.py` | 物理删除 earliest |
+| `backend/app/forge/memory/llm_extract.py` | LLM 偏好抽取 |
+| `backend/app/forge/memory/explicit.py` / `inferred.py` | 正式路径不再调用 |
+| `backend/pyproject.toml` | optional `pinecone` |
+| tests | mock Pinecone / embed / extract |
+
+---
+
+## Phase 0
+
+- [ ] config + env.example
+- [ ] preferences：超额物理删除；测试
+- [ ] ADR README Status=Accepted
+
+## Phase 1
+
+- [ ] `embeddings.py` + 无 key 返回 None
+- [ ] 单元测试 fake httpx
+
+## Phase 2
+
+- [ ] pinecone_store Protocol + InMemory 实现（测试）+ 真 SDK optional
+- [ ] semantic_cache_lookup 分层；`confirm_semantic_candidate` LLM
+- [ ] routers 接线；forbidden 节点不写
+- [ ] 测试：0.84 miss / 0.90 confirm / 0.96 direct
+
+## Phase 3
+
+- [ ] `llm_extract.py`；graph/preferences 改走 LLM
+- [ ] 无模型不抽取；测试
+
+## Phase 4
+
+- [ ] metrics counters（可最小：日志 metadata）
+- [ ] FLAG-INVENTORY 更新


### PR DESCRIPTION
## Summary
- Implement ADR-06: Pinecone semantic cache with soft/hard similarity bands (`<0.85` miss, `[0.85,0.95)` light LLM confirm, `>=0.95` direct return) storing whitelist node structured results (not chat transcripts).
- Preference auto-extract uses optional light chat only (no rules on the production path); overflow physically deletes earliest inferred/explicit. Env knobs documented in `backend/.env.example` (Embedding / Pinecone / PREFERENCE_EXTRACT / SEMANTIC_CONFIRM).

## Test plan
- [x] `uv run pytest tests/test_llm_summary_and_semantic.py tests/test_inferred_preferences.py tests/test_adr_evidence.py`
- [ ] Configure `EMBEDDING_*` + `PINECONE_API_KEY`/`PINECONE_HOST` and smoke Exact miss → semantic store → hard hit
- [ ] Leave `PREFERENCE_EXTRACT_MODEL` empty and confirm no auto preference writes; set model and verify JSON extract + explicit protection

## Notes
- Unrelated local docs (ADR-07+ draft reviews, etc.) were intentionally left untracked.
