### PR TITLE
docs(adr): accept ADR-07..12 from design-review follow-up

### DIFF
--- a/docs/2026-08-16-full-project-design-review.md
+++ b/docs/2026-08-16-full-project-design-review.md
@@ -1,0 +1,411 @@
+# 全项目设计审查报告（2026-08-16）
+
+> 审查方式：11 个独立视角（超时配置 / sandbox 生命周期 / worker 并发 / API 设计 / 资源泄漏 / LangGraph 编排 / 前端架构 / 安全 / 复用与效率 / CLAUDE.md 约定 / 架构层次 + 补漏）并行扫描，关键发现均已在源码逐行核实。
+> 本报告只记录问题与修复建议，不含代码改动。
+> 严重度：P0 = 安全/致命故障，应立即处理；P1 = 高概率生产事故或明确攻击面；P2 = 设计债务，择机偿还。
+
+---
+
+## P0 — 立即处理
+
+### P0-1 JWT 密钥硬编码默认值，无生产环境 fail-fast 校验
+
+- **位置**：`backend/app/core/config.py:17`；派生影响 `backend/app/auth/security.py:39`、`backend/app/core/crypto.py:23-27`
+- **问题**：`jwt_secret: str = "dev-secret-change-me-to-a-32-byte-random-string"`。全仓库无 `env != development` 时的非默认值断言。对比：`llm_apikey_encryption_key` / `s3_sk` 缺省会显式失败，唯独 jwt_secret 有可用默认值。
+- **触发→后果**：部署时漏配 `JWT_SECRET` → 服务照常启动 → 任何读过源码的人可对任意 user_id 签发 access token（含 admin，`require_admin` 只查 DB role）→ 全量账号接管。同一密钥还经 HKDF 派生 Fernet key 解密用户 LLM apikey，DB 泄露时 key 全部可解。
+- **建议**：启动时若 `env != development` 且 `jwt_secret` 为默认值/长度 < 32，直接拒绝启动。
+
+### P0-2 LLM source_files 可覆盖平台 manifest → 依赖白名单失效；Windows 本地 builder 存在命令注入 RCE
+
+- **位置**：`backend/app/forge/build/manifest.py:124`；`backend/app/sandbox/builder.py:92-95, 269`
+- **问题**：`merge_workspace` 用 `workspace.update(source_files)` 无文件名白名单，LLM 输出的 `package.json` / `pnpm-workspace.yaml` / `vite.config.ts` 可直接覆盖平台生成的版本锁定与 allowBuilds 硬约束。且 `corepack_activate_shell` 把 `package.json#packageManager` 字段拼进 shell 字符串后由 `create_subprocess_shell` 执行。
+- **触发→后果**：LLM（或诱导 LLM 的输入）输出恶意 `package.json` → prepare 阶段（`network=bridge`）拉任意 npm 包执行 postinstall；在 `builder_backend=local` 的 Windows 宿主上，`packageManager` 内容直接变成宿主机任意命令执行。
+- **建议**：① `merge_workspace` 对 `source_files` 加保留文件名黑名单（manifest 三件套不可覆盖）；② `packageManager` 用正则白名单 `^pnpm@\d+(\.\d+)*$` 校验后拼接。
+
+### P0-3 worker 容器无 restart 策略，任何未捕获异常即永久停摆
+
+- **位置**：`docker-compose.yml:78`（worker 服务无 `restart:`；backend 服务同样没有）
+- **问题**：`worker.py` 的 `main()` 中 `_consume()` 抛任何异常（连接失败、消费循环崩溃）进程即退出，容器不重启。
+- **触发→后果**：worker 一次崩溃 → execute_run / resume_run / 验证码邮件 / 找回密码邮件 / outbox 派发循环全部中断且无人恢复 → run 永久卡 RUNNING、注册收不到验证码，直到人工介入。
+- **建议**：worker 与 backend 服务加 `restart: unless-stopped`；同时给 `_consume()` 加外层异常捕获 + 重连退避。
+
+### P0-4 基础设施客户端全无底层超时 + done 节点无 TimeoutPolicy → worker 静默挂死（"worker 死锁"实态）
+
+- **位置**：`backend/app/core/db.py:7`（asyncpg 无 statement/pool timeout）、`backend/app/core/redis.py:7`（无 socket_timeout）、`backend/app/sandbox/docker.py:122-128`（aiodocker/aiohttp 默认 total=None、`images.pull` 无 wait_for）、`backend/app/forge/graph.py:1234`（`done` 节点是唯一未挂 TimeoutPolicy 的节点）
+- **问题**：任何一条挂起的 IO（Postgres 行锁等待、Redis 半开连接、Docker daemon 假死时的 `container.delete`）都会让协程永久 await。节点级 TimeoutPolicy 能杀图内节点，但取消后在 finally 里执行的 `container.delete(force=True)` 又是一个无超时 await；收尾 commit/publish、done 节点均在策略之外。
+- **触发→后果**：3 个挂起 IO（`max_concurrent_tasks=3`）各占满一个 prefetch 槽位 → 消息不 ack、租约心跳照常续（Redis 正常时）→ broker 不重投、worker 静默停摆，只能人工重启。这正是"worker 是否死锁"的答案：不是经典互斥死锁，而是**无超时 IO 永久占用并发槽位的活锁**。
+- **建议**：① asyncpg `connect_args={"timeout": ..., "command_timeout": ...}`；② redis `socket_timeout`/`socket_connect_timeout`；③ aiodocker 全部调用包 `asyncio.wait_for`；④ done 节点也挂 policy；⑤ 收尾/清理路径统一走带超时包装。
+
+---
+
+## P1 — 高优先级（可靠性）
+
+### P1-1 ack 后置于整个 run，与 RabbitMQ consumer_timeout 必然冲突
+
+- **位置**：`backend/app/messaging/worker.py:192`（`async with message.process(requeue=False)` 包住整个 run）；`backend/app/forge/reliability/policy.py:47-55`（code_qa 外墙 ≈ 2520s）；`docker-compose.yml` rabbitmq 未配 `consumer_timeout`（默认 30 分钟）
+- **触发→后果**：一个正常慢 run 超 30 分钟未 ack → broker 以 PRECONDITION_FAILED 关闭整个 channel → 该 channel 上全部 prefetch 消息批量重投；原任务跑完后 ack 落空（异常被 `gather(return_exceptions=True)` 吞掉），消费循环退出 → 与 P1-3 重投热循环叠加，大规模重复执行。
+- **建议**：rabbitmq 显式配 `consumer_timeout` ≥ 最大 run 预算，或改用"执行租约 + 快速 ack + 独立看门狗"模式。
+
+### P1-2 decode 失败与 DLQ/重投发布自身失败 → 消息静默丢失，不落 DLQ
+
+- **位置**：`backend/app/messaging/worker.py:193`（`decode_task` 在 try 块外）、`worker.py:220-232`（`_republish_task`/`_publish_to_dlq` 无兜底 try）
+- **触发→后果**：① 消息体非法 → `async with message.process(requeue=False)` 退出时 reject 丢弃，任务异常无人 await（只有 GC 时的 "Task exception was never retrieved"）；② 处理失败进 except 后发布到 DLQ/重投时 broker 瞬时故障 → 同样 reject 丢弃。execute_run 消息丢失后 run 永久卡 RUNNING（48h 回收只针对 PAUSED）。
+- **建议**：decode 与发布动作全部纳入 try/except + 显式日志；DLQ 发布失败时降级本地落盘。
+
+### P1-3 TaskLeaseBusy 固定 sleep(2) 原计数无限重投 → 0.5Hz 热循环
+
+- **位置**：`backend/app/messaging/worker.py:208`（已核实：`await asyncio.sleep(2)` + `_republish_task(retry_count=retry)` 不递增）
+- **触发→后果**：at-least-once 重投的重复 execute_run 在原 run 正常执行期间（可达 40+ 分钟）每 2 秒被 republish 一次，可能仍落回同一 worker → 上千次无意义 publish/消费/日志，RabbitMQ 与日志刷爆；`worker_max_redeliveries=5` 对该路径完全不生效。
+- **建议**：busy 路径改为延迟重投（x-delay 或记录首次时间戳做上限），或递增 retry 计数 + 指数退避。
+
+### P1-4 worker 崩溃后重投不读 checkpoint，从 plan 整图重跑 → 重复计费
+
+- **位置**：`backend/app/forge/graph.py:1299-1300`（`duplicate_execute = not resume and run.status != RUNNING`；崩溃时 status 恰好还是 RUNNING → 放行）、`graph.py:1453`（只有 `resume=True` 才 load_state）
+- **触发→后果**：run 跑到 code 阶段时 worker 被 OOM kill → 消息重投 → 守卫放行 → `_run_body(resume=False)` 从 plan 重新生成 → 用户 token 配额被重复扣、API 成本翻倍；side_effect 幂等键含 execution_id，重跑是新 execution，幂等层拦不住。
+- **建议**：重投消息带 `redelivered` 标志时强制走 checkpoint 恢复路径；或对非 resume 启动也先 `load_state` 检查已有进度。
+
+### P1-5 promote 幂等标记先置位后提交 → 提交失败后重放永久跳过 promote，DONE 但交付旧版本
+
+- **位置**：`backend/app/forge/graph.py:1175-1182`（已核实：`try_begin_side_effect` 成功 → `promote_candidate` → `ctx.s.commit()`；失败路径 commit 失败后 Redis 标记已存在）
+- **触发→后果**：commit 失败/进程崩溃 → run 转 recoverable 暂停 → 用户 /retry 重烧整轮 codegen → 再次到 promote 时走 else 分支直接跳过 → qa_ok=True → DONE 并提示"版本 vX 可试玩"，而 current_version 从未抬升，用户玩到旧版本且无任何报错。
+- **建议**：幂等标记放在 commit 成功之后置位（begin/commit 两段式），或 else 分支校验 DB 实际版本号等于候选版本再认为已 promote。
+
+### P1-6 用户暂停检查点只含 design_doc，恢复后强制回 art_options 重烧
+
+- **位置**：`backend/app/forge/graph.py:682-691`（`build_pause_checkpoint(phase="user_pause", design_doc=doc)` 未合并 existing）、`graph.py:772-774`（`user_pause` 无条件路由 `art_options`）；对照 `games/services.py:464-475` 的暂停会合并 existing keys——两个暂停写入方语义不一致
+- **触发→后果**：在 code/qa 阶段点暂停 → art_options/候选版本/attempt/QA 进度全部丢失 → 续跑时重新调美术 LLM、重新弹 art_confirm、code 从 attempt=0 重烧，已确认的美术方向作废。
+- **建议**：`build_pause_checkpoint` 统一走"读取现有 state 后覆盖少量字段"的合并语义，两个暂停入口共用。
+
+### P1-7 resume grant 消费后崩溃 → run 永久卡 RUNNING，无任何回收者
+
+- **位置**：`backend/app/forge/graph.py:1539-1559`（已核实：`st.pop("resume_grant")` + `run.status=RUNNING` 一并 commit，凭据不可恢复）；`scheduler/services.py:50-53`（`expire_stale_paused_runs` 只回收 PAUSED）
+- **触发→后果**：恢复启动后任一 LLM 阶段崩溃 → broker 重投 resume 消息时 phase 仍在 HITL 集合且 grant 已被消费 → 当"陈旧消息"跳过 → run 永久停在 RUNNING；/retry 只接受 FAILED/PAUSED，用户唯一出路是取消重开，修改意见与已烧 token 全部作废。
+- **建议**：① grant 消费延迟到首个非 HITL 节点成功后；② scheduler 增加 RUNNING 超时回收（如租约丢失 + N 分钟无心跳 → 置 FAILED 可 retry）。
+
+### P1-8 邮件任务与长 run 共用单队列 + prefetch 池 → 验证码被阻塞数分钟
+
+- **位置**：`backend/app/messaging/tasks.py`（五类 routing key 绑定同一 TASK_QUEUE）、`worker.py:256`（prefetch = max_concurrent_tasks = 3）
+- **触发→后果**：3 个游戏生成占满 prefetch → 队列里验证码/重置密码邮件只能等任一 run 完成或 HITL 暂停 → 注册用户数分钟收不到验证码，高峰期反复发生。
+- **建议**：邮件类任务拆独立队列（独立 consumer 或同一进程独立 channel/prefetch）。
+
+### P1-9 任务失败重试无退避 + DLQ 无消费者 → 瞬时故障变永久丢失
+
+- **位置**：`backend/app/messaging/worker.py:225-232`（普通失败路径零延迟立即 republish；已核实与 busy 路径不同）；DLQ 声明后全仓库无 consume/replay 调用；`email/worker.py` 的 aiosmtplib 未显式传 timeout（默认 60s）
+- **触发→后果**：Postgres/SMTP 抖动 30 秒 → 每个 in-flight 任务数秒内连续失败 5 次 → 全部进 DLQ → 恢复后无人重放，需人工清理；期间 run 卡 RUNNING、用户收不到验证码。
+- **建议**：重试带指数退避（延迟队列或 sleep）；提供 DLQ 重放工具脚本；SMTP 显式 timeout。
+
+### P1-10 审核调用吃满 300s LLM 读超时，audit_request_timeout 只管流末等窗
+
+- **位置**：`backend/app/forge/guard.py:264`（`provider.complete(..., max_tokens=2)` 用 `_llm_timeout()`=300s×3 次重试）、`guard.py:443`（输入审核 `await guard.audit(user_msg)` 无 wait_for）、`guard.py:510`（后台审核 task 无超时）
+- **触发→后果**：审核端点建连成功但不回包 → 每次流式节点开头的输入审核最长阻塞 ~20 分钟，token 流一个字不出，远超 `audit_request_timeout=20s` 的设计意图；节点 TimeoutPolicy 兜底强杀后 RetryPolicy 又把"审核+生成"整轮重来。
+- **建议**：所有 `guard.audit` 调用统一包 `asyncio.wait_for(settings.audit_request_timeout)`，与配置语义对齐。
+
+### P1-11 code_or_repair 节点预算 420s，但内部串行工作量可达 ~2100s，系统性错配
+
+- **位置**：`backend/app/forge/reliability/policy.py:30`（预算 = llm_request_timeout 300 + 120 = 420s）；内部：生成 LLM ≤300 + prepare 300 + 3 次构建×300 + 修复 LLM×300（`integration.py:94`、`config.py:69-72`）
+- **触发→后果**：`build_pipeline_enabled=True` 时节点在第一次/第二次构建中途被 TimeoutPolicy 取消 → RetryPolicy 重试整节点再烧 420s → code_qa 外墙耗尽 → run 以超时收场，`build_max_retries` 形同虚设，npm install/构建全部白费。
+- **建议**：code_or_repair 预算按 build 链开启状态动态计算（类似 code_qa_loop 外墙的 `attempts × per` 算法）。
+
+### P1-12 Docker 基础设施故障被标为 failure_kind="build" → 进入 LLM 修复循环烧 token；sandbox_failed 恢复路径不可达
+
+- **位置**：`backend/app/sandbox/docker.py:68-70`（`except DockerError: return BuildResult(ok=False, error="docker error: ...")` 不抛异常）、`backend/app/forge/code_qa_exec.py:461`（归为 build 失败）
+- **触发→后果**：Docker daemon 宕机/镜像拉取失败 → diagnose → repair LLM → 再失败 → 烧完 `code_qa_max_attempts × build_max_retries` 轮 LLM 调用才以 qa_failed 暂停；reliability 层的 SandboxTimeout/SandboxOOM 字符串分类从不命中（BuildResult 只带 error 文本），`sandbox_failed` HITL 阶段全仓库无写入点，是死代码。
+- **建议**：BuildResult 增加 `failure_kind` 字段（infra/build/timeout/oom），后端在对应分支主动填；reliability 分类只消费类型不嗅探中文文本（与 P2-8 同根）。
+
+### P1-13 容器无 AutoRemove/reaper → worker 硬崩溃后容器与临时目录永久残留
+
+- **位置**：`backend/app/sandbox/docker.py:129-131`（已核实 grep 全仓库无 AutoRemove/reaper）、清理仅靠进程内 finally；`docker.py:41` / `local.py:28` 的 `tempfile.mkdtemp` 目录同理
+- **触发→后果**：worker 在执行中途被 OOM kill / 发版 kill -9 → 容器停留 `docker ps -a`、`gf-*-sandbox-*` 临时目录残留 → 磁盘缓慢打满、daemon 膨胀；无任何启动时/定时清扫。
+- **建议**：容器加 `"AutoRemove": True`（配合容错删除）；worker 启动时清扫带命名前缀的孤儿容器与临时目录。
+
+### P1-14 容器无日志轮转 + 全量 log() 读回内存 → 磁盘/内存双打爆
+
+- **位置**：`backend/app/sandbox/docker.py:111`（HostConfig 无 LogConfig/max-size）、`docker.py:138` / `builder.py:229`（`container.log()` 一次性全量拉回）
+- **触发→后果**：沙箱内死循环打印直到 timeout → json-file 日志无上限写 `/var/lib/docker` → 宿主磁盘打满、daemon 拒绝新建容器、全平台 run 失败；同时数百 MB 日志读进 worker 内存可能 OOM。builder.py:201-210 的 HostConfig 同缺。
+- **建议**：HostConfig 加 `"LogConfig": {"Type": "json-file", "Config": {"max-size": "10m", "max-file": "3"}}`；`log(tail=N)` 限制读取量。
+
+### P1-15 WS relay 任务在 try/finally 之外创建 → replay 期断连永久泄漏 channel/队列
+
+- **位置**：`backend/app/ws/runs.py:121-124`（已核实：`relay = create_task(...)` 后 `await _replay_buffered(...)` 若抛错，relay 成为孤儿，try/finally 不覆盖这几行）
+- **触发→后果**：客户端在 replay 最多 200 条缓冲事件期间断开（刷新页面，活跃 run 常见）→ relay 阻塞在 `replayed.wait()` 永不 set → 每次泄漏一个 channel + exclusive 队列直到进程重启；memory 模式下死队列持续无界堆积事件膨胀内存。
+- **建议**：relay 创建后立即纳入 try/finally；`_await_disconnect` 也覆盖 replay 阶段。
+
+### P1-16 超时只 kill 直接子进程，未建进程组 → 孙进程成孤儿继续跑并锁住 workspace
+
+- **位置**：`backend/app/sandbox/local.py:117-122`（已核实：`proc.kill()` 无 killpg，`create_subprocess` 未用 `start_new_session`）、`backend/app/sandbox/builder.py:288-291` 同款
+- **触发→后果**：build_cmd 超时 → 只杀 sh 外壳，pnpm/node/esbuild 孙进程继续占 CPU/内存、持有临时目录文件句柄 → pipeline 的 `TemporaryDirectory.__exit__` 在 Windows 上 rmtree 遇锁抛 OSError，把已判定超时的 run 再炸成意外失败；孤儿进程随超时次数累积。
+- **建议**：`create_subprocess(..., start_new_session=True)`（POSIX）/ Windows 用 job object；kill 时杀整个进程组。
+
+---
+
+## P1 — 高优先级（安全）
+
+### P1-17 /auth/verify-email 无限流，6 位纯数字验证码可爆破
+
+- **位置**：`backend/app/api/auth.py:94`（已核实：全文件仅 register/login/resend/reset 四处有 check_rate_limit，verify-email 漏掉）；`auth/services.py:45`（`randbelow(1_000_000):06d`，TTL 600s，失败不计数不消费）
+- **触发→后果**：攻击者用受害者邮箱注册 → 对 verify-email 不限速枚举 10^6 空间（数百 req/s 十分钟内命中）→ 以受害者邮箱完成验证 → 配合 OAuth 关联/密码重置路径接管账号。
+- **建议**：verify-email 加 IP+邮箱双键限流；验证码校验失败 N 次作废重发。
+
+### P1-18 OAuth callback 按 email 直接绑定已存在账号，未校验 email_verified → 账号预注册劫持
+
+- **位置**：`backend/app/auth/oauth.py:149`（已核实：查到 existing User 即 add(OAuthAccount) 并 issue_session）
+- **触发→后果**：攻击者先用受害者邮箱注册（自设密码）→ 受害者 OAuth 登录 → 身份被永久绑进攻击者掌握密码的账号；且该路径从不把 existing.email_verified 置 True，受害者被困在"未验证"账号里无法自助解绑。
+- **建议**：email 绑定仅当 existing.email_verified 为真；否则走"邮箱验证后合并"流程。
+
+### P1-19 openai_compat base_url 无主机限制 → 认证后 SSRF
+
+- **位置**：`backend/app/llm/services.py:154`（test_draft_config/create_config 直接请求用户指定 URL）
+- **触发→后果**：任意登录用户传 `base_url=http://169.254.169.254` 或内网地址 → 服务端发起内网请求，靠 error 文案/耗时差探测内网端口与服务；create_config 成功后每次 run 持续向该地址发请求。
+- **建议**：base_url 做协议+主机白名单/黑名单（禁环回、链路本地、内网段），至少 test 端点要禁。
+
+### P1-20 dev 调试路由完全无鉴权，仅靠 env 门控，而 env 默认值是 development
+
+- **位置**：`backend/app/main.py:100`（`if settings.env == "development"` 才挂载）、`config.py:199`（`env: str = "development"`）
+- **触发→后果**：生产漏配 ENV → `/api/v1/dev/verification-code?email=` 任意人可读他人邮箱验证码（配合 P1-17 直接接管）；`/dev/redis/flush` 全站登出/配额清零；`/dev/reset` 批量 fail 运行中 run。
+- **建议**：dev 路由挂载增加显式开关（默认关）而非依赖 env 字符串；env=development 且非本机监听时启动警告。
+
+### P1-21 prepare 阶段联网运行 + 共享 pnpm store 以 rw 挂载 → 跨租户供应链投毒
+
+- **位置**：`backend/app/forge/build/dependency_preparer.py:71-77`（online 时 `network_mode=bridge`、store rw）、`builder.py:183-186`
+- **触发→后果**：配合 P0-2 的 manifest 覆盖：攻击者的 run 在 prepare 阶段向共享 `/pnpm/store` 写入被篡改的包内容 → 后续所有用户的 offline build（信任 store）取到毒包 → 跨用户构建产物投毒；prepare 的外网访问也可作内网扫描跳板。
+- **建议**：store 按租户隔离或 prepare 也走代理白名单；对 store 写入做内容校验（integrity manifest）。
+
+### P1-22 token 配额只在 run 创建时 check-then-act 检查一次，run 中途无限超额
+
+- **位置**：`backend/app/games/services.py:344`（仅 start_run 检查）；`forge/llm/client.py` 的 call_llm 全流程只有限流 + record_usage，无余量校验
+- **触发→后果**：剩余配额 1000 时并发创建多个 run 全部通过检查后各自烧任意多；run 启动时剩 1 token，run 内 20+ 次 LLM 调用不再查配额——日/月限额形同虚设；而配额告警邮件声称"生成将挂起直至次日重置"，实际无任何挂起逻辑。
+- **建议**：call_llm 记账前检查余量，超限抛 QPAUSED 类错误让 run 转可恢复暂停；或至少按 run 预算预扣。
+
+### P1-23 试用账号"只读"仅前端承诺，后端只挡了密码/资料/点赞三处
+
+- **位置**：`backend/app/auth/trial.py:26`（`reject_trial_mutation` 仅被 auth/profile/reactions 调用；games/runs/publish/llm_config 均无 trial 检查）
+- **触发→后果**：`demo@gameforge.dev/password123` 公开在前端源码，任何人直接调 API 创建游戏、配 LLM key、启动 run、提交发布申请——所有试用用户共享同一日配额（一人耗尽全员不可用），且可向管理员审核队列灌垃圾。
+- **建议**：trial 用户在烧钱/建状态端点统一拦截（依赖注入式 guard），或给 trial 独立极小配额。
+
+---
+
+## P1 — 高优先级（前端）
+
+### P1-24 切换游戏不重置任何运行态 → 游戏 B 的页面持续显示并操作游戏 A 的 run
+
+- **位置**：`frontend/src/pages/forge/ForgePage.tsx:235-238, 307`
+- **问题**：路由 `/forge/A → /forge/B` 时组件不卸载，仅 `setGameId + resumedRef=null`；previewUrl/runId/runStatus/items/messages 全部残留。`if (preview && !previewUrl && token)` 因 previewUrl 还是 A 的旧值恒 false，B 的草稿预览永不铸出。
+- **触发→后果**：B 的工坊渲染 A 的游戏试玩、A 的时间线/HITL 卡；用户在 B 页面点取消实际取消 A 的 run；A 的 localOnly 聊天消息混入 B 的聊天流。
+- **建议**：routeGameId 变化时重置全部 run 相关 state（或给 ForgePage 加 key={gameId} 强制重挂载）。
+
+### P1-25 WS 重连复用闭包捕获的过期 token → 4401 后静默永久放弃重连 + 误报"生成失败"
+
+- **位置**：`frontend/src/ws/client.ts:46, 73`
+- **触发→后果**：长 run（常超 15 分钟，超过 access token TTL）期间一次断网/休眠唤醒 → 重连仍带旧 token → 4401 → `return` 放弃重连且无提示 → 时间线/流式停更，还触发"生成失败"toast 而 run 实际正常；另无应用层心跳，半开连接要等 TCP 超时。
+- **建议**：重连时从 auth store 重读最新 token；4401 时先刷新一次再重试；加心跳 ping/pong。
+
+### P1-26 fetchDraftHtml 自行调用 refresh，绕过 client.ts 的单飞刷新 → 并发刷新可把有效会话登出
+
+- **位置**：`frontend/src/lib/hosting.ts:92`
+- **触发→后果**：access token 过期后草稿 fetch 与 react-query 请求同时 401 → 两路并发 refresh 同一旧 token → 轮换语义下后到者失败 → `if (store.refresh_token === refresh) clearSession()` 把仍有有效凭据的用户登出；client.ts:75-79 注释明示此风险但此处未复用单飞。
+- **建议**：fetchDraftHtml 走 client.ts 导出的 single-flight refresh。
+
+---
+
+## P2 — 架构层次问题
+
+### P2-1 HostingBackend 抽象不完整：write_version_layers/artifact_dir 直接穿透 local，S3 模式下产物只落本地盘，OSS 对象泄漏
+
+- **位置**：`backend/app/hosting/store.py:24`（write_version_layers 永远 local，不经 get_hosting_backend）、`games/services.py:292`（prune 只 rmtree 本地，OSS 对象永久泄漏）、`s3.py:135` 注释宣称"真相源=OSS"而 `serve.py:62` 先读本地——SoT 互相矛盾
+- **建议**：把 write_version_layers/删除/目录语义纳入 HostingBackend 协议，或明确 local 是 cache 层、所有语义操作走 backend。
+
+### P2-2 HITL phase 词表是无枚举的影子状态机，4 个文件人肉同步
+
+- **位置**：`graph.py:75`（`_HITL_RESUME_PHASES` 注释自认"与 app.api.runs._HITL_PHASES 对齐"）、`api/runs.py:146`、`dev/runtime.py:53`、`games/services.py:536`
+- **建议**：phase 集合定义在 enums.py 紧邻 RunPhase/PauseReason，域层单点导出，API/dev 只消费不复制。漏改任意一处会产生"陈旧 resume 被放行/合法 resolve 被 409"类最难查的 bug。
+
+### P2-3 错误分类靠中文错误文本嗅探，BuildResult 不携带 failure_kind
+
+- **位置**：`backend/app/forge/reliability/errors.py:105-109`（`if "构建超时" in str(exc)`、`re.search(r"\boom\b")`）；生产者 `local.py:122`、`docker.py:137`、`builder.py:228` 各自硬编码同一句中文；对照 PlaytestResult 有 failure_kind 字段——同一仓库两套结果类型一套说分类语言一套不说
+- **建议**：与 P1-12 合并修复：BuildResult 加 failure_kind，分类只消费类型。换 E2B 后端或改文案即静默退化为 WorkerInterrupted，影响 /retry 与告警路由。
+
+### P2-4 checkpoint 双写 Redis+DB 但 revision 字段无人消费，Redis 残留旧值时从过期检查点恢复
+
+- **位置**：`backend/app/forge/state.py:39, 51`（save_state 先 flush 后 r.set，提交由调用方稍后执行且无回滚钩子；load_state 优先 Redis；row.revision += 1 但全文件无 load 路径读它）
+- **触发→后果**：① DB 提交成功而 Redis 写失败/failover 到旧副本 → 之后所有 load 优先返回旧状态，"确认了 B 方案却按 A 方案生成"；② 调用方事务回滚后 Redis 留下幻影 checkpoint/幻影 grant，重投的历史 resume 消息借幻影 grant 通过陈旧过滤擅自推进 run。
+- **建议**：load 时比对 DB.revision（SELECT 单列代价极低）不一致则弃缓存；或 save 改为 commit 后写缓存 + 提供 invalidate。
+
+### P2-5 provider 通用路径上叠厂商嗅探补丁 + usage 估算兜底（违反"不估算"红线）
+
+- **位置**：`backend/app/llm/provider.py:158`（`"qwen3" in model` 子串判断注入 enable_thinking）、`_direct_hosts` 硬编码 8 个国内域名、`provider.py:528`（流式缺 usage 帧时 `char_count // 4` 估算 output、input 记 0，注释自认"已知例外"）
+- **建议**：引入 provider profile（请求体钩子/代理策略/usage 提取策略可配置），新厂商只加 profile 不动主干；usage 缺帧时宁可记 0 并打标告警，估算值会系统性污染配额与报表（CLAUDE.md 明文"不估算"）。
+
+### P2-6 沙箱 tier/超时配置三处三种形态，heavy 档不可达
+
+- **位置**：`docker.py:25`（模块级 _TIERS 硬编码）、`local.py:19`（_TIMEOUT_S=60 私有常量）、builder 走 settings.builder_timeout_s；`sandbox/base.py:89`（生产唯一路径 `get_sandbox()` 的 `create()` 从不传 tier → heavy 档 1g/2cpu/120s 形同虚设，重构建被 60s 反复误杀）
+- **建议**：tier→资源/超时映射收敛进 config.py 单表，`get_sandbox` 支持 tier 透传。
+
+### P2-7 resolve_hitl 域状态机整段写在 API 路由层
+
+- **位置**：`backend/app/api/runs.py:322`（80 行业务编排：锁、phase 校验、decision 白名单、状态迁移、入队凭据全在 router）；与 services.cancel_run/retry_run 分裂两处；`games/services.py:492` 的通用 /resume 只校验 status==PAUSED 就发 approve，完全绕过 decision 白名单——art_confirm 暂停时静默替用户选了方案 B
+- **建议**：resolve/resume 逻辑下沉域层与 cancel/retry 并列，phase→decisions 映射单点定义。
+
+---
+
+## P2 — API 设计问题
+
+### P2-8 建状态端点缺幂等五件套（项目明文约定）
+
+- **位置**：`api/publish.py:38`（publish/submit 仅靠部分唯一索引兜底 409，无 Idempotency-Key/创建锁/限流）、`api/games.py:121`（POST /games 与 POST /games/fork/{slug} 五件套全无，fork 连唯一索引都没有；草稿数上限存在 TOCTOU——并发双击可突破 max_drafts_per_user）
+- **建议**：对照 create_run（Idempotency-Key + run:create 锁 + 部分唯一索引）补齐；fork 至少加幂等键。
+
+### P2-9 先查后写的并发竞态直接 500（无 IntegrityError 兜底）
+
+- **位置**：`reactions/services.py:60`（toggle_reaction 并发双击 → uq_game_reaction 冲突 → 500）、`profile/services.py:35`（handle 抢名 → 500 而非 409 HANDLE_TAKEN）、`forge/memory/preferences.py:37`（upsert 同构竞态）
+- **建议**：统一捕获 IntegrityError 转 409/幂等返回（publish.submit 已有同型兜底可复用）。
+
+### P2-10 输入校验缺口 → 裸 500
+
+- **位置**：`schemas/game.py:10`（GameCreate/GamePatch.title 无 max_length，超 DB String(255) → 500；requirement 无上限，与 RunCreate ≤2000 口径不一致；LLMConfigCreate.model/apikey 同样无上限）、`feedback/services.py:35`（run_id 声明为 str，`uuid.UUID()` 抛 ValueError → 500，应声明 UUID 自动 400）、`schemas/admin.py:37`（AdminSettings 裸 int 无 ge=1，管理员填 0 使全站用户立即 QUOTA_EXCEEDED）
+- **建议**：补 Pydantic 约束（max_length/ge），feedback.run_id 改 UUID 类型。
+
+### P2-11 列表接口无分页 → 全量拉取
+
+- **位置**：`games/services.py:414`（GET /games/{id}/runs 无 limit，多轮对话长期累积数百 run 全量序列化）、`publish/services.py:131`（/publish/queue 带 status 查历史时全量；admin/audit-logs、admin/users 均有分页，此端点漏配）
+- **建议**：补 limit/offset 或游标分页。
+
+### P2-12 resolve_hitl 的防重锁无 try/finally + check-then-commit 竞态
+
+- **位置**：`api/runs.py:336`（锁 SET 成功后业务段任一步抛错 → 锁留满 60s TTL，用户重试一律 409 与真实状态矛盾）、`runs.py:352-391`（读到 PAUSED 后经历多个 await 才 commit，无行锁/乐观锁；窗口内 scheduler 超时回收或 cancel 置 FAILED 后，resolve 的 commit 无条件覆盖回 RUNNING → 已回收的 run 复活继续烧 LLM）
+- **建议**：锁包 try/finally；commit 改条件 UPDATE（WHERE status=PAUSED）或加 version 乐观锁。
+
+### P2-13 限流键取 request.client.host，反代后全体用户共享一个桶
+
+- **位置**：`api/auth.py:54-68`（login/register/resend/reset 均按 client.host）；对照 `hosting/routes.py:125` 却信任 x-forwarded-for——同一项目两套取 IP 策略
+- **触发→后果**：生产经 nginx 后所有请求同源 IP → 攻击者单 IP 打满 30/min 即令全站用户登录持续 429（定向 DoS）。
+- **建议**：统一可信代理层配置（uvicorn --proxy-headers + forwarded-allow-ips），限流键加账号维度。
+
+---
+
+## P2 — 运维与资源
+
+### P2-14 task_outbox 只标记从不清理 + cancel 全表扫描
+
+- **位置**：`messaging/outbox.py:28-36`（无 delete/purge；cancel_run_tasks 对全部未发布行全表拉取后 Python 逐行匹配 run_id）
+- **建议**：定时清理已发布行（保留 N 天）；cancel 查询加 run_id 索引列或 JSON 谓词下推。
+
+### P2-15 多 worker 副本调度扫描无行锁，单行 AppError 中断整轮
+
+- **位置**：`scheduler/services.py:96-115`（查询无 with_for_update(skip_locked)；循环内 take_down 遇 INVALID_STATE 直接冒泡 → 本轮回滚，排在后面的到期游戏全部延迟且每分钟重复报错；expire_stale_paused_runs 与用户 resolve_hitl 在 48h 边界同样竞争）
+- **建议**：SELECT FOR UPDATE SKIP LOCKED + per-row try/except。
+
+### P2-16 RabbitWsBus 每条 WS 事件新建/关闭一个 channel（含 declare_exchange）
+
+- **位置**：`messaging/rabbit.py:303`（流式打字机 80ms 微批 → 单 run ~12 channel/s，并发 3 run ~40 channel/s 的创建销毁，broker CPU/延迟被事件转发吃掉）
+- **建议**：进程内复用长生命周期 channel + exchange declare 缓存。
+
+### P2-17 事件循环上的同步阻塞 IO（同类多点）
+
+- **位置**：`forge/build/pipeline.py:73`（TemporaryDirectory.__exit__ 同步 rmtree node_modules 数万小文件，Windows 达数秒，同 worker 其他 run/scheduler/outbox 全停摆）、`sandbox/builder.py:179`（`_ensure_bind_mount_permissions` 同步 rglob+chmod，超 90s 租约心跳无法续 → 租约被抢重复执行）、`games/official.py:282`（fork 时 shutil.copytree/rmtree 最高 50MB 同步拷贝）、`games/services.py:289`（prune_old_versions 同步 rmtree）
+- **建议**：统一挪 `asyncio.to_thread`（注意与租约心跳的交互：to_thread 不阻塞事件循环，心跳可续）。
+
+### P2-18 lifespan/worker 停机不释放 DB engine 与 Redis 池
+
+- **位置**：`main.py:52`（lifespan 只 flush langfuse）、`worker.py` _consume finally（只关 RabbitMQ；handlers._worker_redis 第二个池与 engine 均不关）
+- **触发→后果**：--reload/测试多次创建 app 时 Postgres 连接阶梯上涨触发 max_connections。
+- **建议**：lifespan 收尾 engine.dispose() + pool.aclose()。
+
+### P2-19 /preview/{token} 的 path label 未归一化 → Prometheus 序列无界膨胀
+
+- **位置**：`core/metrics.py:65`（归一化只认 hex+连字符；token_urlsafe(32) 必含 g-z/_ → 原文进 label，每次预览新增 series；/play/{用户自定 slug} 随游戏数线性增长）
+- **建议**：按路由模板（/preview/{token}、/play/{slug}）在注册处归一化。
+
+### P2-20 analytics play_count 读-改-写丢更新 + UV 取可伪造 XFF
+
+- **位置**：`analytics/store.py:57`（`play_count = play_count + 1` 非 SQL 原子自增，并发丢计数）、`hosting/routes.py:125`（visitor_id 取 X-Forwarded-For 可随意注水 30 日 UV，admin 报表失真）
+- **建议**：`UPDATE ... SET play_count = play_count + 1`；UV 换签名 cookie 或至少去掉可伪造头。
+
+---
+
+## P2 — 其余 Sandbox/Forge 问题
+
+### P2-21 DockerSandbox 容器以镜像默认用户运行 + 未复用 builder 的 uid 对齐 → build_cmd 写产物 EACCES
+
+- **位置**：`docker.py:107-121`（无 User 键；镜像 USER sandbox uid 10001 对宿主 uid 建的 workspace 无写权限）；builder.py:195 的 `_docker_user_spec()` + `_ensure_bind_mount_permissions` 正是解同一问题的，sandbox 后端未复用。另：容器内若以 root 运行（某些镜像），配合 rw bind mount 存在逃逸放大面。
+- **建议**：复用 builder 的 user spec 逻辑。
+
+### P2-22 e2b stub 用模块级 _LIVE 全局持有活会话
+
+- **位置**：`sandbox/e2b.py:21-48`（进程崩溃即泄漏远端沙箱持续计费；多 worker 进程各自为政）。当前默认关闭（ADR-03），PoC 阶段风险。
+- **建议**：启用前改 DB 记录会话句柄 + 定时对账回收。
+
+### P2-23 Backend 层写源文件 `workspace / rel` 无路径校验，纵深防御缺失
+
+- **位置**：`local.py:80-86`、`docker.py:60-63`（完全依赖调用方 `_normalize_files` 过滤 `..`；当前唯一调用传固定键，不可达，但新增调用点即成逃逸面）。
+- **建议**：backend 层统一校验 rel 规范化后仍在 workspace 内。
+
+### P2-24 _qa_html（整份 index.html 含 base64）进图状态并扩散进主图 state
+
+- **位置**：`forge/code_qa_exec.py:594`、`graph.py:1238`（`{**result}` 未剔除即并入主图；单 run 内存随产物体积无界增长，prefetch=N 放大 N 倍）。
+- **建议**：子图终态白名单字段回传主图。
+
+### P2-25 LangGraph RetryPolicy 不分异常类型：ContentAttacked/RunFinalized/AppError 都被整节点重试
+
+- **位置**：`forge/reliability/policy.py:69`（RetryPolicy 未传 retry_on；guard 设计"命中即中止不重试"被破坏——攻击场景成本恰好翻倍；LLM_CONFIG_INVALID 类注定失败请求也多发一次；与 httpx ×4、code_qa attempt ×3、build 环 ×3、worker 重投 ×5 叠加，最坏一次 code 阶段放大到 70+ 次 LLM HTTP 调用；plan 节点内自修复 ×3 叠外层 ×2 = 最多 6 次 plan LLM 调用）
+- **建议**：RetryPolicy 传 retry_on 排除业务性异常（ContentAttacked/AppError/RunFinalized）。
+
+---
+
+## P2 — 前端其余问题
+
+### P2-26 8s 兜底轮询 effect 依赖每次渲染新建的 detail 对象 → interval 反复拆建可被流式渲染饿死
+
+- **位置**：`ForgePage.tsx:430`（deps 含 useQuery 结果对象；流式期间每次 llm_delta 重渲染都 clearInterval+setInterval，轮询可能永远打不到后端——恰是 WS 半死时最需要兜底的时刻）
+- **建议**：deps 收敛为原始值（runId/runStatus），或轮询挪入 react-query refetchInterval。
+
+### P2-27 聊天 messages 无上限 + 每 delta 微批全量重渲染 1400 行页面
+
+- **位置**：`ForgePage.tsx:468, 482-488`（timeline 有 slice(0,80) 上限，messages 无；ChatPanel 全量 map 无虚拟化无 memo）
+- **建议**：messages 设上限 + 增量渲染（对最后一抽头 memo 或虚拟化）。
+
+### P2-28 同一页面三套独立 run 状态轮询
+
+- **位置**：`hooks/use-active-runs.ts:10`（ActiveRunBanner 8s 轮询 listActiveRuns）+ ForgePage 8s 轮询 getRun（纯 setState 不入 react-query 缓存）+ RunHistoryPanel ['game-runs']——三来源无共享去重，毫秒级不一致造成状态闪烁。
+- **建议**：run 状态统一收敛 react-query 缓存键。
+
+### P2-29 ChatPanel 无滚动跟随，流式输出与 HITL 卡片可能完全不可见
+
+- **位置**：`ChatPanel.tsx:115`（panel 模式 overflow-y-auto 容器无任何 scrollTop/scrollIntoView 管理；HITL 决策卡渲染在滚动容器尾部，用户误以为生成卡死）。
+- **建议**：追加消息时若接近底部则自动跟随；HITL 卡固定渲染。
+
+### P2-30 refresh_token（30 天）明文存 localStorage + WS token 走 URL query
+
+- **位置**：`stores/auth-store.ts:66`（一次 XSS 即长期静默控制账号；refresh 无会话族复用检测）、`ws/runs.py:101`（?token= 落代理/访问日志）。
+- **建议**：refresh 改 httpOnly cookie + rotation 复用检测；WS 改首帧鉴权或短期票据。
+
+---
+
+## P2 — CLAUDE.md 约定违反（汇总）
+
+| 约定 | 违反点 | 位置 |
+|---|---|---|
+| 禁硬编码密钥 | jwt_secret 默认值（P0-1）；trial 账号 password123 前后端各一份 | `config.py:17`、`auth/trial.py:18`、`frontend/src/lib/trial.ts` |
+| usage 不估算 | 流式缺 usage 帧按字符数÷4 估算并写 Redis 计量 | `llm/provider.py:528`（见 P2-5） |
+| 不硬编码游戏玩法 | 三款完整可玩小游戏源码（1227 行）硬编码并由业务模块 seed 成已发布游戏 | `scripts/official_assets/*.html` ← `games/official.py:215`（注：`forge/build/demos.py` 是构建管线验证 fixture，可豁免） |
+| 禁止静默吞异常 | `list_models` 的 `except Exception: pass` 无任何日志；`official.py` `_copy_artifact` 源缺失静默 return（fork 出空产物 404 且无日志） | `llm/provider.py:218`、`games/official.py` |
+| 幂等五件套 | publish/submit、POST /games、fork | 见 P2-8 |
+| async 优先 | 官方游戏 fork 的同步 copytree | 见 P2-17 |
+| 单文件 ≤500 行 / 单函数 ≤50 行 | `graph.py` 1505、`code_qa_exec.py` 623、`provider.py` 611、`games/services.py` 611、`prompts.py` 601、`guard.py` 571、`design_doc.py` 463；超 50 行函数：`run_generation` 173、`_repair_project` 203、`execute_code_or_repair` 176、`create_run` 109；前端 `ForgePage.tsx` 1366、`messages.ts` 1384（`types.gen.ts` 7403 为生成物豁免） | — |
+
+---
+
+## 修复优先级建议
+
+**第一批（上线前必须）**：P0-1 ~ P0-4，P1-17/18/19/20（安全五连）、P1-2（消息丢失）。
+**第二批（一周内）**：P1-1/3/4/5/6/7（worker 与状态机可靠性核心链）、P1-13/14/15/16（sandbox 与 WS 泄漏）、P1-24/25/26（前端三高）。
+**第三批（排期偿还）**：其余 P1（配额、SSRF、邮件队列拆分）、P2 全部。
+**专项重构建议**（跨多条问题共享根因）：
+1. **超时体系**：基建客户端（DB/Redis/Docker）统一 timeout 层 → 消 P0-4、缓解 P1-1/10/11。
+2. **failure_kind 贯通**：BuildResult/PlaytestResult 统一错误分类 → 消 P1-12、P2-3。
+3. **checkpoint 单一真相源**：revision 校验或 commit-after-cache → 消 P2-4、P1-5/6/7 的共因。
+4. **HITL 域层收口**：phase/decision 词表 + resolve/resume 下沉 services → 消 P2-2/7、P2-12。
+5. **HostingBackend 协议补全** → 消 P2-1、P1-13 的产物残留部分。
+
+---
+
+*审查方法备注：候选发现约 79 条，去重合并为 56 条（多视角交叉确认：jwt_secret×2、consumer_timeout×2、RetryPolicy×2、list_models×2、进程组×2、verify-email×2 等）；关键机制性声明（compose restart 缺失、worker ack 模式、promote 时序、user_pause 检查点、grant 消费、manifest 覆盖、relay 作用域、verify-email 限流缺失、AutoRemove/LogConfig 缺失、db/redis 无超时参数）均已在源码逐行核实。*

--- a/docs/adr/ACCEPT-CHECKLIST.md
+++ b/docs/adr/ACCEPT-CHECKLIST.md
@@ -1,6 +1,7 @@
 # ADR Accept Checklist
 
-> Owner sign-off: **ByteTitan-star** (2026-08-16). Status on ADR-02/03/04 set to **Accepted**.
+> Owner sign-off: **ByteTitan-star** (2026-08-16).
+> Design-review follow-up: [ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md).
 
 ## 签字区
 
@@ -8,7 +9,16 @@
 | --- | --- | --- | --- |
 | ADR-02 | ByteTitan-star | 2026-08-16 | Accept |
 | ADR-03 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-03 revision 2026-08-16 | ByteTitan-star | 2026-08-16 | Accept |
 | ADR-04 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-05 revision 2026-08-16 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-06 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-07 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-08 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-09 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-10 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-11 | ByteTitan-star | 2026-08-16 | Accept |
+| ADR-12 (Sections A/B/C) | ByteTitan-star | 2026-08-16 | Accept |
 
 ## Machine evidence
 
@@ -18,3 +28,4 @@ cd backend && uv run pytest tests/test_adr_evidence.py -q
 
 `app/forge/adr_evidence.py` checks runtime invariants aligned with Accepted decisions
 (E2B preferred, inferred+cap=50, forge_messages SoT, semantic direct-hit still forbidden).
+ADR-07～12 evidence hooks may be added as implementation lands.

--- a/docs/adr/ADR-03-sandbox-provider-strategy.md
+++ b/docs/adr/ADR-03-sandbox-provider-strategy.md
@@ -3,7 +3,7 @@
 * Status: **Accepted**
 * Date: 2026-08-16
 * Accepted-by: ByteTitan-star
-* Related: [sandbox-data-flow.md](./sandbox-data-flow.md), [../sandbox-e2b-benchmark.md](../sandbox-e2b-benchmark.md)
+* Related: [sandbox-data-flow.md](./sandbox-data-flow.md), [../sandbox-e2b-benchmark.md](../sandbox-e2b-benchmark.md), [ADR-11](./ADR-11-sandbox-hosting-resources.md), [ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
 
 ## Context
 
@@ -24,3 +24,28 @@ Choose sandbox provider for isolated game build/execute: Docker vs E2B (or hybri
 * Production-like runs should set a real `E2B_API_KEY`.
 * Benchmark table in `sandbox-e2b-benchmark.md` remains the ops scorecard for cost/latency.
 * Data egress via E2B is accepted by Owner for this project configuration.
+
+---
+
+## Revision 2026-08-16（设计审查后）
+
+* Status: **Accepted**
+* Accepted-by: ByteTitan-star
+* Date: 2026-08-16
+
+### 新增决策
+
+1. **部署现实优先于「默认常量」：**  
+   `docker-compose.yml` 当前将 `SANDBOX_BACKEND` / 构建链设为 **docker**。在 E2B 密钥、会话对账与 ADR-11 启用前置未满足前，**Docker（及必要时 local）路径的安全与资源加固是生产必做项**，不得以「ADR 写了首选 E2B」跳过。
+2. **回退路径同等约束：**  
+   Fallback 到 docker/local 时，仍须遵守 ADR-07（manifest / packageManager）、ADR-11（failure_kind、AutoRemove、日志轮转、uid 对齐、路径校验）。`local` + Windows builder 禁止用于多租户宿主。
+3. **Tier 配置单表：**  
+   `lite|standard|heavy` 的 CPU/内存/超时映射收敛到单一配置源；禁止 `docker.py` / `local.py` / builder settings 三套魔法数长期并存。  
+   澄清审查误表述：heavy **并非死代码**——`recommend_tier` 可在引擎/体量/压力信号下返回 heavy；待修的是配置分裂与透传一致性。
+4. **E2B 启用门槛：**  
+   启用前须完成 ADR-11 §7（会话句柄持久化 + 定时对账）。未完成前保持 Docker 为 compose 默认部署后端是可接受的显式选择，但应在运维文档写明，避免与 `config.py` 默认值互相「以为对方是真相」。
+
+### 修订后后果
+
+* 文档、compose、config 三者允许短期不一致，但 **必须在 FLAG-INVENTORY / 运维手册标明「当前部署后端」**。
+* ADR-11 成为 Docker/local 加固的配套决策；本 ADR 只定选型与门槛，不重复列出全部 HostConfig 细则。

--- a/docs/adr/ADR-05-recoverable-pause-representation.md
+++ b/docs/adr/ADR-05-recoverable-pause-representation.md
@@ -2,7 +2,7 @@
 
 * Status: **Accepted**
 * Date: 2026-08-15
-* Related: P0 Reliability, HITL
+* Related: P0 Reliability, HITL；[ADR-10](./ADR-10-checkpoint-hitl-idempotency.md), [ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
 
 ## Decision
 
@@ -12,3 +12,27 @@ Recoverable pauses use explicit `paused` + `pause_reason` (and checkpoint metada
 
 * Resume / cancel / timeout paths share one pause model.
 * Operators and clients can distinguish HITL wait vs infra pause.
+
+---
+
+## Revision 2026-08-16（设计审查后）
+
+* Status: **Accepted**
+* Accepted-by: ByteTitan-star
+* Date: 2026-08-16
+
+### 新增决策
+
+1. **检查点合并语义：**  
+   任何暂停写入（图内 `user_pause`、服务层暂停、HITL 暂停）必须 **合并现有 checkpoint**，仅覆盖 phase / pause_reason / 必要字段；禁止只持久化 `design_doc` 导致 art/code/qa 进度丢失。
+2. **Phase 词表归属：**  
+   HITL / resume 相关 phase 集合是域模型的一部分，单点定义并导出；API、graph、dev、games **禁止各维护一份影子集合**（详见 ADR-10）。
+3. **与 RUNNING 的边界：**  
+   「可恢复」不仅指 `PAUSED`：resume grant 消费、租约丢失后的 RUNNING 卡住，必须有回收或可 retry 路径（ADR-10 §3）。ADR-05 原「paused + pause_reason」模型扩展为：**暂停态与可恢复失败态都要机器可区分**。
+4. **恢复路由：**  
+   恢复时按 checkpoint 真实进度续跑；不得把「用户暂停」无条件解释为「回到 art_options 重来」。
+
+### 修订后后果
+
+* ADR-05 仍是暂停**表示**的权威；promote 幂等、grant 时序、resolve 下沉等**机制**以 ADR-10 为实施决策。
+* 客户端可用统一 pause_reason / phase 展示「等人 / 等 infra / 可 retry」，减少「假死」误判。

--- a/docs/adr/ADR-07-production-security-baseline.md
+++ b/docs/adr/ADR-07-production-security-baseline.md
@@ -1,0 +1,66 @@
+# ADR-07: Production Security Baseline
+
+* Status: **Accepted**
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+* Related: P0-1, P0-2, P1-17～23；[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+* Source review: [2026-08-16-full-project-design-review.md](../2026-08-16-full-project-design-review.md)
+
+---
+
+## Context
+
+全项目设计审查确认：生产可因默认 `jwt_secret`、LLM 产物覆盖 manifest、验证码/OAuth/SSRF/dev 路由/试用账号等路径被接管或横向移动。这些不是「以后优化」，而是上线前安全基线。
+
+**核实：** P0-1/2、P1-17～20 已在源码属实；P1-21～23 机制属实。
+
+## Decision
+
+### 1. 密钥与启动门禁（P0-1）
+
+1. `env != development` 时：若 `jwt_secret` 等于默认值或长度 &lt; 32，**拒绝启动**。
+2. 开发环境允许默认值；生产/预发必须来自环境变量或密钥管理，禁止写入仓库。
+3. 由 `jwt_secret` 派生的 Fernet 密钥（LLM apikey 加解密）继承同一门禁——无独立「弱默认」。
+
+### 2. LLM 工作区合并与 packageManager（P0-2）
+
+1. `merge_workspace` 对 `source_files` 施加 **保留文件黑名单**（至少：`package.json`、`pnpm-workspace.yaml`、`vite.config.*` 及平台生成的锁文件/约束文件），禁止覆盖平台 manifest。
+2. `packageManager` 仅允许匹配 `^pnpm@\d+(\.\d+)*$` 的值再拼接；否则忽略并回落固定版本。
+3. `builder_backend=local` 视为高风险开发路径：文档与默认配置明确「禁止在共享/多租户宿主上启用」。
+
+### 3. 认证与账号（P1-17 / P1-18）
+
+1. `/auth/verify-email` 必须与 register/login 同级限流（IP + 邮箱双键）；校验失败达到阈值后作废验证码并要求重发。
+2. OAuth callback：仅当已存在用户的 `email_verified=True` 时才按 email 绑定；否则走「验证后合并」或拒绝静默绑定，并避免把受害者困在未验证账号。
+
+### 4. SSRF（P1-19）
+
+1. 用户可控的 `openai_compat` `base_url`：协议白名单（仅 https，开发可放宽 http+localhost）+ 主机黑名单（环回、链路本地、私网、云 metadata）。
+2. `test_draft_config` 与 `create_config` 共用同一校验；校验失败返回 400，不发请求。
+
+### 5. Dev 路由（P1-20）
+
+1. Dev 调试路由 **不得** 仅依赖 `env == "development"` 字符串；增加显式开关（默认 **关**），例如 `DEV_ROUTES_ENABLED=false`。
+2. 仅当显式开启且（可选）绑定本机监听时才挂载；生产配置检查清单必须包含该项。
+
+### 6. 构建供应链（P1-21）
+
+1. 共享 pnpm store 不得被不可信 prepare 阶段任意 rw 污染跨租户产物：优先 **按租户/按 run 隔离 store**，或 prepare 出站走代理白名单 + store 写入完整性校验。
+2. 与 Decision §2 一并视为上线前项；不能只修黑名单不修 store。
+
+### 7. 配额与试用（P1-22 / P1-23）
+
+1. Token 配额：除 `start_run` 外，在 `call_llm` 记账路径检查余量；超限将 run 转为可恢复暂停（或等价 QPAUSED），禁止「启动时剩 1 token、中途无限烧」。
+2. Trial 用户：烧钱与建状态 API（创建游戏、LLM config、start run、publish 等）统一依赖注入拦截；或给 trial 独立极小配额。公开试用口令不得视为安全边界。
+
+## Consequences
+
+* 漏配密钥时服务起不来（优于静默被接管）。
+* LLM 无法再通过覆盖 `package.json` 绕过 allowBuilds；local builder 命令注入面关闭。
+* 验证码爆破、OAuth 预注册劫持、SSRF、dev 信息泄露、试用账号滥用的攻击面显著缩小。
+* 配额与 trial 从「前端承诺」变为后端强制，可能改变现有试用体验——产品文案需同步。
+
+## Non-goals
+
+* 完整 WAF / 零信任网络改造。
+* 将 refresh token 迁 httpOnly cookie（见 ADR-12，可延后）。

--- a/docs/adr/ADR-08-worker-messaging-reliability.md
+++ b/docs/adr/ADR-08-worker-messaging-reliability.md
@@ -1,0 +1,62 @@
+# ADR-08: Worker & Messaging Reliability
+
+* Status: **Accepted**
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+* Related: P0-3, P1-1～4, P1-8, P1-9；[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+
+---
+
+## Context
+
+Worker 承担 `execute_run` / `resume_run`、邮件与 outbox。审查确认：容器无 restart、长 run 与 RabbitMQ `consumer_timeout` 冲突、decode/DLQ 失败可丢消息、租约 busy 热循环、崩溃重投不读 checkpoint、邮件与长任务共池。
+
+**核实：** 上述机制在 `docker-compose.yml`、`messaging/worker.py`、`forge/graph.py` 属实。
+
+## Decision
+
+### 1. 进程存活（P0-3）
+
+1. Compose（及等价编排）中 `worker` 与 `backend` 设置 `restart: unless-stopped`（或平台同等策略）。
+2. `_consume()` 外层捕获异常，带指数退避重连，禁止「一次异常进程退出且永不回来」。
+
+### 2. Ack 与长任务（P1-1）
+
+任选其一并文档化为唯一策略（推荐先做 A，中期演进 B）：
+
+* **A（短线）：** RabbitMQ 显式配置 `consumer_timeout` ≥ 最大 run 预算（含 code_qa 外墙），并监控接近阈值的 run。
+* **B（目标态）：** 快速 ack + 执行租约 + 独立看门狗；消息确认与 run 生命周期解耦。
+
+禁止长期维持「默认 30 分钟 consumer_timeout + 整 run 占着 unacked」而不改任一侧。
+
+### 3. 消息不丢（P1-2）
+
+1. `decode_task` 与业务处理同属可观测失败路径：非法消息记日志后进 DLQ（或明确 reject 策略），禁止未 await 的 Task 异常。
+2. `_republish_task` / `_publish_to_dlq` 包 try/except；DLQ 发布失败时降级本地落盘（或等价持久化），并告警。
+
+### 4. 租约 busy 与失败重试（P1-3 / P1-9）
+
+1. `TaskLeaseBusy`：**禁止**固定 `sleep(2)` + 原 `retry_count` 无限重投。改为延迟重投（x-delay / 延迟队列）或递增计数 + 指数退避，并设上限后进 DLQ。
+2. 普通失败重试同样带退避；提供 DLQ 重放脚本或运维手册步骤。
+3. SMTP 客户端显式 timeout。
+
+### 5. 崩溃重投与 checkpoint（P1-4）
+
+1. Broker 重投（`redelivered`）或 run 已为 `RUNNING` 的重复 `execute_run`：必须走 checkpoint 恢复语义（`load_state`），不得从 plan 无条件整图重烧。
+2. 与 ADR-10 的 grant/幂等决策一致：重跑不得靠「新 execution_id」绕过用户可感知的重复计费。
+
+### 6. 队列隔离（P1-8）
+
+1. 邮件类任务（验证码、重置密码）使用 **独立队列**（独立 consumer 或同进程独立 channel + prefetch）。
+2. 长 run 占满游戏任务 prefetch 时，不得阻塞验证码投递超过产品 SLA（建议目标：秒级，而非分钟级）。
+
+## Consequences
+
+* Worker 崩溃可自动恢复；消息丢失面缩小。
+* 可能增加 RabbitMQ 配置复杂度与延迟队列依赖。
+* 重投改走 checkpoint 后，部分「看起来像重新开始」的行为会变为续跑——前端文案需一致。
+
+## Non-goals
+
+* 多区域跨机房消息总线。
+* 替换 RabbitMQ 为其它 broker（除非另开 ADR）。

--- a/docs/adr/ADR-09-timeout-and-io-boundaries.md
+++ b/docs/adr/ADR-09-timeout-and-io-boundaries.md
@@ -1,0 +1,54 @@
+# ADR-09: Timeout & IO Boundaries
+
+* Status: **Accepted**
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+* Related: P0-4, P1-10, P1-11, P2-25；[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+
+---
+
+## Context
+
+审查将「worker 死锁」澄清为：**无超时 IO 永久占用并发槽位的活锁**。Postgres / Redis / Docker 客户端缺少底层超时；图节点 TimeoutPolicy 未覆盖 `done` 与部分 finally 清理；审核调用未尊重 `audit_request_timeout`；`code_or_repair` 节点预算与内部串行工作量系统性错配；LangGraph `RetryPolicy` 未排除业务性异常。
+
+**核实：** `db.py` / `redis.py` 无超时参数；`done` 节点无 TimeoutPolicy；`RetryPolicy` 未传 `retry_on`——属实。
+
+## Decision
+
+### 1. 基础设施客户端统一超时（P0-4）
+
+1. asyncpg / SQLAlchemy：配置连接与 `command_timeout`（或等价），禁止无限等待行锁/假死连接。
+2. Redis：配置 `socket_connect_timeout` / `socket_timeout`（或 asyncio 客户端等价项）。
+3. aiodocker / 镜像拉取 / `container.delete`：一律 `asyncio.wait_for`（或封装层），清理路径不得在超时策略之外无限 await。
+4. 超时值进 `config.py` 单表，禁止各模块魔法数。
+
+### 2. 图节点 TimeoutPolicy（P0-4）
+
+1. `done` 与所有有外部 IO 的节点一律挂 TimeoutPolicy。
+2. 节点被取消后的 finally 清理必须走带超时包装的同一工具函数。
+
+### 3. 审核超时语义（P1-10）
+
+1. 所有 `guard.audit`（流式前同步、后台 task）统一 `asyncio.wait_for(settings.audit_request_timeout)`。
+2. `audit_request_timeout` 表示端到端审核预算，不得仅覆盖「流末等窗」而让 `complete()` 吃满 LLM 读超时 × 重试。
+
+### 4. code_or_repair 预算（P1-11）
+
+1. 当 `build_pipeline_enabled=True` 时，节点 TimeoutPolicy 预算按 build 链动态计算（类比 `code_qa_loop` 外墙的 `attempts × per`），使 `build_max_retries` 有意义。
+2. 预算与配置项可观测（metrics/日志），避免静默错配。
+
+### 5. RetryPolicy 可重试集合（P2-25）
+
+1. `RetryPolicy` 必须传 `retry_on`：排除 `ContentAttacked`、`RunFinalized`、明确的 `AppError` 业务失败等「再试也无意义 / 有害」的类型。
+2. 瞬时 IO / 超时类才进入节点级重试；与 httpx、code_qa attempt、build 环、worker 重投的乘法效应要有文档化上限意识。
+
+## Consequences
+
+* 挂起 IO 不再永久占满 `max_concurrent_tasks`；故障可失败可告警。
+* 动态预算可能拉长单节点墙钟时间——需与 ADR-08 的 `consumer_timeout` / 租约策略一起调。
+* 攻击流量与配置错误不再被 RetryPolicy 成倍放大。
+
+## Non-goals
+
+* 分布式追踪全链路采样策略（可另开观测 ADR）。
+* 修改 LLM 供应商 SLA。

--- a/docs/adr/ADR-10-checkpoint-hitl-idempotency.md
+++ b/docs/adr/ADR-10-checkpoint-hitl-idempotency.md
@@ -1,0 +1,59 @@
+# ADR-10: Checkpoint, HITL & Idempotency
+
+* Status: **Accepted**
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+* Related: P1-5/6/7, P2-2/4/7/12；修订衔接 [ADR-05](./ADR-05-recoverable-pause-representation.md)；[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+
+---
+
+## Context
+
+可恢复暂停已有 ADR-05，但实现上：promote 幂等「先标记后提交」、用户暂停检查点过窄、resume grant 过早消费、HITL phase 词表多文件复制、checkpoint Redis/DB 双写但 revision 未校验、`resolve_hitl` 锁与竞态写在 API 层。
+
+**核实：** `graph.py` promote / `user_pause` / `resume_grant` 路径属实；`api/runs.py` 与 `graph.py` 各维护 HITL 集合属实。
+
+## Decision
+
+### 1. Promote 幂等两段式（P1-5）
+
+1. Side-effect 幂等采用 **begin / commit**（或「commit 成功后再置完成标记」）：DB 提交失败或进程崩溃后，重放必须能再次 promote 或能检测到「候选版本已是 current」而非永久跳过。
+2. else「已执行」分支必须校验 DB 实际版本（或等价事实）后再宣称成功。
+
+### 2. 暂停检查点合并语义（P1-6）
+
+1. `build_pause_checkpoint`（及所有写入方）统一：**读取现有 state，再覆盖少量字段**；禁止只写 `design_doc` 丢掉 art/code/qa 进度。
+2. 图内暂停与 `games/services` 暂停共用同一合并函数，消除双语义。
+3. `user_pause` 恢复路由按检查点 phase/进度续跑，不得无条件强制回 `art_options` 重烧已确认美术。
+
+### 3. Resume grant 与 RUNNING 回收（P1-7）
+
+1. `resume_grant` 消费延迟到「已离开 HITL 集合的首个成功推进」之后；或提供可重建的一次性凭证语义，避免「grant 已吃、消息被当陈旧跳过、run 永 RUNNING」。
+2. Scheduler 增加 RUNNING 超时回收：租约丢失且 N 分钟无心跳 → 置 FAILED（可 retry）或可恢复暂停；不得仅回收 PAUSED。
+
+### 4. HITL 词表与域层（P2-2 / P2-7）
+
+1. Phase 集合与 phase→allowed decisions 单点定义在域层（如 `enums` / `hitl` 模块），紧邻 `RunPhase` / `PauseReason`；API / graph / dev / games **只消费不复制**。
+2. `resolve_hitl` / 通用 resume 的锁、校验、入队下沉 services，与 `cancel_run` / `retry_run` 并列；禁止 API 路由内 80 行状态机。
+3. 通用 `/resume` 不得在 `art_confirm` 等阶段静默代选决策。
+
+### 5. Checkpoint 缓存一致性（P2-4）
+
+1. `load_state` 优先 Redis 时必须比对 DB `revision`（或等价）；不一致则弃缓存读 DB。
+2. 或改为 **事务 commit 成功后再写 Redis**，并提供 invalidate；禁止「DB 回滚后 Redis 残留幻影 grant」。
+
+### 6. resolve 锁与条件提交（P2-12）
+
+1. 防重锁包 try/finally（或等价释放），避免异常后 60s 误 409。
+2. 状态迁移用条件 UPDATE（`WHERE status=PAUSED`）或 version 乐观锁，禁止无条件覆盖已 FAILED/已回收的 run。
+
+## Consequences
+
+* 暂停/恢复/重放行为对用户可预测；减少「DONE 但旧版本」「永 RUNNING」。
+* 域层收口会触及 `api/runs.py` 与 `graph.py` 较大移动——需测试护栏。
+* Scheduler 回收 RUNNING 可能打断长任务：阈值与阈值必须和 ADR-08/09 租约心跳一致。
+
+## Non-goals
+
+* 更换 LangGraph checkpointer 实现品牌。
+* 多区域共享 checkpoint（单区域 Postgres+Redis 足够）。

--- a/docs/adr/ADR-11-sandbox-hosting-resources.md
+++ b/docs/adr/ADR-11-sandbox-hosting-resources.md
@@ -1,0 +1,65 @@
+# ADR-11: Sandbox & Hosting Resources / SoT
+
+* Status: **Accepted**
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+* Related: P1-12～16, P2-1/3/6/21～23；衔接 [ADR-03](./ADR-03-sandbox-provider-strategy.md)；[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+
+---
+
+## Context
+
+Sandbox / builder / hosting 在故障分类、容器生命周期、日志、进程组、路径校验与 Hosting SoT 上不一致。Compose 部署强制 Docker（见 ADR-03 修订），因此 Docker 路径加固是生产问题，不是「仅 local 开发」。
+
+**核实：** DockerError 吞成 build 文案、无 AutoRemove/LogConfig、WS relay 泄漏、local 无进程组、`write_version_layers` 穿透 local——属实。P2-6「heavy 不可达」为 **部分属实**（auto 可选 heavy；问题是配置三处分裂）。
+
+## Decision
+
+### 1. failure_kind 贯通（P1-12 / P2-3）
+
+1. `BuildResult`（及同类）携带结构化 `failure_kind`：至少 `infra` / `build` / `timeout` / `oom`。
+2. Docker daemon / 拉镜像失败标 `infra`，**不得**进入 LLM 修复烧 token 循环。
+3. Reliability 分类只消费类型字段，禁止依赖中文错误字符串嗅探；`sandbox_failed` HITL 必须有真实写入点。
+
+### 2. 容器与临时目录生命周期（P1-13 / P1-14）
+
+1. 容器 HostConfig：`AutoRemove`（或等价）+ 日志轮转（如 json-file `max-size`/`max-file`）。
+2. `container.log` 使用 `tail=N`，禁止无界读入 worker 内存。
+3. Worker 启动时清扫命名前缀孤儿容器与 `gf-*-sandbox-*` 类临时目录。
+
+### 3. 进程组与路径纵深（P1-16 / P2-23）
+
+1. Local / shell builder：POSIX `start_new_session` + 杀进程组；Windows 用 Job Object 或文档化等价方案。
+2. Backend 写文件时校验 `rel` 规范化后仍在 workspace 内，不唯依赖调用方 `_normalize_files`。
+
+### 4. Docker 用户与 tier 配置（P2-21 / P2-6）
+
+1. `DockerSandbox` 复用 builder 的 uid/user spec 与 bind mount 权限对齐，避免 EACCES / 不必要的 root。
+2. `tier → 资源/超时` 收敛进 `config.py`（或单一模块表）；`docker` / `local` / `builder` 禁止各写一套魔法数。
+3. `get_sandbox().create` 支持 tier 透传；auto 推荐与显式 tier 行为可测。
+
+### 5. HostingBackend 协议补全（P2-1）
+
+1. `write_version_layers`、删除/prune、目录语义纳入 `HostingBackend`；禁止 store 门面永远写 local 而声称 OSS 为 SoT。
+2. 若保留本地 cache：文档明确 cache vs SoT，prune 必须同时清理远端对象。
+
+### 6. WS relay 生命周期（P1-15）
+
+1. Relay task 创建后立即纳入 try/finally；`ready.wait` / replay / disconnect 全覆盖。
+2. 客户端在 replay 期断开必须取消 relay，禁止 exclusive 队列与 memory bus 无界堆积。
+
+### 7. E2B 启用前置（P2-22）
+
+1. 在 ADR-03 首选 E2B 真正启用前：会话句柄须可持久化并对账回收；禁止仅模块级 `_LIVE` 字典。
+2. 未满足前，生产保持可观测的 Docker 路径（与 ADR-03 修订一致）。
+
+## Consequences
+
+* Infra 故障不再伪装成「代码质量差」；磁盘/内存打满风险下降。
+* Hosting 多后端行为一致，OSS 泄漏可治理。
+* tier 单表可能改变个别引擎的超时体感——需回归构建超时用例。
+
+## Non-goals
+
+* 立刻切换全部流量到 E2B（仍由 ADR-03 + 密钥/对账就绪决定）。
+* 重写整个构建流水线产品形态。

--- a/docs/adr/ADR-12-api-frontend-ops-debt.md
+++ b/docs/adr/ADR-12-api-frontend-ops-debt.md
@@ -1,0 +1,56 @@
+# ADR-12: API, Frontend & Ops Debt
+
+* Status: **Accepted**（Section A/B/C 一并 Accept；实施仍可分批）
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+* Related: P1-24～26；P2-5, P2-8～11, P2-13～20, P2-24～30；[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+
+---
+
+## Context
+
+审查后半段为 API 幂等/校验/分页、前端 Forge/WS/鉴权体验、运维资源与观测债务。单项多为 P2，但 **P1-24/25/26** 会直接造成错游戏操作、假失败、误登出，应优先于一般 P2。
+
+**核实：** Forge 切游戏不重置、WS 闭包旧 token、`fetchDraftHtml` 自刷新——属实。其余 P2 按机制归类，实施前 spot-check。
+
+## Decision
+
+本 ADR 分三节独立 Accept，避免「一纸绑死全部债务」。
+
+### Section A — 前端高优先级（P1-24/25/26）【建议随批次 B】
+
+1. `routeGameId` 变化时重置全部 run 相关 state，或 `ForgePage` 使用 `key={gameId}` 强制重挂载。
+2. WS 重连从 auth store **重读**最新 access token；4401 时先 refresh 再重试；增加应用层心跳。
+3. `fetchDraftHtml` 必须走与 `client.ts` 相同的 single-flight refresh，禁止并发 refresh 清会话。
+
+### Section B — API 契约（P2-8～13）【排期】
+
+1. 建状态端点补齐幂等五件套（对照 `create_run`）：`Idempotency-Key` / 创建锁 / 部分唯一索引 / 限流；`fork` 至少幂等键。
+2. 先查后写统一捕获 `IntegrityError` → 409 或幂等成功（reactions / handle / preferences）。
+3. Pydantic 补 `max_length` / `ge`；`feedback.run_id` 用 UUID 类型。
+4. 列表接口补分页（game runs、publish queue 历史等）。
+5. 限流键：统一可信代理下的客户端 IP 策略，并加账号维度；禁止反代后全站共享一个桶。
+
+### Section C — 运维 / 观测 / 其余前端（P2-5, 14～20, 24～30）【排期】
+
+1. **LLM provider：** 厂商差异走 profile，禁止主干硬编码域名/模型子串；usage 缺帧记 0 + 告警，**禁止字符估算**（对齐 CLAUDE.md）。
+2. **Outbox / scheduler：** 已发布行定时清理；cancel 下推谓词；scheduler `FOR UPDATE SKIP LOCKED` + per-row try/except。
+3. **RabbitWsBus：** 复用长生命周期 channel；exchange declare 缓存。
+4. **同步 IO：** `rmtree` / `copytree` / chmod 扫描等挪 `asyncio.to_thread`，避免卡住租约心跳。
+5. **Lifespan：** `engine.dispose()` + Redis pool `aclose()`。
+6. **Metrics：** `/preview/{token}`、`/play/{slug}` 按路由模板归一化 label。
+7. **Analytics：** `play_count` 原子自增；UV 不依赖可伪造 XFF。
+8. **图状态：** `_qa_html` 等大字段禁止无白名单并入主图 state（P2-24）。
+9. **前端体验：** 轮询 deps 用原始值；messages 上限；run 状态收敛 react-query；ChatPanel 滚动跟随。
+10. **Token 存储：** refresh 迁 httpOnly cookie + 会话族检测；WS 改首帧鉴权或短期票据（可单独安全子节）。
+
+## Consequences
+
+* Section A 显著降低工坊误操作与「假失败」。
+* Section B/C 降低 500、DoS 限流误伤、连接泄漏与报表失真。
+* 分节 Accept 允许 Owner 只签字 A，其余保持 Proposed。
+
+## Non-goals
+
+* 一次性重写全部前端状态管理框架。
+* 在本 ADR 内重新定义产品配额数值（配额强制策略见 ADR-07）。

--- a/docs/adr/ADR-MODIFICATION-GUIDE-2026-08-16.md
+++ b/docs/adr/ADR-MODIFICATION-GUIDE-2026-08-16.md
@@ -1,0 +1,186 @@
+# ADR 修改指南（2026-08-16 全项目设计审查）
+
+* Status: **Guide**（配套决策均已 Accepted；见 ACCEPT-CHECKLIST）
+* Source: [2026-08-16-full-project-design-review.md](../2026-08-16-full-project-design-review.md)
+* Date: 2026-08-16
+* Accepted-by: ByteTitan-star
+
+---
+
+## 1. TL;DR
+
+1. 审查报告中的 **P0 / 多数 P1 在源码中属实**，应转化为可签字的 Architecture Decision，而不是直接当实现工单堆砌。
+2. 按 **决策边界** 拆成 **6 份新 ADR（07～12）**，并 **修订 ADR-03、ADR-05**；现有 ADR-01/02/04/06 本次不改正文。
+3. 本指南给出：**核实结论 → 映射表 → Accept 顺序 → 各 ADR 链接**。实现计划另开；此处不改业务代码。
+
+---
+
+## 2. 核实方法与口径
+
+| 口径 | 含义 |
+| --- | --- |
+| **属实** | 源码/compose 可定位到审查描述的机制；后果链路成立 |
+| **部分属实** | 机制存在，但严重度、触发条件或「完全不可达」等表述需收窄 |
+| **夸大 / 误报** | 关键断言与当前代码不符（本次极少） |
+| **未逐行复验** | 机制同类、或依赖组合路径；接受审查结论但实施前再 spot-check |
+
+抽查覆盖：`config.py`、`manifest.py`、`builder.py`、`docker-compose.yml`、`db.py`、`redis.py`、`worker.py`、`graph.py`、`auth.py`、`oauth.py`、`trial.py`、`ws/runs.py`、`ForgePage.tsx`、`ws/client.ts`、`hosting/store.py`、`reliability/policy.py`、`sandbox/tiers.py` 等。
+
+---
+
+## 3. 核实结论摘要
+
+### 3.1 P0 — 全部属实
+
+| ID | 结论 | 证据要点 |
+| --- | --- | --- |
+| P0-1 | **属实** | `jwt_secret` 有可用默认值；无 `env != development` fail-fast |
+| P0-2 | **属实**（RCE 面收窄） | `merge_workspace` 无保留文件黑名单；`packageManager` 仅 `startswith("pnpm@")` 后拼进 `create_subprocess_shell`。**宿主机 RCE** 主要在 `builder_backend=local` + Windows；Docker builder 仍有 manifest 覆盖与供应链面 |
+| P0-3 | **属实** | `docker-compose.yml` 的 `backend`/`worker` **无** `restart:` |
+| P0-4 | **属实** | `create_async_engine` 无 statement/command timeout；Redis pool 无 socket timeout；`done` 节点未挂 `TimeoutPolicy`（其它节点有） |
+
+### 3.2 P1 — 核心项属实（节选）
+
+| ID | 结论 | 备注 |
+| --- | --- | --- |
+| P1-1～4 | **属实** | 整 run 包在 `message.process`；busy 路径 `sleep(2)` 且不递增 retry；崩溃重投 `resume=False` |
+| P1-5 | **属实** | `try_begin_side_effect` → `promote` → `commit` 顺序 |
+| P1-6 | **属实** | `user_pause` 检查点仅 `design_doc`；恢复路由强制 `art_options` |
+| P1-7 | **属实** | `resume_grant` 与 `RUNNING` 同事务消费；scheduler 只回收 PAUSED |
+| P1-8/9 | **属实** | 邮件与 run 同队列；失败立即 republish；DLQ 无消费者 |
+| P1-10/11 | **属实** | audit 未对齐 `audit_request_timeout`；`code_or_repair` 预算与内部串行工作量错配 |
+| P1-12～16 | **属实** | DockerError→build 文案；无 AutoRemove/LogConfig；WS relay 在 try 外；local kill 无进程组 |
+| P1-17～20 | **属实** | verify-email 无限流；OAuth 绑定不查 `email_verified`；base_url 无主机限制；dev 路由靠 `env==development` |
+| P1-21～23 | **属实** | prepare 联网 + 共享 store rw；配额仅 start_run 检查；trial 拦截面极窄 |
+| P1-24～26 | **属实** | 切游戏不重置 state；WS 重连用闭包旧 token；`fetchDraftHtml` 自刷新绕过单飞 |
+
+### 3.3 需收窄的表述
+
+| ID | 审查原文 | 核实后 |
+| --- | --- | --- |
+| P2-6 | 「heavy 档不可达」 | **部分属实**。`resolve_create_tier` / `recommend_tier` **可以**返回 `heavy`（引擎/体量/近期压力）。真问题是 **docker/local/builder 三处超时与资源表分裂**，以及 create 未传 explicit tier 时依赖 auto 启发式 |
+| ADR-03 vs compose | 「生产首选 E2B」 | **配置分裂**。`config` 默认 `sandbox_backend=e2b`，但 **compose 强制 `SANDBOX_BACKEND=docker`**。部署路径上 Docker 加固不可因「ADR 写了 E2B」而跳过 |
+| P0-2 RCE | 「Windows 本地 builder RCE」 | **属实但范围收窄**：local+Windows 为命令注入；全后端均受 manifest 覆盖影响 |
+
+### 3.4 P2 — 抽样属实，批量纳入 ADR-12 / 专项 ADR
+
+Hosting 穿透 local（P2-1）、HITL 词表多处复制（P2-2）、中文错误嗅探（P2-3）、checkpoint revision 未消费（P2-4）、RetryPolicy 无 `retry_on`（P2-25）等已 spot-check 或与 P1 同根。其余 P2 按「同类机制」纳入 ADR-12，实施前再逐条复验。
+
+---
+
+## 4. 与现有 ADR 的关系
+
+| 现有 ADR | 本次动作 | 原因 |
+| --- | --- | --- |
+| ADR-01 降级产物发布 | **不改** | 与审查无冲突；promote 幂等时序由 ADR-10 补 |
+| ADR-02 偏好保留 | **不改** | 范围外 |
+| ADR-03 沙箱选型 | **修订** | 写明 compose/回退路径仍须 Docker/local 加固；tier 配置收敛 |
+| ADR-04 会话存储 | **不改** | 范围外 |
+| ADR-05 可恢复暂停 | **修订** | 补充检查点合并语义、phase 词表归属、与 grant/RUNNING 回收的边界 |
+| ADR-06 语义缓存 | **不改** | 范围外（与 FLAG 默认值一致性另议，不在本次） |
+
+---
+
+## 5. 新建 / 修订 ADR 一览
+
+| ADR | 文件 | 覆盖审查项 | 建议 Status |
+| --- | --- | --- | --- |
+| [ADR-07](./ADR-07-production-security-baseline.md) | 生产安全基线 | P0-1/2，P1-17～23 | **Accepted** |
+| [ADR-08](./ADR-08-worker-messaging-reliability.md) | Worker / 消息可靠性 | P0-3，P1-1～4/8/9 | **Accepted** |
+| [ADR-09](./ADR-09-timeout-and-io-boundaries.md) | 超时与 IO 边界 | P0-4，P1-10/11 | **Accepted** |
+| [ADR-10](./ADR-10-checkpoint-hitl-idempotency.md) | Checkpoint / HITL / 幂等 | P1-5/6/7，P2-2/4/7/12 | **Accepted** |
+| [ADR-11](./ADR-11-sandbox-hosting-resources.md) | Sandbox / Hosting 资源与 SoT | P1-12～16，P2-1/3/6/21～23 | **Accepted** |
+| [ADR-12](./ADR-12-api-frontend-ops-debt.md) | API / 前端 / 运维债 | P1-24～26，其余 P2 | **Accepted** |
+| [ADR-03 修订](./ADR-03-sandbox-provider-strategy.md) | 沙箱策略补强 | P2-6/21/22 + compose 现实 | **Accepted** |
+| [ADR-05 修订](./ADR-05-recoverable-pause-representation.md) | 暂停表示补强 | P1-6/7，P2-2 | **Accepted** |
+
+---
+
+## 6. 审查项 → ADR 完整映射
+
+### P0
+
+| ID | ADR |
+| --- | --- |
+| P0-1 | ADR-07 |
+| P0-2 | ADR-07（+ ADR-11 store/隔离相关） |
+| P0-3 | ADR-08 |
+| P0-4 | ADR-09 |
+
+### P1 可靠性
+
+| ID | ADR |
+| --- | --- |
+| P1-1, P1-2, P1-3, P1-4 | ADR-08 |
+| P1-5, P1-6, P1-7 | ADR-10（衔接 ADR-05） |
+| P1-8, P1-9 | ADR-08 |
+| P1-10, P1-11 | ADR-09 |
+| P1-12 | ADR-11（failure_kind） |
+| P1-13, P1-14, P1-15, P1-16 | ADR-11 |
+
+### P1 安全
+
+| ID | ADR |
+| --- | --- |
+| P1-17～23 | ADR-07 |
+
+### P1 前端
+
+| ID | ADR |
+| --- | --- |
+| P1-24, P1-25, P1-26 | ADR-12 |
+
+### P2
+
+| ID | ADR |
+| --- | --- |
+| P2-1, P2-3, P2-6, P2-21～23 | ADR-11 / ADR-03 |
+| P2-2, P2-4, P2-7, P2-12 | ADR-10 / ADR-05 |
+| P2-5, P2-8～11, P2-13～20, P2-24～30 | ADR-12 |
+| P2-25 RetryPolicy | ADR-09（与超时/重试同策）或 ADR-12；**决策写入 ADR-09** |
+
+---
+
+## 7. 建议 Accept / 实施顺序
+
+与审查「修复优先级」对齐，但以 **ADR 签字** 为单位：
+
+| 批次 | ADR | 对应审查批次 |
+| --- | --- | --- |
+| **A（上线前）** | ADR-07、ADR-08、ADR-09；ADR-03/05 修订段 | P0 + 安全五连 + 消息丢失 + 超时 |
+| **B（一周内）** | ADR-10、ADR-11 | Worker 状态机 + sandbox/WS 泄漏 |
+| **C（排期）** | ADR-12 分节 Accept | 配额、API 债、前端体验、运维 |
+
+**跨 ADR 共享根因（实施时合并 PR 亦可）：**
+
+1. 超时体系 → ADR-09  
+2. `failure_kind` 贯通 → ADR-11  
+3. Checkpoint 单一真相源 → ADR-10  
+4. HITL 域层收口 → ADR-10 + ADR-05  
+5. HostingBackend 协议补全 → ADR-11  
+
+---
+
+## 8. Accept 检查建议
+
+签字前至少确认：
+
+- [ ] 每份 ADR 的 Decision 可映射到可测验收（测试或运维检查项）
+- [ ] ADR-07 与 CLAUDE.md「禁硬编码密钥」一致  
+- [ ] ADR-03 修订后，compose 的 `SANDBOX_BACKEND=docker` 不再与文档矛盾  
+- [ ] ADR-05/10 对 `user_pause` / `resume_grant` / RUNNING 回收无互相打架的表述  
+- [ ] ADR-12 标明哪些条款可延后，避免「一纸 Accept 绑死全部 P2」
+
+机器证据：可后续扩展 `tests/test_adr_evidence.py`（现有文件仅覆盖 ADR-02/03/04 类不变量）。
+
+---
+
+## 9. 明确不在本次指南范围
+
+- 实现代码与具体 PR 拆分（用 writing-plans / 实现会话）
+- ADR-06 / Pinecone / 偏好抽取路径变更
+- 敏感词检测文档、官方小游戏资源是否迁出等产品决策（审查 CLAUDE 违反表仅记录，不升格为 ADR-07 强制项，除非 Owner 另批）
+
+---
+
+*本指南随 ADR-07～12 与 ADR-03/05 修订一并维护；审查原文仍以 `docs/2026-08-16-full-project-design-review.md` 为问题清单 SoT。*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,14 +3,23 @@
 Accepted Architecture Decision Records for Forge Runtime evolution.
 Full narrative lives in [2026-08-15-forge-runtime-evolution-plan.md](../2026-08-15-forge-runtime-evolution-plan.md).
 
+Design-review follow-up (verify + modification guide):
+[ADR-MODIFICATION-GUIDE-2026-08-16.md](./ADR-MODIFICATION-GUIDE-2026-08-16.md)
+
 | ADR | Title | Status | Accepted-by |
 | --- | --- | --- | --- |
 | [ADR-01](./ADR-01-degraded-artifact-publishing.md) | Degraded Artifact Publishing | **Accepted** | (prior) |
 | [ADR-02](./ADR-02-preference-retention.md) | Preference Retention | **Accepted** | ByteTitan-star |
-| [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Accepted** | ByteTitan-star |
+| [ADR-03](./ADR-03-sandbox-provider-strategy.md) | Sandbox Provider Strategy | **Accepted** (+ 2026-08-16 revision) | ByteTitan-star |
 | [ADR-04](./ADR-04-conversation-storage-migration.md) | Conversation Storage Migration | **Accepted** | ByteTitan-star |
-| [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** | (prior) |
-| [ADR-06](./ADR-06-semantic-pinecone-and-preference-ops.md) | Semantic Cache (Pinecone) + Preference Ops | **Proposed** | — |
+| [ADR-05](./ADR-05-recoverable-pause-representation.md) | Recoverable Pause Representation | **Accepted** (+ 2026-08-16 revision) | ByteTitan-star |
+| [ADR-06](./ADR-06-semantic-pinecone-and-preference-ops.md) | Semantic Cache (Pinecone) + Preference Ops | **Accepted** | ByteTitan-star |
+| [ADR-07](./ADR-07-production-security-baseline.md) | Production Security Baseline | **Accepted** | ByteTitan-star |
+| [ADR-08](./ADR-08-worker-messaging-reliability.md) | Worker & Messaging Reliability | **Accepted** | ByteTitan-star |
+| [ADR-09](./ADR-09-timeout-and-io-boundaries.md) | Timeout & IO Boundaries | **Accepted** | ByteTitan-star |
+| [ADR-10](./ADR-10-checkpoint-hitl-idempotency.md) | Checkpoint, HITL & Idempotency | **Accepted** | ByteTitan-star |
+| [ADR-11](./ADR-11-sandbox-hosting-resources.md) | Sandbox & Hosting Resources / SoT | **Accepted** | ByteTitan-star |
+| [ADR-12](./ADR-12-api-frontend-ops-debt.md) | API, Frontend & Ops Debt | **Accepted** | ByteTitan-star |
 
 Sign-off record: [ACCEPT-CHECKLIST.md](./ACCEPT-CHECKLIST.md)  
 Feature flag defaults: [FLAG-INVENTORY.md](./FLAG-INVENTORY.md)


### PR DESCRIPTION
## Summary
- Accept ADR-07 through ADR-12 covering production security, worker/messaging reliability, timeout/IO boundaries, checkpoint/HITL/idempotency, sandbox/hosting resources, and API/frontend/ops debt.
- Revise ADR-03 and ADR-05 for compose/Docker reality and recoverable-pause semantics; record Owner acceptances in ACCEPT-CHECKLIST.
- Add the source design-review report and ADR modification guide with verification notes and mapping tables.

## Background
Follow-up to `docs/2026-08-16-full-project-design-review.md`. Findings were spot-checked against the codebase; decisions are documented as Accepted ADRs (implementation remains follow-on work).

## Changes
- New: ADR-07..12, ADR-MODIFICATION-GUIDE-2026-08-16, design-review report
- Updated: ADR-03, ADR-05, README, ACCEPT-CHECKLIST

## Test plan
- [ ] Review ADR index links resolve
- [ ] Confirm ACCEPT-CHECKLIST lists ADR-07..12 and ADR-03/05 revisions as Accept
- [ ] Skim ADR-07/08/09 Decisions for launch blockers before implementation PRs

## Impact & Risks
Docs-only; no runtime behavior change until implementation PRs land.

Made with [Cursor](https://cursor.com)