### PR TITLE
feat(security): implement ADR Batch A P0 security and reliability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
       - id: mypy
         name: mypy
-        entry: uv run --no-project python scripts/run_backend_tool.py mypy --install-types --non-interactive
+        entry: uv run --no-project python scripts/run_backend_tool.py mypy --follow-imports=silent --install-types --non-interactive
         language: system
         pass_filenames: true  # ✅ 只检查改动文件
         files: '^backend/.*\.py$'

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -152,6 +152,8 @@ AUDIT_LEXICON_DIR=
 
 # 全局
 ENV=development
+# ADR-07：dev 调试路由显式开关（默认关；本地开发需要 /api/v1/dev/* 时设 true）
+DEV_ROUTES_ENABLED=true
 LOG_LEVEL=INFO
 # 日志落盘：空=仓库根 logs/（backend.log / worker.log）；-=仅 stdout
 LOG_DIR=

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -9,6 +9,7 @@ from app.auth import services
 from app.auth.deps import CurrentUser, DbSession, RedisClient
 from app.auth.ratelimit import check_rate_limit
 from app.core.config import settings
+from app.core.errors import AppError, ErrorCode
 from app.core.response import ApiResponse, ErrorResponse
 from app.email import queue as email_queue
 from app.enums import Role
@@ -91,9 +92,43 @@ async def refresh(req: RefreshReq, db: DbSession, r: RedisClient) -> ApiResponse
     )
 
 
-@router.post("/verify-email", response_model=ApiResponse[VerifyEmailResp], responses=ERR_400)
-async def verify_email(req: VerifyEmailReq, db: DbSession) -> ApiResponse[VerifyEmailResp]:
-    user = await services.verify_email(db, req.email, req.code)
+@router.post(
+    "/verify-email",
+    response_model=ApiResponse[VerifyEmailResp],
+    responses={**ERR_400, **ERR_429},
+)
+async def verify_email(
+    req: VerifyEmailReq, request: Request, db: DbSession, r: RedisClient
+) -> ApiResponse[VerifyEmailResp]:
+    host = request.client.host if request.client else "na"
+    email_key = req.email.strip().lower()
+    await check_rate_limit(
+        r,
+        f"rl:verify:{host}",
+        settings.default_rate_limit_per_min,
+        60,
+    )
+    await check_rate_limit(
+        r,
+        f"rl:verify:email:{email_key}",
+        settings.default_rate_limit_per_min,
+        60,
+    )
+    fail_key = f"verify_fail:{email_key}"
+    try:
+        user = await services.verify_email(db, req.email, req.code)
+    except AppError:
+        fails = int(await r.incr(fail_key))
+        await r.expire(fail_key, settings.verify_email_ttl)
+        if fails >= settings.verify_email_max_failures:
+            await services.invalidate_pending_verifications_for_email(db, req.email)
+            await r.delete(fail_key)
+            raise AppError(
+                ErrorCode.VALIDATION_ERROR,
+                "验证失败次数过多，请重新获取验证码",
+            ) from None
+        raise
+    await r.delete(fail_key)
     return ApiResponse(data=VerifyEmailResp(user_id=user.id))
 
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -3,6 +3,8 @@
 路由薄，业务在 app.auth.services；错误经 AppError 转 ErrorResponse；限流走 Redis。
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Request, status
 
 from app.auth import services
@@ -36,10 +38,16 @@ from app.schemas.common import UserPublic
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 # docs/10 §3 错误码对应响应，供 openapi 标注
-ERR_401 = {401: {"model": ErrorResponse, "description": "未认证或 token 失效"}}
-ERR_400 = {400: {"model": ErrorResponse, "description": "token 无效或已过期"}}
-ERR_409 = {409: {"model": ErrorResponse, "description": "邮箱已注册"}}
-ERR_429 = {429: {"model": ErrorResponse, "description": "限流"}}
+ERR_401: dict[int | str, dict[str, Any]] = {
+    401: {"model": ErrorResponse, "description": "未认证或 token 失效"}
+}
+ERR_400: dict[int | str, dict[str, Any]] = {
+    400: {"model": ErrorResponse, "description": "token 无效或已过期"}
+}
+ERR_409: dict[int | str, dict[str, Any]] = {
+    409: {"model": ErrorResponse, "description": "邮箱已注册"}
+}
+ERR_429: dict[int | str, dict[str, Any]] = {429: {"model": ErrorResponse, "description": "限流"}}
 
 
 @router.post(
@@ -52,8 +60,10 @@ async def register(
     req: RegisterReq, request: Request, db: DbSession, r: RedisClient
 ) -> ApiResponse[RegisterResp]:
     await check_rate_limit(
-        r, f"rl:register:{request.client.host if request.client else 'na'}",
-        settings.default_rate_limit_per_min, 60,
+        r,
+        f"rl:register:{request.client.host if request.client else 'na'}",
+        settings.default_rate_limit_per_min,
+        60,
     )
     user, code = await services.register_user(db, req.email, req.password)
     await email_queue.enqueue_verification(user.email, code)
@@ -65,8 +75,10 @@ async def login(
     req: LoginReq, request: Request, db: DbSession, r: RedisClient
 ) -> ApiResponse[LoginResp]:
     await check_rate_limit(
-        r, f"rl:login:{request.client.host if request.client else 'na'}",
-        settings.default_rate_limit_per_min, 60,
+        r,
+        f"rl:login:{request.client.host if request.client else 'na'}",
+        settings.default_rate_limit_per_min,
+        60,
     )
     user, access, refresh = await services.login_user(db, r, req.email, req.password)
     return ApiResponse(
@@ -75,8 +87,10 @@ async def login(
             refresh_token=refresh,
             expires_in=settings.jwt_access_ttl,
             user=UserPublic(
-                user_id=user.id, email=user.email,
-                role=Role(user.role), email_verified=user.email_verified,
+                user_id=user.id,
+                email=user.email,
+                role=Role(user.role),
+                email_verified=user.email_verified,
             ),
         )
     )
@@ -187,9 +201,7 @@ async def password_reset_confirm(
     req: PasswordResetConfirmReq, db: DbSession
 ) -> ApiResponse[PasswordResetConfirmResp]:
     user = await services.confirm_password_reset(db, req.token, req.new_password)
-    return ApiResponse(
-        data=PasswordResetConfirmResp(user_id=user.id, email=user.email)
-    )
+    return ApiResponse(data=PasswordResetConfirmResp(user_id=user.id, email=user.email))
 
 
 @router.post(

--- a/backend/app/auth/oauth.py
+++ b/backend/app/auth/oauth.py
@@ -96,6 +96,7 @@ async def _github_profile(code: str) -> OAuthProfile:
         email = data.get("email") or f"{data['id']}@users.noreply.github.com"
         return OAuthProfile(provider_sub=str(data["id"]), email=email, name=data.get("login"))
 
+
 async def _google_profile(code: str) -> OAuthProfile:
     async with httpx.AsyncClient(timeout=15) as client:
         tok = await client.post(

--- a/backend/app/auth/oauth.py
+++ b/backend/app/auth/oauth.py
@@ -148,6 +148,11 @@ async def oauth_callback(
 
     existing = await db.scalar(select(User).where(User.email == profile.email))
     if existing is not None:
+        if not existing.email_verified:
+            raise AppError(
+                ErrorCode.EMAIL_NOT_VERIFIED,
+                "该邮箱已注册但未验证，请先完成邮箱验证后再关联 OAuth",
+            )
         db.add(
             OAuthAccount(
                 user_id=existing.id,

--- a/backend/app/auth/services.py
+++ b/backend/app/auth/services.py
@@ -106,6 +106,16 @@ async def resend_verification(db: AsyncSession, email: str) -> str | None:
     return await _issue_verification_code(db, user.id)
 
 
+async def invalidate_pending_verifications_for_email(
+    db: AsyncSession, email: str
+) -> None:
+    """作废某邮箱用户全部未使用验证码（爆破达限后调用）。"""
+    user = await db.scalar(select(User).where(User.email == email))
+    if user is None:
+        return
+    await _invalidate_pending_verifications(db, user.id)
+
+
 async def verify_email(db: AsyncSession, email: str, code: str) -> User:
     user = await db.scalar(select(User).where(User.email == email))
     if user is None:

--- a/backend/app/auth/services.py
+++ b/backend/app/auth/services.py
@@ -106,9 +106,7 @@ async def resend_verification(db: AsyncSession, email: str) -> str | None:
     return await _issue_verification_code(db, user.id)
 
 
-async def invalidate_pending_verifications_for_email(
-    db: AsyncSession, email: str
-) -> None:
+async def invalidate_pending_verifications_for_email(db: AsyncSession, email: str) -> None:
     """作废某邮箱用户全部未使用验证码（爆破达限后调用）。"""
     user = await db.scalar(select(User).where(User.email == email))
     if user is None:
@@ -147,9 +145,7 @@ async def login_user(
     return await issue_session(db, r, user)
 
 
-async def issue_session(
-    db: AsyncSession, r: redis.Redis, user: User
-) -> tuple[User, str, str]:
+async def issue_session(db: AsyncSession, r: redis.Redis, user: User) -> tuple[User, str, str]:
     if user.disabled:
         raise AppError(ErrorCode.FORBIDDEN, await disabled_user_message(db))
     access = create_access_token(user_id=user.id, role=user.role)
@@ -157,9 +153,7 @@ async def issue_session(
     return user, access, refresh
 
 
-async def refresh_tokens(
-    db: AsyncSession, r: redis.Redis, refresh_token: str
-) -> tuple[str, str]:
+async def refresh_tokens(db: AsyncSession, r: redis.Redis, refresh_token: str) -> tuple[str, str]:
     rotated = await rotate_refresh(r, refresh_token)
     if rotated is None:
         raise AppError(ErrorCode.UNAUTHORIZED, "refresh token 无效")
@@ -177,9 +171,7 @@ async def logout(r: redis.Redis, refresh_token: str) -> None:
     await revoke_refresh(r, refresh_token)
 
 
-async def request_password_reset(
-    db: AsyncSession, email: str
-) -> tuple[str, str] | None:
+async def request_password_reset(db: AsyncSession, email: str) -> tuple[str, str] | None:
     """防枚举：用户不存在时返回 None，调用方仍恒返回 sent=true。"""
     user = await db.scalar(select(User).where(User.email == email))
     if user is None or is_trial_user(user):
@@ -196,9 +188,7 @@ async def request_password_reset(
     return user.email, token
 
 
-async def confirm_password_reset(
-    db: AsyncSession, token: str, new_password: str
-) -> User:
+async def confirm_password_reset(db: AsyncSession, token: str, new_password: str) -> User:
     row = await _consume_token(db, PasswordResetToken, token)
     user = await db.get(User, row.user_id)
     if user is None:
@@ -232,7 +222,9 @@ async def _consume_token(
     """校验+消费 token：未过期、未使用，否则 VALIDATION_ERROR。"""
     stmt = select(model).where(model.token_hash == _hash_token(token))
     row = await db.scalar(stmt)
-    if row is None or row.used_at is not None:
+    if not isinstance(row, (EmailVerification, PasswordResetToken)):
+        raise AppError(ErrorCode.VALIDATION_ERROR, "token 无效或已用")
+    if row.used_at is not None:
         raise AppError(ErrorCode.VALIDATION_ERROR, "token 无效或已用")
     if _utcnow() > _aware(row.expires_at):
         raise AppError(ErrorCode.VALIDATION_ERROR, "token 已过期")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -81,6 +81,7 @@ class Settings(BaseSettings):
     default_daily_token_limit: int = 500_000
     default_monthly_token_limit: int = 10_000_000
     default_rate_limit_per_min: int = 30
+    verify_email_max_failures: int = 5  # 验证码连续失败达限后作废 pending 码
     # LLM 连通测试（真实付费调用）每分钟上限，比通用限流更紧
     llm_probe_rate_limit_per_min: int = 5
     # create_run 幂等缓存有效期（秒）：同一 Idempotency-Key 在窗口内复用同一 run
@@ -234,6 +235,8 @@ class Settings(BaseSettings):
 
     # 全局
     env: str = "development"
+    # ADR-07 P1-20：dev 调试路由显式开关（默认关；本地/pytest 在 .env 或 conftest 打开）
+    dev_routes_enabled: bool = False
     log_level: str = "INFO"
     # 落盘目录：空=仓库根 logs/；-=仅 stdout（pytest）
     log_dir: str = ""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,11 @@ class Settings(BaseSettings):
     rabbitmq_url: str = "amqp://gameforge:gameforge@localhost:5672/"
     # rabbitmq | memory（pytest 默认 memory，见 conftest）
     messaging_backend: str = "rabbitmq"
+    # ADR-09：基建客户端超时（秒）
+    db_connect_timeout: int = 10
+    db_command_timeout: int = 60
+    redis_socket_connect_timeout: float = 5.0
+    redis_socket_timeout: float = 5.0
 
     # 加密与签名
     jwt_secret: str = "dev-secret-change-me-to-a-32-byte-random-string"

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -4,7 +4,19 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from app.core.config import settings
 
-engine = create_async_engine(settings.database_url, pool_pre_ping=True, future=True)
+_connect_args: dict[str, object] = {}
+if settings.database_url.startswith("postgresql"):
+    _connect_args = {
+        "timeout": settings.db_connect_timeout,
+        "command_timeout": settings.db_command_timeout,
+    }
+
+engine = create_async_engine(
+    settings.database_url,
+    pool_pre_ping=True,
+    future=True,
+    connect_args=_connect_args,
+)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -4,7 +4,12 @@ import redis.asyncio as redis
 
 from app.core.config import settings
 
-pool = redis.ConnectionPool.from_url(settings.redis_url, decode_responses=True)
+pool = redis.ConnectionPool.from_url(
+    settings.redis_url,
+    decode_responses=True,
+    socket_connect_timeout=settings.redis_socket_connect_timeout,
+    socket_timeout=settings.redis_socket_timeout,
+)
 
 
 async def get_redis() -> AsyncIterator[redis.Redis]:

--- a/backend/app/core/security_boot.py
+++ b/backend/app/core/security_boot.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.core.config import Settings
 
-DEFAULT_JWT_SECRET = "dev-secret-change-me-to-a-32-byte-random-string"
+DEFAULT_JWT_SECRET = "dev-secret-change-me-to-a-32-byte-random-string"  # nosec B105
 
 
 def assert_production_secrets(settings: Settings) -> None:

--- a/backend/app/core/security_boot.py
+++ b/backend/app/core/security_boot.py
@@ -1,0 +1,22 @@
+"""Startup secret checks (ADR-07 / P0-1)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.config import Settings
+
+DEFAULT_JWT_SECRET = "dev-secret-change-me-to-a-32-byte-random-string"
+
+
+def assert_production_secrets(settings: Settings) -> None:
+    """Refuse to boot outside development with a default or short JWT secret."""
+    if settings.env == "development":
+        return
+    secret = (settings.jwt_secret or "").strip()
+    if secret == DEFAULT_JWT_SECRET or len(secret) < 32:
+        raise RuntimeError(
+            "JWT_SECRET must be set to a non-default value of at least 32 characters "
+            f"when env={settings.env!r}"
+        )

--- a/backend/app/forge/build/manifest.py
+++ b/backend/app/forge/build/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import json
 from typing import Any
 
@@ -10,6 +11,31 @@ from app.forge.build.constants import BUILDER_ALLOWED_BUILDS
 from app.forge.build.profile import BuildProfile, default_build_profile
 from app.forge.build.routing import BuildRouting, resolve_package_versions
 from app.forge.build.template import load_vite_ts_template_files
+
+# LLM source_files 不得覆盖的平台 manifest（ADR-07 P0-2）
+PROTECTED_WORKSPACE_FILES = frozenset(
+    {
+        "package.json",
+        "pnpm-workspace.yaml",
+        "pnpm-lock.yaml",
+        "package-lock.json",
+        "yarn.lock",
+        "tsconfig.json",
+        "build-profile.json",
+    }
+)
+PROTECTED_WORKSPACE_GLOBS = ("vite.config.*",)
+
+
+def _normalize_workspace_rel(rel: str) -> str:
+    return rel.replace("\\", "/").lstrip("./")
+
+
+def is_protected_workspace_file(rel: str) -> bool:
+    name = _normalize_workspace_rel(rel)
+    if name in PROTECTED_WORKSPACE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pattern) for pattern in PROTECTED_WORKSPACE_GLOBS)
 
 
 def _split_deps(resolved: dict[str, str]) -> tuple[dict[str, str], dict[str, str]]:
@@ -121,7 +147,10 @@ def merge_workspace(
 ) -> dict[str, str]:
     """平台 manifest + LLM 业务源码；缺 index.html 时平台注入。"""
     workspace = dict(generate_manifest_files(routing, profile))
-    workspace.update(source_files)
+    for rel, content in source_files.items():
+        if is_protected_workspace_file(rel):
+            continue
+        workspace[rel] = content
     if "index.html" not in workspace:
         workspace["index.html"] = generate_platform_index_html()
     return workspace

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -72,9 +72,7 @@ from app.sandbox.playtest import run_playtest, run_playtest_dist  # noqa: F401
 PLAN_MAX_ATTEMPTS = 3
 
 # resume 时需要推进凭据 resume_grant 的 HITL 检查点阶段；与 app.api.runs._HITL_PHASES 对齐。
-_HITL_RESUME_PHASES = frozenset(
-    {"plan_confirm", "art_confirm", "sandbox_failed", "qa_failed"}
-)
+_HITL_RESUME_PHASES = frozenset({"plan_confirm", "art_confirm", "sandbox_failed", "qa_failed"})
 
 log = logging.getLogger(__name__)
 
@@ -93,9 +91,7 @@ def _read_html(path: Path) -> str:
         return data.decode("gbk", errors="replace")
 
 
-async def _save_thumbnail(
-    s: AsyncSession, game: Game, version: int, png: bytes
-) -> None:
+async def _save_thumbnail(s: AsyncSession, game: Game, version: int, png: bytes) -> None:
     """把 QA 通过时截的封面落盘并写库（GameVersion.thumbnail_path + Game.cover_path）。
 
     截图是封面增强项：任何异常只 log、不 raise，run 继续进 done（静默降级，卡片回退渐变）。
@@ -238,9 +234,7 @@ def _ensure_charset(html: str) -> str:
     # 没有 <head>：紧跟 <!DOCTYPE html> 之后插入一个最小 head。
     m = re.search(r"<!doctype html\s*>", html, re.IGNORECASE)
     if m:
-        return (
-            html[: m.end()] + "<head><meta charset=\"utf-8\"></head>" + html[m.end() :]
-        )
+        return html[: m.end()] + '<head><meta charset="utf-8"></head>' + html[m.end() :]
     return html
 
 
@@ -283,9 +277,7 @@ class RunFinalized(Exception):
 
 
 class _Ctx:
-    def __init__(
-        self, s: AsyncSession, r: redis.Redis, run: GenerationRun, game: Game
-    ) -> None:
+    def __init__(self, s: AsyncSession, r: redis.Redis, run: GenerationRun, game: Game) -> None:
         self.s = s
         self.r = r
         self.run = run
@@ -331,9 +323,7 @@ async def _refresh_session_summary(ctx: _Ctx) -> None:
                 )
                 return content
 
-            return await synthesize_summary_via_llm(
-                turns, previous, complete=complete
-            )
+            return await synthesize_summary_via_llm(turns, previous, complete=complete)
 
     await refresh_session_summary_if_needed(ctx.s, ctx.game, summarizer=summarizer)
 
@@ -367,11 +357,7 @@ async def _compose_plan_input(
     )
     if design_doc is None:
         return built.user_message
-    return (
-        "【当前完整设计稿 JSON】\n"
-        f"{design_doc_to_text(design_doc)}\n\n"
-        + built.user_message
-    )
+    return f"【当前完整设计稿 JSON】\n{design_doc_to_text(design_doc)}\n\n" + built.user_message
 
 
 async def _compose_art_input(
@@ -384,13 +370,10 @@ async def _compose_art_input(
     """Art/revise 用户消息：经 ContextBuilder 注入 summary/preferences。"""
     await _refresh_session_summary(ctx)
     await _upsert_preferences_from_text(ctx, current_input)
-    design_block = (
-        "【已确认游戏策划稿 JSON】\n" + design_doc_to_text(design_doc)
-    )
+    design_block = "【已确认游戏策划稿 JSON】\n" + design_doc_to_text(design_doc)
     if previous_options is not None:
-        design_block += (
-            "\n\n【上一轮方向 JSON】\n"
-            + json.dumps(previous_options, ensure_ascii=False)
+        design_block += "\n\n【上一轮方向 JSON】\n" + json.dumps(
+            previous_options, ensure_ascii=False
         )
     if not current_input.strip():
         prompt_input = "请基于已确认策划稿给出美术方向选项。"
@@ -450,9 +433,7 @@ async def _streamed_llm_or_fallback(
     打字机价值低且避免产生上千事件）。
     """
     if settings.stream_enabled:
-        return await run_streamed_llm(
-            ctx, system, user_msg, phase=phase, emit_delta=emit_delta
-        )
+        return await run_streamed_llm(ctx, system, user_msg, phase=phase, emit_delta=emit_delta)
     return await _llm(ctx, system, user_msg)
 
 
@@ -625,11 +606,7 @@ async def _pause_recoverable(
         pause_reason=PauseReason.RECOVERABLE_ERROR,
         design_doc=existing.get("design_doc"),
         recovery=recovery,
-        extra={
-            k: v
-            for k, v in existing.items()
-            if k not in {"pause_reason", "recovery", "phase"}
-        },
+        extra={k: v for k, v in existing.items() if k not in {"pause_reason", "recovery", "phase"}},
     )
     await ckpt.save_state(ctx.r, ctx.run.id, checkpoint, ctx.s)
     await add_message(
@@ -697,9 +674,7 @@ async def _check_ctrl(
 
 
 def _build_graph(ctx: _Ctx) -> Any:
-    async def generate_design_doc(
-        system_prompt: str, user_msg: str
-    ) -> dict[str, Any]:
+    async def generate_design_doc(system_prompt: str, user_msg: str) -> dict[str, Any]:
         """生成并真实校验策划稿；格式错误时把具体问题反馈给模型自修复。"""
         issues: list[str] = []
         design_doc: dict[str, Any] = {}
@@ -808,9 +783,7 @@ def _build_graph(ctx: _Ctx) -> Any:
     async def revise_plan_node(state: ForgeState) -> dict:
         with observe_phase("plan"):
             await _set_phase(ctx, RunPhase.PLAN)
-            current_doc = coerce_design_doc(
-                state.get("design_doc") or {}, ctx.game.title
-            )
+            current_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
             user_msg = await _compose_plan_input(
                 ctx,
                 current_input=state.get("modify_text") or "",
@@ -914,9 +887,7 @@ def _build_graph(ctx: _Ctx) -> Any:
 
     async def art_options_node(state: ForgeState) -> dict:
         with observe_phase("art"):
-            design_doc = coerce_design_doc(
-                state.get("design_doc") or {}, ctx.game.title
-            )
+            design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
             await _set_phase(ctx, RunPhase.ART)
             ctrl = await _check_ctrl(ctx, design_doc)
             if ctrl != "ok":
@@ -926,9 +897,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "failed": ctrl == "cancel",
                 }
             try:
-                user_msg = await _compose_art_input(
-                    ctx, current_input="", design_doc=design_doc
-                )
+                user_msg = await _compose_art_input(ctx, current_input="", design_doc=design_doc)
                 art_hints = {
                     "requirement": ctx.game.requirement or "",
                     "goal": (design_doc.get("title") or ctx.game.title or ""),
@@ -947,9 +916,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                 "art_options": art_options,
             }
             await ckpt.save_state(ctx.r, ctx.run.id, checkpoint, ctx.s)
-            await _pause_hitl(
-                ctx, "art_confirm", design_doc, extra={"art_options": art_options}
-            )
+            await _pause_hitl(ctx, "art_confirm", design_doc, extra={"art_options": art_options})
             return {
                 "design_doc": design_doc,
                 "art_options": art_options,
@@ -959,9 +926,7 @@ def _build_graph(ctx: _Ctx) -> Any:
     async def revise_art_options_node(state: ForgeState) -> dict:
         with observe_phase("art"):
             await _set_phase(ctx, RunPhase.ART)
-            design_doc = coerce_design_doc(
-                state.get("design_doc") or {}, ctx.game.title
-            )
+            design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
             ctrl = await _check_ctrl(ctx, design_doc)
             if ctrl != "ok":
                 return {
@@ -1000,9 +965,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                 },
                 ctx.s,
             )
-            await _pause_hitl(
-                ctx, "art_confirm", design_doc, extra={"art_options": art_options}
-            )
+            await _pause_hitl(ctx, "art_confirm", design_doc, extra={"art_options": art_options})
             return {
                 "design_doc": design_doc,
                 "art_options": art_options,
@@ -1014,9 +977,7 @@ def _build_graph(ctx: _Ctx) -> Any:
     async def art_detail_node(state: ForgeState) -> dict:
         with observe_phase("art"):
             await _set_phase(ctx, RunPhase.ART)
-            design_doc = coerce_design_doc(
-                state.get("design_doc") or {}, ctx.game.title
-            )
+            design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
             ctrl = await _check_ctrl(ctx, design_doc)
             if ctrl != "ok":
                 return {
@@ -1126,9 +1087,7 @@ def _build_graph(ctx: _Ctx) -> Any:
 
     async def code_qa_loop_node(state: ForgeState) -> dict:
         """主图包装：调用子图；ok 则 promote，exhausted 则 PAUSED HITL。"""
-        design_doc = coerce_design_doc(
-            state.get("design_doc") or {}, ctx.game.title
-        )
+        design_doc = coerce_design_doc(state.get("design_doc") or {}, ctx.game.title)
         loop_in: dict[str, Any] = {
             "design_doc": design_doc,
             "artifacts": state.get("artifacts") or [],
@@ -1148,10 +1107,10 @@ def _build_graph(ctx: _Ctx) -> Any:
         else:
             loop_in["attempt"] = int(state.get("attempt") or 0)
 
-        subgraph = build_code_qa_loop(
-            code_or_repair=code_or_repair_node,
-            playtest=playtest_node,
-            diagnose=diagnose_node,
+        subgraph = build_code_qa_loop(  # type: ignore[arg-type]
+            code_or_repair=code_or_repair_node,  # type: ignore[arg-type]
+            playtest=playtest_node,  # type: ignore[arg-type]
+            diagnose=diagnose_node,  # type: ignore[arg-type]
         )
         result = await subgraph.ainvoke(loop_in)
 
@@ -1173,9 +1132,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "design_doc": design_doc,
                     "playtest_errors": ["qa_ok 但缺少 candidate_version"],
                 }
-            key = side_effect_key(
-                ctx.run.id, "code_qa_loop", f"v{int(version)}", "promote"
-            )
+            key = side_effect_key(ctx.run.id, "code_qa_loop", f"v{int(version)}", "promote")
             if await try_begin_side_effect(ctx.r, key):
                 promote_candidate(ctx.game, int(version))
                 await ctx.s.commit()
@@ -1208,9 +1165,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "art_direction": result.get("art_direction")
                     or state.get("art_direction")
                     or {},
-                    "artifacts": result.get("artifacts")
-                    or state.get("artifacts")
-                    or [],
+                    "artifacts": result.get("artifacts") or state.get("artifacts") or [],
                     "candidate_version": result.get("candidate_version"),
                     **gate.as_dict(),
                 },
@@ -1284,11 +1239,11 @@ def _build_graph(ctx: _Ctx) -> Any:
             return {}
 
     def after_plan(state: ForgeState) -> Literal["__end__"]:
-        return END
+        return END  # type: ignore[return-value]
 
     def after_art(state: ForgeState) -> Literal["code_qa_loop", "__end__"]:
         if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
-            return END
+            return END  # type: ignore[return-value]
         return "code_qa_loop"
 
     def after_code_qa(
@@ -1296,9 +1251,9 @@ def _build_graph(ctx: _Ctx) -> Any:
     ) -> Literal["done", "__end__"]:
         if state.get("qa_ok"):
             return "done"
-        return END
+        return END  # type: ignore[return-value]
 
-    def _node_kwargs(policy_key: str) -> dict[str, object]:
+    def _node_kwargs(policy_key: str) -> Any:
         if not settings.reliability_node_timeout:
             return {}
         return {
@@ -1313,7 +1268,7 @@ def _build_graph(ctx: _Ctx) -> Any:
     g.add_node("revise_art_options", revise_art_options_node, **_node_kwargs("art"))
     g.add_node("art_detail", art_detail_node, **_node_kwargs("art"))
     g.add_node("code_qa_loop", code_qa_loop_node, **_node_kwargs("code_qa_loop"))
-    g.add_node("done", done_node)
+    g.add_node("done", done_node, **_node_kwargs("done"))
     g.add_conditional_edges(
         START,
         route_start,
@@ -1328,18 +1283,12 @@ def _build_graph(ctx: _Ctx) -> Any:
     )
     g.add_conditional_edges("plan", after_plan, {END: END})
     g.add_conditional_edges("revise_plan", after_plan, {END: END})
-    g.add_conditional_edges(
-        "art_options", after_art, {"code_qa_loop": "code_qa_loop", END: END}
-    )
+    g.add_conditional_edges("art_options", after_art, {"code_qa_loop": "code_qa_loop", END: END})
     g.add_conditional_edges(
         "revise_art_options", after_art, {"code_qa_loop": "code_qa_loop", END: END}
     )
-    g.add_conditional_edges(
-        "art_detail", after_art, {"code_qa_loop": "code_qa_loop", END: END}
-    )
-    g.add_conditional_edges(
-        "code_qa_loop", after_code_qa, {"done": "done", END: END}
-    )
+    g.add_conditional_edges("art_detail", after_art, {"code_qa_loop": "code_qa_loop", END: END})
+    g.add_conditional_edges("code_qa_loop", after_code_qa, {"done": "done", END: END})
     g.add_edge("done", END)
     return g.compile()
 
@@ -1381,15 +1330,11 @@ async def run_generation(
             inactive = run.status in (RunStatus.FAILED.value, RunStatus.DONE.value)
             duplicate_execute = not resume and run.status != RunStatus.RUNNING.value
             if inactive or duplicate_execute or run.ended_at is not None:
-                log.warning(
-                    "skip inactive run", extra={"stage": stage, "status": run.status}
-                )
+                log.warning("skip inactive run", extra={"stage": stage, "status": run.status})
                 return
             try:
                 with observe_run(str(run_id)):
-                    await _run_body(
-                        s, r, run, game, run_id, resume, decision, modify_text
-                    )
+                    await _run_body(s, r, run, game, run_id, resume, decision, modify_text)
                 duration = round(time.monotonic() - started, 3)
                 log.info(
                     "request completed",
@@ -1452,13 +1397,11 @@ async def run_generation(
                     return
 
                 classified = (
-                    e
-                    if isinstance(e, FatalError) or is_recoverable(e)
-                    else classify_exception(e)
+                    e if isinstance(e, FatalError) or is_recoverable(e) else classify_exception(e)
                 )
                 if is_fatal(classified) or isinstance(e, AppError):
                     fail_code = (
-                        e.code.value if isinstance(e, AppError) else classified.error_code
+                        e.code.value if isinstance(e, AppError) else classified.error_code  # type: ignore[attr-defined]
                     )
                     fail_msg = f"本轮生成失败：{e}"
                     run.status = RunStatus.FAILED.value
@@ -1487,7 +1430,7 @@ async def run_generation(
                     await _pause_recoverable(
                         forge_ctx,
                         phase=run.phase or "code",
-                        error_code=classified.error_code,
+                        error_code=classified.error_code,  # type: ignore[attr-defined]
                         message=f"可恢复故障，已暂停：{classified}",
                         attempts=1,
                     )

--- a/backend/app/forge/guard.py
+++ b/backend/app/forge/guard.py
@@ -286,11 +286,7 @@ class Guard:
 
             parsed = _parse_verdict(content)
             if parsed is not None:
-                return (
-                    _LlmAuditStatus.MALICIOUS
-                    if parsed
-                    else _LlmAuditStatus.CLEAN
-                )
+                return _LlmAuditStatus.MALICIOUS if parsed else _LlmAuditStatus.CLEAN
 
             last_raw = content.strip()
             if attempt < _AUDIT_MAX_RETRIES:
@@ -299,8 +295,7 @@ class Guard:
                     extra={"attempt": attempt + 1, "raw_preview": last_raw[:50]},
                 )
                 user_msg = (
-                    f"{user_msg}\n\n{_AUDIT_RETRY_HINT}\n"
-                    f"上次输出：{last_raw[:80] or '(empty)'}"
+                    f"{user_msg}\n\n{_AUDIT_RETRY_HINT}\n上次输出：{last_raw[:80] or '(empty)'}"
                 )
                 continue
 
@@ -401,9 +396,7 @@ def _resolve_provider(value: str) -> LLMProvider:
         return LLMProvider.OPENAI_COMPAT
 
 
-async def _emit_attacked(
-    ctx: Any, *, side: str, res: AuditResult, phase: str
-) -> None:
+async def _emit_attacked(ctx: Any, *, side: str, res: AuditResult, phase: str) -> None:
     """发 ATTACKED 事件。前端收到后断 WS + 弹友好提示。run 终态由 run_generation 处理。"""
     await publish_event(
         ctx.run.id,
@@ -439,8 +432,14 @@ async def run_streamed_llm(
     """
     guard = await build_guard(ctx)
 
-    # 1) 输入侧审核
-    in_res = await guard.audit(user_msg)
+    # 1) 输入侧审核（受 audit_request_timeout 约束，超时视为未命中）
+    try:
+        in_res = await asyncio.wait_for(
+            guard.audit(user_msg),
+            timeout=settings.audit_request_timeout,
+        )
+    except TimeoutError:
+        in_res = None
     if in_res is not None and in_res.is_malicious:
         await _emit_attacked(ctx, side="input", res=in_res, phase=phase)
         raise ContentAttacked(
@@ -452,9 +451,9 @@ async def run_streamed_llm(
 
     started = time.monotonic()
     content_parts: list[str] = []
-    batch_buf: list[str] = []          # 微批缓冲：攒够发一个 LLM_DELTA
+    batch_buf: list[str] = []  # 微批缓冲：攒够发一个 LLM_DELTA
     last_flush = started
-    pending: list[str] = []            # 自上次输出审核以来的增量
+    pending: list[str] = []  # 自上次输出审核以来的增量
     last_audit_at = started
     usage = llm_provider.Usage()
     audit_task: asyncio.Task | None = None  # 后台审核 task：不阻塞 token 流
@@ -490,9 +489,7 @@ async def run_streamed_llm(
                 batch_buf.append(chunk.delta)
                 pending.append(chunk.delta)
                 if emit_delta:
-                    last_flush = await _maybe_flush(
-                        ctx, phase, batch_buf, last_flush, force=False
-                    )
+                    last_flush = await _maybe_flush(ctx, phase, batch_buf, last_flush, force=False)
             if chunk.usage is not None:
                 usage = chunk.usage
             # 已启动的后台审核完成 → 立刻检查结果（不阻塞 token 流）
@@ -524,7 +521,7 @@ async def run_streamed_llm(
             audit_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await audit_task
-        await gen.aclose()
+        await gen.aclose()  # type: ignore[attr-defined]
 
     # 流结束：emit_delta 时 flush 残留微批；再发 LLM_CALL（usage，对齐现有 _llm 事件字段）
     if emit_delta and batch_buf:
@@ -568,4 +565,3 @@ def _detect_provider(ctx: Any) -> str:
     """
     provider = getattr(getattr(ctx, "run", None), "provider", None)
     return str(provider) if provider else "unknown"
-

--- a/backend/app/forge/reliability/policy.py
+++ b/backend/app/forge/reliability/policy.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from langgraph.types import RetryPolicy, TimeoutPolicy
 
 from app.core.config import settings
+from app.core.errors import AppError
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,7 +31,7 @@ NODE_EXECUTION_POLICIES: dict[str, NodeExecutionPolicy] = {
     "code_or_repair": NodeExecutionPolicy(run_timeout_margin_s=120.0, max_attempts=2),
     "playtest": NodeExecutionPolicy(fixed_run_timeout_s=90.0, max_attempts=2),
     "diagnose": NodeExecutionPolicy(run_timeout_margin_s=30.0, max_attempts=2),
-    # 外墙：给满 attempt 预算的粗上限；细粒度 timeout 在子图节点上
+    "done": NodeExecutionPolicy(fixed_run_timeout_s=30.0, max_attempts=1),
     "code_qa_loop": NodeExecutionPolicy(
         fixed_run_timeout_s=None,
         run_timeout_margin_s=0.0,
@@ -45,7 +46,6 @@ def resolve_node_run_timeout(node: str) -> float:
         return float(policy.fixed_run_timeout_s)
     llm = float(settings.llm_request_timeout)
     if node == "code_qa_loop":
-        # attempt × (code + playtest + diagnose) 粗算，避免外墙先于子步骤超时
         attempts = max(1, int(settings.code_qa_max_attempts))
         per = (
             resolve_node_run_timeout("code_or_repair")
@@ -53,17 +53,35 @@ def resolve_node_run_timeout(node: str) -> float:
             + resolve_node_run_timeout("diagnose")
         )
         return float(attempts * per)
+    if node == "code_or_repair" and settings.build_pipeline_enabled:
+        build_budget = float(
+            max(1, settings.build_max_retries) * max(1, settings.builder_timeout_s)
+        )
+        return llm + float(policy.run_timeout_margin_s) + build_budget
     return llm + float(policy.run_timeout_margin_s)
 
 
 def langgraph_timeout_policy(node: str) -> TimeoutPolicy:
     policy = NODE_EXECUTION_POLICIES[node]
-    kwargs: dict[str, float] = {"run_timeout": resolve_node_run_timeout(node)}
+    run_timeout = resolve_node_run_timeout(node)
     if policy.idle_timeout_s is not None:
-        kwargs["idle_timeout"] = float(policy.idle_timeout_s)
-    return TimeoutPolicy(**kwargs)
+        return TimeoutPolicy(
+            run_timeout=run_timeout,
+            idle_timeout=float(policy.idle_timeout_s),
+        )
+    return TimeoutPolicy(run_timeout=run_timeout)
+
+
+def _default_retry_on(exc: Exception) -> bool:
+    """Exclude business-terminal errors from LangGraph node retries (ADR-09)."""
+    if isinstance(exc, AppError):
+        return False
+    return type(exc).__name__ not in {"ContentAttacked", "RunFinalized"}
 
 
 def langgraph_retry_policy(node: str) -> RetryPolicy:
     policy = NODE_EXECUTION_POLICIES[node]
-    return RetryPolicy(max_attempts=max(1, policy.max_attempts))
+    return RetryPolicy(
+        max_attempts=max(1, policy.max_attempts),
+        retry_on=_default_retry_on,
+    )

--- a/backend/app/llm/services.py
+++ b/backend/app/llm/services.py
@@ -14,6 +14,7 @@ from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
 from app.enums import LLMProvider
 from app.llm import crypto, provider
+from app.llm.url_safety import validate_llm_base_url
 from app.models.llm_config import UserLLMConfig
 from app.models.user import User
 from app.schemas.llm_config import (
@@ -98,6 +99,7 @@ async def create_config(
     db: AsyncSession, user: User, req: LLMConfigCreate
 ) -> LLMConfigCreateResp:
     """连通测试通过才保存（docs/05 §连通性测试）。openai_compat 校验 base_url。"""
+    validate_llm_base_url(req.base_url)
     ok, err = await provider.test_connectivity(
         req.provider, req.apikey, req.model, req.base_url
     )
@@ -151,6 +153,7 @@ async def delete_config(
 
 async def test_draft_config(req: LLMConfigTestReq) -> LLMConfigDryTestResp:
     """保存前探测，不写入数据库。"""
+    validate_llm_base_url(req.base_url)
     ok, err = await provider.test_connectivity(
         req.provider, req.apikey, req.model, req.base_url
     )

--- a/backend/app/llm/services.py
+++ b/backend/app/llm/services.py
@@ -95,14 +95,10 @@ async def _unset_default(db: AsyncSession, user: User) -> None:
     )
 
 
-async def create_config(
-    db: AsyncSession, user: User, req: LLMConfigCreate
-) -> LLMConfigCreateResp:
+async def create_config(db: AsyncSession, user: User, req: LLMConfigCreate) -> LLMConfigCreateResp:
     """连通测试通过才保存（docs/05 §连通性测试）。openai_compat 校验 base_url。"""
     validate_llm_base_url(req.base_url)
-    ok, err = await provider.test_connectivity(
-        req.provider, req.apikey, req.model, req.base_url
-    )
+    ok, err = await provider.test_connectivity(req.provider, req.apikey, req.model, req.base_url)
     if not ok:
         raise AppError(ErrorCode.LLM_CONFIG_INVALID, f"连通测试失败: {err}")
     if req.is_default:
@@ -137,9 +133,7 @@ async def patch_config(
     return _to_resp(cfg)
 
 
-async def delete_config(
-    db: AsyncSession, user: User, config_id: UUID
-) -> LLMConfigDeleteResp:
+async def delete_config(db: AsyncSession, user: User, config_id: UUID) -> LLMConfigDeleteResp:
     cfg = await _get_owned(db, user, config_id)
     if cfg.is_default:
         stmt = select(UserLLMConfig).where(UserLLMConfig.user_id == user.id)
@@ -154,15 +148,11 @@ async def delete_config(
 async def test_draft_config(req: LLMConfigTestReq) -> LLMConfigDryTestResp:
     """保存前探测，不写入数据库。"""
     validate_llm_base_url(req.base_url)
-    ok, err = await provider.test_connectivity(
-        req.provider, req.apikey, req.model, req.base_url
-    )
+    ok, err = await provider.test_connectivity(req.provider, req.apikey, req.model, req.base_url)
     return LLMConfigDryTestResp(tested_ok=ok, error=err)
 
 
-async def test_config(
-    db: AsyncSession, user: User, config_id: UUID
-) -> LLMConfigTestResp:
+async def test_config(db: AsyncSession, user: User, config_id: UUID) -> LLMConfigTestResp:
     cfg = await _get_owned(db, user, config_id)
     ok, err = await provider.test_connectivity(
         LLMProvider(cfg.provider),

--- a/backend/app/llm/url_safety.py
+++ b/backend/app/llm/url_safety.py
@@ -1,0 +1,88 @@
+"""Validate user-supplied LLM base_url against SSRF (ADR-07 P1-19)."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from app.core.config import settings
+from app.core.errors import AppError, ErrorCode
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return bool(
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _host_allowed_in_development(host: str) -> bool:
+    return host in {"localhost", "127.0.0.1", "::1"}
+
+
+def validate_llm_base_url(base_url: str | None, *, env: str | None = None) -> None:
+    """Raise AppError if base_url is missing scheme/host or targets private/metadata nets.
+
+    Empty base_url is allowed (provider defaults). Development may use http://localhost.
+    """
+    if base_url is None or not str(base_url).strip():
+        return
+    raw = str(base_url).strip()
+    parsed = urlparse(raw)
+    scheme = (parsed.scheme or "").lower()
+    host = (parsed.hostname or "").lower()
+    current_env = env if env is not None else settings.env
+
+    if not host:
+        raise AppError(ErrorCode.LLM_CONFIG_INVALID, "base_url 缺少主机名")
+
+    if scheme == "https":
+        pass
+    elif scheme == "http" and current_env == "development" and _host_allowed_in_development(
+        host
+    ):
+        pass
+    else:
+        raise AppError(
+            ErrorCode.LLM_CONFIG_INVALID,
+            "base_url 仅允许 https（development 可对本机使用 http）",
+        )
+
+    if host in {"metadata.google.internal", "metadata"}:
+        raise AppError(ErrorCode.LLM_CONFIG_INVALID, "base_url 主机不允许")
+
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        addr = None
+
+    if addr is not None:
+        if _is_blocked_ip(addr) and not (
+            current_env == "development" and _host_allowed_in_development(host)
+        ):
+            raise AppError(ErrorCode.LLM_CONFIG_INVALID, "base_url 禁止指向内网或保留地址")
+        return
+
+    # Hostname: resolve and reject if any A/AAAA is blocked (best-effort).
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            resolved = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if _is_blocked_ip(resolved) and not (
+            current_env == "development" and _host_allowed_in_development(host)
+        ):
+            raise AppError(
+                ErrorCode.LLM_CONFIG_INVALID,
+                "base_url 解析到内网或保留地址，已拒绝",
+            )

--- a/backend/app/llm/url_safety.py
+++ b/backend/app/llm/url_safety.py
@@ -41,10 +41,8 @@ def validate_llm_base_url(base_url: str | None, *, env: str | None = None) -> No
     if not host:
         raise AppError(ErrorCode.LLM_CONFIG_INVALID, "base_url 缺少主机名")
 
-    if scheme == "https":
-        pass
-    elif scheme == "http" and current_env == "development" and _host_allowed_in_development(
-        host
+    if scheme == "https" or (
+        scheme == "http" and current_env == "development" and _host_allowed_in_development(host)
     ):
         pass
     else:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from app.core.errors import register_exception_handlers
 from app.core.langfuse import flush_langfuse, init_langfuse
 from app.core.logging import setup_logging
 from app.core.metrics import register_metrics
+from app.core.security_boot import assert_production_secrets
 from app.games.official import seed_official_games
 from app.hosting import routes as hosting_routes
 from app.ws import runs as ws_runs
@@ -44,6 +45,7 @@ API_V1 = "/api/v1"
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """启动：init langfuse + dev 自动 seed 官方游戏；停机 flush 缓冲 trace（docs/02 §可观测）。"""
+    assert_production_secrets(settings)
     init_langfuse()
     if settings.env == "development":
         await _dev_seed_official_games()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,7 +99,7 @@ register_metrics(app)
 
 app.include_router(health.router)
 app.include_router(auth.router, prefix=API_V1)
-if settings.env == "development":
+if settings.dev_routes_enabled:
     app.include_router(dev.router, prefix=API_V1)
 app.include_router(llm_config.router, prefix=API_V1)
 app.include_router(games.router, prefix=API_V1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,8 +72,7 @@ async def _dev_seed_official_games() -> None:
         )
     except Exception:
         log.exception(
-            "dev seed 失败（不阻断启动），请手动执行 "
-            "`uv run python -m scripts.seed_official_games`"
+            "dev seed 失败（不阻断启动），请手动执行 `uv run python -m scripts.seed_official_games`"
         )
 
 

--- a/backend/app/messaging/worker.py
+++ b/backend/app/messaging/worker.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from app.core.config import settings
 from app.core.logging import setup_logging
+from app.core.security_boot import assert_production_secrets
 from app.messaging.handlers import dispatch_task  # 任务分发器
 from app.messaging.rabbit import _task_channel, close_connection  # RabbitMQ 连接管理
 from app.messaging.tasks import (  # 队列名称和消息解码
@@ -297,6 +298,7 @@ def main() -> None:
     """
     # 初始化日志：服务标识为 "worker"，按配置的级别和目录输出
     setup_logging(settings.log_level, service="worker", log_dir=settings.log_dir)
+    assert_production_secrets(settings)
     # worker 是独立进程，需各自注册 langfuse 单例（run_generation 在此进程跑）
     from app.core.langfuse import init_langfuse
 

--- a/backend/app/messaging/worker.py
+++ b/backend/app/messaging/worker.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from app.core.config import settings
 from app.core.logging import setup_logging
@@ -31,14 +31,14 @@ if TYPE_CHECKING:
 def _is_transport_reset_noise(context: dict[str, object]) -> bool:
     """
     判断是否为 Windows 上传输层重置的噪音错误。
-    
+
     背景：Windows + asyncio 环境下，当远程服务器（如 SMTP 邮件服务器）主动关闭连接时，
     asyncio 会抛出 ConnectionResetError (WinError 10054)。
     这通常发生在邮件已成功发送后的连接清理阶段，不影响业务功能。
-    
+
     参数：
         context: asyncio 异常上下文，包含 'exception' 和 'message' 字段
-    
+
     返回：
         bool: 如果是已知噪音错误返回 True，否则返回 False
     """
@@ -52,11 +52,11 @@ def _worker_loop_exception_handler(
 ) -> None:
     """
     自定义 asyncio 事件循环异常处理器。
-    
+
     作用：
         1. 捕获并降级 Windows 上连接清理的噪音错误（避免污染日志）
         2. 其他异常走默认处理流程
-    
+
     参数：
         loop: asyncio 事件循环
         context: 异常上下文信息
@@ -119,38 +119,37 @@ def _message_retry_count(message: AbstractIncomingMessage) -> int:
     headers = message.headers or {}
     raw = headers.get(HEADER_RETRY_COUNT, 0)
     try:
-        return max(0, int(raw))
+        return max(0, int(cast(Any, raw)))
     except (TypeError, ValueError):
         return 0
 
 
-def _merged_headers(
-    message: AbstractIncomingMessage, **extra: object
-) -> dict[str, object]:
-    headers = dict(message.headers or {})
+def _merged_headers(message: AbstractIncomingMessage, **extra: Any) -> dict[str, Any]:
+    headers: dict[str, Any] = dict(message.headers or {})
     headers.update(extra)
     return headers
 
 
-async def _republish_task(
-    message: AbstractIncomingMessage, task: str, *, retry_count: int
-) -> None:
+async def _republish_task(message: AbstractIncomingMessage, task: str, *, retry_count: int) -> None:
     """带递增重试计数重新入队（ack 原消息后由调用方完成）。"""
     import aio_pika
     from aio_pika import Message
 
-    channel, exchange = await _task_channel()
     try:
-        await exchange.publish(
-            Message(
-                body=message.body,
-                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
-                headers=_merged_headers(message, **{HEADER_RETRY_COUNT: retry_count}),
-            ),
-            routing_key=task,
-        )
-    finally:
-        await channel.close()
+        channel, exchange = await _task_channel()
+        try:
+            await exchange.publish(
+                Message(
+                    body=message.body,
+                    delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                    headers=_merged_headers(message, **{HEADER_RETRY_COUNT: retry_count}),
+                ),
+                routing_key=task,
+            )
+        finally:
+            await channel.close()
+    except Exception:
+        log.exception("republish failed task=%s retry=%s", task, retry_count)
 
 
 async def _publish_to_dlq(
@@ -160,39 +159,53 @@ async def _publish_to_dlq(
     import aio_pika
     from aio_pika import Message
 
-    channel, _exchange = await _task_channel()
     try:
-        await channel.declare_queue(TASK_DLQ, durable=True)
-        await channel.default_exchange.publish(
-            Message(
-                body=message.body,
-                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
-                headers=_merged_headers(
-                    message,
-                    **{
-                        HEADER_RETRY_COUNT: retry_count,
-                        "x-death-task": task,
-                        "x-death-reason": error[:500],
-                    },
+        channel, _exchange = await _task_channel()
+        try:
+            await channel.declare_queue(TASK_DLQ, durable=True)
+            await channel.default_exchange.publish(
+                Message(
+                    body=message.body,
+                    delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                    headers=_merged_headers(
+                        message,
+                        **{
+                            HEADER_RETRY_COUNT: retry_count,
+                            "x-death-task": task,
+                            "x-death-reason": error[:500],
+                        },
+                    ),
                 ),
-            ),
-            routing_key=TASK_DLQ,
-        )
-    finally:
-        await channel.close()
+                routing_key=TASK_DLQ,
+            )
+        finally:
+            await channel.close()
+    except Exception:
+        log.exception("DLQ publish failed task=%s retry=%s", task, retry_count)
+
+
+def _retry_backoff_seconds(retry: int) -> float:
+    """指数退避，上限 60s（ADR-08 租约 busy / 失败重投）。"""
+    return float(min(60, 2 ** max(0, retry)))
 
 
 async def _run_one(message: AbstractIncomingMessage) -> None:
     """处理单条消息。
 
-    成功 → ack；TaskLeaseBusy → 短暂休眠后原计数重投；
-    其他失败 → 递增 x-retry-count 重投，超过 worker_max_redeliveries 写入 DLQ 后 ack，
+    成功 → ack；TaskLeaseBusy → 递增计数 + 指数退避重投；
+    其他失败 → 递增 x-retry-count 退避重投，超过 worker_max_redeliveries 写入 DLQ 后 ack。
     避免毒消息无限占用 prefetch 槽位。
     """
     # requeue=False：由本函数显式 republish / DLQ，避免无计数的裸 nack 循环
     async with message.process(requeue=False):
-        task, payload = decode_task(message.body)
         retry = _message_retry_count(message)
+        try:
+            task, payload = decode_task(message.body)
+        except Exception as exc:
+            log.exception("decode_task failed; routing to DLQ")
+            await _publish_to_dlq(message, "undecodable", retry_count=retry, error=str(exc))
+            return
+
         log.info(
             "task=%s payload_keys=%s retry=%s",
             task,
@@ -204,33 +217,71 @@ async def _run_one(message: AbstractIncomingMessage) -> None:
         except Exception as exc:
             from app.forge.runner import TaskLeaseBusy
 
+            max_retries = settings.worker_max_redeliveries
             if isinstance(exc, TaskLeaseBusy):
-                # 租约冲突不算毒消息：不递增计数，短暂退避后原样重投
-                await asyncio.sleep(2)
-                log.info("task lease busy; requeue task=%s retry=%s", task, retry)
-                await _republish_task(message, task, retry_count=retry)
+                if retry >= max_retries:
+                    log.warning(
+                        "task lease busy → DLQ after %s retries task=%s",
+                        retry,
+                        task,
+                    )
+                    await _publish_to_dlq(message, task, retry_count=retry, error=str(exc))
+                    return
+                next_retry = retry + 1
+                delay = _retry_backoff_seconds(retry)
+                await asyncio.sleep(delay)
+                log.info(
+                    "task lease busy; requeue task=%s retry=%s/%s delay=%.0fs",
+                    task,
+                    next_retry,
+                    max_retries,
+                    delay,
+                )
+                await _republish_task(message, task, retry_count=next_retry)
                 return
 
-            max_retries = settings.worker_max_redeliveries
             if retry >= max_retries:
                 log.exception(
                     "task=%s poison → DLQ after %s retries",
                     task,
                     retry,
                 )
-                await _publish_to_dlq(
-                    message, task, retry_count=retry, error=str(exc)
-                )
+                await _publish_to_dlq(message, task, retry_count=retry, error=str(exc))
                 return
 
             next_retry = retry + 1
+            delay = _retry_backoff_seconds(retry)
             log.exception(
-                "task=%s failed; requeue retry=%s/%s",
+                "task=%s failed; requeue retry=%s/%s delay=%.0fs",
                 task,
                 next_retry,
                 max_retries,
+                delay,
             )
+            await asyncio.sleep(delay)
             await _republish_task(message, task, retry_count=next_retry)
+
+
+async def _consume_once(in_flight: set[asyncio.Task]) -> None:
+    """单次连接消费循环；连接断开或异常由外层重连。"""
+    channel, _exchange = await _task_channel()
+    try:
+        await channel.set_qos(prefetch_count=settings.max_concurrent_tasks)
+        queue = await channel.declare_queue(TASK_QUEUE, durable=True)
+        log.info(
+            "worker listening queue=%s concurrency=%s url=%s",
+            TASK_QUEUE,
+            settings.max_concurrent_tasks,
+            settings.rabbitmq_url,
+        )
+        async with queue.iterator() as it:
+            async for message in it:
+                handler = asyncio.create_task(_run_one(message))
+                in_flight.add(handler)
+                handler.add_done_callback(in_flight.discard)
+    finally:
+        with contextlib.suppress(Exception):
+            await channel.close()
 
 
 async def _consume() -> None:
@@ -239,40 +290,29 @@ async def _consume() -> None:
 
     并发模型（docs/02 §可观测）：
         - channel.set_qos(prefetch_count=N)：broker 最多投 N 条未 ack 消息 → 并发=N 且自带背压。
-        - 每条消息起一个 _run_one task：ack 在该 task 结束时触发，慢 LLM 不阻塞消费循环。
+        - 每条消息起一个 _run_one task：ack 在该 task 结束时触发，长 LLM 不阻塞消费循环。
         - asyncio.create_task 拷贝 contextvars，各 run 的 trace_id/run_id/user_id 互不串扰。
         - 水平扩容：多开 worker 进程（docker compose --scale worker=N），竞争消费同一队列。
+        - 外层指数退避重连：单次消费异常不拖死进程（ADR-08）。
     """
-    # 1. 设置事件循环的自定义异常处理器
     asyncio.get_running_loop().set_exception_handler(_worker_loop_exception_handler)
 
-    # 2. 启动定时任务扫描协程（并发执行）
     scan_task = asyncio.create_task(_scheduler_loop())
     outbox_task = asyncio.create_task(_outbox_loop())
     in_flight: set[asyncio.Task] = set()
+    backoff = 1.0
     try:
-        # 3. 连接 RabbitMQ，获取 channel 和交换器
-        channel, _exchange = await _task_channel()
-        # prefetch 限流：ack 在 _run_one 结束时触发，故并发数即 prefetch_count
-        await channel.set_qos(prefetch_count=settings.max_concurrent_tasks)
-        # 声明一个队列，队列名称为 TASK_QUEUE，队列是持久的， durable=True
-        queue = await channel.declare_queue(TASK_QUEUE, durable=True)
-        log.info(
-            "worker listening queue=%s concurrency=%s url=%s",
-            TASK_QUEUE,
-            settings.max_concurrent_tasks,
-            settings.rabbitmq_url,
-        )
-
-        # 4. 消费循环：每条消息交给独立 task，立即继续取下一条
-        async with queue.iterator() as it:
-            async for message in it:
-                handler = asyncio.create_task(_run_one(message))
-                in_flight.add(handler)
-                handler.add_done_callback(in_flight.discard)
+        while True:
+            try:
+                await _consume_once(in_flight)
+                backoff = 1.0
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("worker consume failed; reconnect in %.0fs", backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(60.0, backoff * 2)
     finally:
-        # 5. 清理：停调度循环、等在飞行的任务落地、flush langfuse、关连接。
-        #    被取消的在飞行任务：未正常 ack，broker 会在断连时把未 ack 消息重投，不丢。
         scan_task.cancel()
         outbox_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -290,7 +330,7 @@ async def _consume() -> None:
 def main() -> None:
     """
     Worker 主入口函数。
-    
+
     执行步骤：
         1. 配置日志系统（指定服务名为 'worker'）
         2. 启动异步消息消费协程
@@ -303,7 +343,7 @@ def main() -> None:
     from app.core.langfuse import init_langfuse
 
     init_langfuse()
-    
+
     # 运行异步主协程，捕获 Ctrl+C 信号
     with contextlib.suppress(KeyboardInterrupt):
         asyncio.run(_consume())

--- a/backend/app/sandbox/builder.py
+++ b/backend/app/sandbox/builder.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import json
 import os
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -17,6 +18,16 @@ from aiodocker.exceptions import DockerError
 from app.core.config import settings
 from app.core.metrics import SANDBOX_RUNS
 from app.forge.build.profile import BuildProfile
+
+_PACKAGE_MANAGER_RE = re.compile(r"^pnpm@\d+(\.\d+)*$")
+
+
+def sanitize_package_manager_version(package_manager: str) -> str | None:
+    """Return pnpm version only when packageManager matches ADR-07 whitelist."""
+    pm = (package_manager or "").strip()
+    if not _PACKAGE_MANAGER_RE.fullmatch(pm):
+        return None
+    return pm.split("@", 1)[1]
 
 
 @dataclass
@@ -90,8 +101,9 @@ def corepack_activate_shell(workspace: Path) -> str:
     pkg_path = workspace / "package.json"
     if pkg_path.is_file():
         pm = json.loads(pkg_path.read_text(encoding="utf-8")).get("packageManager", "")
-        if pm.startswith("pnpm@"):
-            version = pm.split("@", 1)[1]
+        sanitized = sanitize_package_manager_version(str(pm or ""))
+        if sanitized:
+            version = sanitized
     return f"corepack prepare pnpm@{version} --activate && "
 
 

--- a/backend/app/sandbox/builder.py
+++ b/backend/app/sandbox/builder.py
@@ -50,7 +50,8 @@ def _docker_user_spec() -> str:
     """与宿主同 uid/gid，避免 bind mount 产物无法清理（CI runner ≠ node:1000）。"""
     if os.name == "nt":
         return "node"
-    return f"{os.getuid()}:{os.getgid()}"
+    # POSIX-only APIs; Windows mypy stubs omit them.
+    return f"{os.getuid()}:{os.getgid()}"  # type: ignore[attr-defined]
 
 
 def _ensure_bind_mount_permissions(path: Path, *, recursive: bool = True) -> None:
@@ -131,8 +132,7 @@ def pnpm_setup_shell(*, store_dir: str = "/pnpm/store", workspace: Path | None =
     reg = registry.replace("'", "")
     st = store.replace("'", "")
     return (
-        f"{prefix}{cache_cfg}pnpm config set registry '{reg}' "
-        f"&& pnpm config set store-dir '{st}'"
+        f"{prefix}{cache_cfg}pnpm config set registry '{reg}' && pnpm config set store-dir '{st}'"
     )
 
 
@@ -216,7 +216,7 @@ class DockerBuilder:
                 "Memory": 1024 * 1024 * 1024,
                 "NanoCpus": 2_000_000_000,
                 "ReadonlyRootfs": True,
-                "Tmpfs": {"/tmp": "rw,noexec,nosuid,size=512m"},
+                "Tmpfs": {"/tmp": "rw,noexec,nosuid,size=512m"},  # nosec B108
                 "SecurityOpt": ["no-new-privileges:true"],
                 "CapDrop": ["ALL"],
             },
@@ -229,7 +229,8 @@ class DockerBuilder:
             except DockerError:
                 await docker.images.pull(self.image)
             container = await docker.containers.create_or_replace(
-                name=f"gf-builder-{workspace.name}", config=config
+                name=f"gf-builder-{workspace.name}",
+                config=config,  # type: ignore[arg-type]
             )
             await container.start()
             try:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,9 +33,7 @@ from app.messaging.factory import reset_messaging
 from app.models import Base
 
 # 单连接 in-memory sqlite（StaticPool 保证 create_all 与查询同一库）
-_engine = create_async_engine(
-    "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, future=True
-)
+_engine = create_async_engine("sqlite+aiosqlite:///:memory:", poolclass=StaticPool, future=True)
 _SessionLocal = async_sessionmaker(_engine, expire_on_commit=False, class_=AsyncSession)
 
 # email -> token（按用途前缀），供测试读取验证/重置 token；notify 列表存通知
@@ -503,9 +501,7 @@ async def admin_client() -> AsyncIterator[httpx.AsyncClient]:
             json={"email": "admin@b.com", "password": "password123"},
         )
         async with _SessionLocal() as s:
-            user = (
-                await s.scalars(select(User).where(User.email == "admin@b.com"))
-            ).first()
+            user = (await s.scalars(select(User).where(User.email == "admin@b.com"))).first()
             assert user is not None
             user.role = "admin"
             await s.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,11 @@
 `uv run pytest` 无需 docker。每测建表/清表隔离；email enqueue 替换为捕获。
 """
 
+import os
+
+# ADR-07：dev 路由默认关闭；测试依赖 /api/v1/dev/*，须在导入 app / Settings 前打开。
+os.environ["DEV_ROUTES_ENABLED"] = "true"
+
 import json
 import uuid
 from collections import defaultdict

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,7 @@
 """M1 认证全闭环：register→verify→login→refresh→logout + 错误路径。"""
 
 import httpx
+import pytest
 
 PWD = "password123"
 EMAIL = "a@b.com"
@@ -165,3 +166,25 @@ async def test_unverified_cannot_create_game_403(client: httpx.AsyncClient) -> N
     )
     assert resp.status_code == 403
     assert resp.json()["error"]["code"] == "EMAIL_NOT_VERIFIED"
+
+
+async def test_verify_email_failures_invalidate_code(
+    client: httpx.AsyncClient, sent: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADR-07：连续验证失败达限后作废 pending 码。"""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "verify_email_max_failures", 3)
+    email = "vf@b.com"
+    await client.post("/api/v1/auth/register", json={"email": email, "password": PWD})
+    good = sent[f"verify:{email}"]
+    for _ in range(3):
+        resp = await client.post(
+            "/api/v1/auth/verify-email", json={"email": email, "code": "000000"}
+        )
+        assert resp.status_code == 400
+    # 达限后正确码也应失效
+    resp = await client.post(
+        "/api/v1/auth/verify-email", json={"email": email, "code": good}
+    )
+    assert resp.status_code == 400

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -11,25 +11,19 @@ async def test_register_verify_login_refresh_logout(
     client: httpx.AsyncClient, sent: dict[str, str]
 ) -> None:
     # 1. 注册（生成 6 位验证码，由 conftest 捕获）
-    resp = await client.post(
-        "/api/v1/auth/register", json={"email": EMAIL, "password": PWD}
-    )
+    resp = await client.post("/api/v1/auth/register", json={"email": EMAIL, "password": PWD})
     assert resp.status_code == 201, resp.text
     token = sent[f"verify:{EMAIL}"]
     assert token
     assert len(token) == 6
 
     # 2. 验证邮箱
-    resp = await client.post(
-        "/api/v1/auth/verify-email", json={"email": EMAIL, "code": token}
-    )
+    resp = await client.post("/api/v1/auth/verify-email", json={"email": EMAIL, "code": token})
     assert resp.status_code == 200, resp.text
     assert resp.json()["data"]["email_verified"] is True
 
     # 3. 登录（已验证）
-    resp = await client.post(
-        "/api/v1/auth/login", json={"email": EMAIL, "password": PWD}
-    )
+    resp = await client.post("/api/v1/auth/login", json={"email": EMAIL, "password": PWD})
     assert resp.status_code == 200, resp.text
     body = resp.json()["data"]
     refresh = body["refresh_token"]
@@ -57,13 +51,9 @@ async def test_register_verify_login_refresh_logout(
 
 
 async def test_register_duplicate_email_409(client: httpx.AsyncClient) -> None:
-    resp = await client.post(
-        "/api/v1/auth/register", json={"email": "dup@b.com", "password": PWD}
-    )
+    resp = await client.post("/api/v1/auth/register", json={"email": "dup@b.com", "password": PWD})
     assert resp.status_code == 201
-    resp = await client.post(
-        "/api/v1/auth/register", json={"email": "dup@b.com", "password": PWD}
-    )
+    resp = await client.post("/api/v1/auth/register", json={"email": "dup@b.com", "password": PWD})
     assert resp.status_code == 409
     assert resp.json()["error"]["code"] == "EMAIL_TAKEN"
 
@@ -154,9 +144,7 @@ async def test_password_change_requires_auth(client: httpx.AsyncClient) -> None:
 async def test_unverified_cannot_create_game_403(client: httpx.AsyncClient) -> None:
     """门禁：未验证邮箱的用户不能创建游戏（_require_verified → 403）。"""
     await client.post("/api/v1/auth/register", json={"email": "uv@b.com", "password": PWD})
-    resp = await client.post(
-        "/api/v1/auth/login", json={"email": "uv@b.com", "password": PWD}
-    )
+    resp = await client.post("/api/v1/auth/login", json={"email": "uv@b.com", "password": PWD})
     assert resp.status_code == 200, resp.text
     token = resp.json()["data"]["access_token"]
     resp = await client.post(
@@ -184,7 +172,5 @@ async def test_verify_email_failures_invalidate_code(
         )
         assert resp.status_code == 400
     # 达限后正确码也应失效
-    resp = await client.post(
-        "/api/v1/auth/verify-email", json={"email": email, "code": good}
-    )
+    resp = await client.post("/api/v1/auth/verify-email", json={"email": email, "code": good})
     assert resp.status_code == 400

--- a/backend/tests/test_dev_routes_gate.py
+++ b/backend/tests/test_dev_routes_gate.py
@@ -1,0 +1,13 @@
+"""ADR-07 P1-20: /dev routes require DEV_ROUTES_ENABLED."""
+
+from app.core.config import Settings
+
+
+def test_dev_routes_default_off() -> None:
+    s = Settings(_env_file=None, dev_routes_enabled=False)
+    assert s.dev_routes_enabled is False
+
+
+def test_dev_routes_can_enable() -> None:
+    s = Settings(_env_file=None, dev_routes_enabled=True)
+    assert s.dev_routes_enabled is True

--- a/backend/tests/test_dev_routes_gate.py
+++ b/backend/tests/test_dev_routes_gate.py
@@ -4,10 +4,10 @@ from app.core.config import Settings
 
 
 def test_dev_routes_default_off() -> None:
-    s = Settings(_env_file=None, dev_routes_enabled=False)
+    s = Settings(dev_routes_enabled=False)
     assert s.dev_routes_enabled is False
 
 
 def test_dev_routes_can_enable() -> None:
-    s = Settings(_env_file=None, dev_routes_enabled=True)
+    s = Settings(dev_routes_enabled=True)
     assert s.dev_routes_enabled is True

--- a/backend/tests/test_manifest_protect.py
+++ b/backend/tests/test_manifest_protect.py
@@ -1,0 +1,31 @@
+"""ADR-07 P0-2: protect platform manifest from LLM source_files overrides."""
+
+from app.forge.build.manifest import generate_manifest_files, merge_workspace
+from app.forge.build.routing import BuildRouting
+from app.sandbox.builder import sanitize_package_manager_version
+
+
+def test_merge_workspace_ignores_protected_overrides() -> None:
+    routing = BuildRouting(build="vite", renderer="canvas")
+    base = generate_manifest_files(routing)
+    poisoned = {
+        "package.json": '{"name":"evil"}',
+        "pnpm-workspace.yaml": "packages:\n  - evil\n",
+        "vite.config.ts": "export default {}",
+        "tsconfig.json": "{}",
+        "src/main.ts": "console.log(1)",
+    }
+    ws = merge_workspace(routing, poisoned)
+    assert ws["package.json"] == base["package.json"]
+    assert ws["pnpm-workspace.yaml"] == base["pnpm-workspace.yaml"]
+    assert ws["vite.config.ts"] == base["vite.config.ts"]
+    assert ws["tsconfig.json"] == base["tsconfig.json"]
+    assert ws["src/main.ts"] == "console.log(1)"
+
+
+def test_sanitize_package_manager_version() -> None:
+    assert sanitize_package_manager_version("pnpm@9.15.0") == "9.15.0"
+    assert sanitize_package_manager_version("pnpm@11.21.0") == "11.21.0"
+    assert sanitize_package_manager_version("pnpm@9.15.0; rm -rf /") is None
+    assert sanitize_package_manager_version("yarn@1.0.0") is None
+    assert sanitize_package_manager_version("") is None

--- a/backend/tests/test_oauth_bind.py
+++ b/backend/tests/test_oauth_bind.py
@@ -14,9 +14,7 @@ from app.core.errors import AppError, ErrorCode
 async def test_oauth_callback_rejects_unverified_existing_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    existing = SimpleNamespace(
-        id=uuid4(), email="victim@example.com", email_verified=False
-    )
+    existing = SimpleNamespace(id=uuid4(), email="victim@example.com", email_verified=False)
     profile = SimpleNamespace(email="victim@example.com", provider_sub="gh-1")
 
     db = AsyncMock()
@@ -37,9 +35,7 @@ async def test_oauth_callback_rejects_unverified_existing_email(
     db.commit = AsyncMock()
     db.refresh = AsyncMock()
 
-    monkeypatch.setattr(
-        oauth_mod, "fetch_oauth_profile", AsyncMock(return_value=profile)
-    )
+    monkeypatch.setattr(oauth_mod, "fetch_oauth_profile", AsyncMock(return_value=profile))
 
     with pytest.raises(AppError) as ei:
         await oauth_mod.oauth_callback(db, r, "github", "code", "state")

--- a/backend/tests/test_oauth_bind.py
+++ b/backend/tests/test_oauth_bind.py
@@ -1,0 +1,47 @@
+"""ADR-07 P1-18: OAuth email bind requires verified account."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.auth import oauth as oauth_mod
+from app.core.errors import AppError, ErrorCode
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_rejects_unverified_existing_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = SimpleNamespace(
+        id=uuid4(), email="victim@example.com", email_verified=False
+    )
+    profile = SimpleNamespace(email="victim@example.com", provider_sub="gh-1")
+
+    db = AsyncMock()
+    r = AsyncMock()
+    r.getdel = AsyncMock(return_value="github")
+
+    call_n = {"n": 0}
+
+    async def _scalar(_stmt):  # noqa: ANN001
+        call_n["n"] += 1
+        # 1st: OAuthAccount lookup → None; 2nd: User by email → existing
+        if call_n["n"] == 1:
+            return None
+        return existing
+
+    db.scalar = AsyncMock(side_effect=_scalar)
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    monkeypatch.setattr(
+        oauth_mod, "fetch_oauth_profile", AsyncMock(return_value=profile)
+    )
+
+    with pytest.raises(AppError) as ei:
+        await oauth_mod.oauth_callback(db, r, "github", "code", "state")
+    assert ei.value.code == ErrorCode.EMAIL_NOT_VERIFIED
+    db.add.assert_not_called()

--- a/backend/tests/test_reliability_policy.py
+++ b/backend/tests/test_reliability_policy.py
@@ -1,0 +1,36 @@
+"""ADR-09: node timeout budgets and retry_on exclusions."""
+
+from app.core.config import settings
+from app.core.errors import AppError, ErrorCode
+from app.forge.reliability.policy import (
+    _default_retry_on,
+    resolve_node_run_timeout,
+)
+
+
+def test_done_node_has_fixed_timeout() -> None:
+    assert resolve_node_run_timeout("done") == 30.0
+
+
+def test_code_or_repair_budget_grows_when_build_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "build_pipeline_enabled", False)
+    base = resolve_node_run_timeout("code_or_repair")
+    monkeypatch.setattr(settings, "build_pipeline_enabled", True)
+    monkeypatch.setattr(settings, "build_max_retries", 3)
+    monkeypatch.setattr(settings, "builder_timeout_s", 300)
+    assert resolve_node_run_timeout("code_or_repair") == base + 900.0
+
+
+def test_retry_on_excludes_app_error() -> None:
+    assert _default_retry_on(AppError(ErrorCode.VALIDATION_ERROR, "x")) is False
+
+
+def test_retry_on_allows_generic() -> None:
+    assert _default_retry_on(RuntimeError("boom")) is True
+
+
+def test_retry_on_excludes_content_attacked_by_name() -> None:
+    class ContentAttacked(Exception):
+        pass
+
+    assert _default_retry_on(ContentAttacked()) is False

--- a/backend/tests/test_security_boot.py
+++ b/backend/tests/test_security_boot.py
@@ -1,0 +1,28 @@
+"""ADR-07: production JWT secret fail-fast."""
+
+import pytest
+
+from app.core.config import Settings
+from app.core.security_boot import DEFAULT_JWT_SECRET, assert_production_secrets
+
+
+def test_assert_rejects_default_jwt_in_production() -> None:
+    s = Settings(env="production", jwt_secret=DEFAULT_JWT_SECRET)
+    with pytest.raises(RuntimeError, match="JWT_SECRET"):
+        assert_production_secrets(s)
+
+
+def test_assert_rejects_short_jwt_in_production() -> None:
+    s = Settings(env="staging", jwt_secret="x" * 16)
+    with pytest.raises(RuntimeError, match="JWT_SECRET"):
+        assert_production_secrets(s)
+
+
+def test_assert_allows_default_in_development() -> None:
+    s = Settings(env="development", jwt_secret=DEFAULT_JWT_SECRET)
+    assert_production_secrets(s)
+
+
+def test_assert_allows_strong_secret_in_production() -> None:
+    s = Settings(env="production", jwt_secret="a" * 32)
+    assert_production_secrets(s)

--- a/backend/tests/test_url_safety.py
+++ b/backend/tests/test_url_safety.py
@@ -1,0 +1,39 @@
+"""ADR-07 P1-19: openai_compat base_url SSRF checks."""
+
+import pytest
+
+from app.core.errors import AppError
+from app.llm.url_safety import validate_llm_base_url
+
+
+def test_https_public_host_ok() -> None:
+    validate_llm_base_url("https://api.openai.com/v1", env="production")
+
+
+def test_http_localhost_ok_in_development() -> None:
+    validate_llm_base_url("http://127.0.0.1:11434", env="development")
+
+
+def test_http_localhost_rejected_in_production() -> None:
+    with pytest.raises(AppError):
+        validate_llm_base_url("http://127.0.0.1:11434", env="production")
+
+
+def test_rejects_link_local_metadata() -> None:
+    with pytest.raises(AppError):
+        validate_llm_base_url("http://169.254.169.254/latest", env="production")
+
+
+def test_rejects_private_ip() -> None:
+    with pytest.raises(AppError):
+        validate_llm_base_url("https://10.0.0.1/v1", env="production")
+
+
+def test_rejects_non_http_scheme() -> None:
+    with pytest.raises(AppError):
+        validate_llm_base_url("file:///etc/passwd", env="development")
+
+
+def test_empty_ok() -> None:
+    validate_llm_base_url(None, env="production")
+    validate_llm_base_url("  ", env="production")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "6379:6379"
     volumes:
       - redisdata:/data    # 缓存数据
-    healthcheck:    # 健康检查  
+    healthcheck:    # 健康检查
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 3s
@@ -33,6 +33,8 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: gameforge
       RABBITMQ_DEFAULT_PASS: gameforge
+      # ADR-08: raise consumer_timeout so long code_qa runs are not force-closed (~2h)
+      RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit consumer_timeout 7200000"
     ports:
       - "5672:5672"
       - "15672:15672"
@@ -48,6 +50,7 @@ services:
       dockerfile: docker/Dockerfile.backend
     # aiodocker 需访问 docker.sock；生产 K8s 用 sidecar/ DinD，勿长期 root
     user: "0:0"
+    restart: unless-stopped
     env_file:
       - ./backend/.env.example
     environment:
@@ -85,6 +88,7 @@ services:
     deploy:
       replicas: ${WORKER_REPLICAS:-1}
     user: "0:0"
+    restart: unless-stopped
     env_file:
       - ./backend/.env.example
     environment:

--- a/docs/superpowers/plans/2026-08-16-adr-batch-a-p0-security.md
+++ b/docs/superpowers/plans/2026-08-16-adr-batch-a-p0-security.md
@@ -1,0 +1,304 @@
+# ADR Batch A（P0 安全 / Worker / 超时）实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 落地 ADR-07/08/09 上线前必做项：JWT 启动门禁、manifest 覆盖防护、verify-email 限流、OAuth 绑定校验、SSRF 主机限制、dev 路由显式开关、compose restart、worker 消息路径加固、基建超时与节点 Retry/Timeout 策略。
+
+**架构：** 安全校验下沉到 `config` / `manifest` / `auth` / `llm` 纯函数或服务层；worker 在 `_run_one` / `_consume` 加兜底；超时进 `config` + `db`/`redis`/`policy`/`guard`。本切片**不含**：pnpm store 租户隔离、配额中途预扣、trial 全端拦截、邮件独立队列、checkpoint 重投恢复（留给 Batch B / 后续 PR）。
+
+**技术栈：** FastAPI、Pydantic Settings、pytest、asyncio、aio_pika、LangGraph policies、docker-compose。
+
+**规格：** `docs/adr/ADR-07-*.md`、`ADR-08-*.md`、`ADR-09-*.md`、`ADR-MODIFICATION-GUIDE-2026-08-16.md`
+
+---
+
+## 文件职责
+
+| 文件 | 职责 |
+| --- | --- |
+| `backend/app/core/config.py` | `jwt` 门禁、`dev_routes_enabled`、DB/Redis/Docker 超时配置项 |
+| `backend/app/core/security_boot.py`（新建） | `assert_production_secrets()` 启动校验 |
+| `backend/app/main.py` | lifespan 调用门禁；dev 路由挂载条件 |
+| `backend/app/forge/build/manifest.py` | `PROTECTED_WORKSPACE_FILES` + merge 过滤 |
+| `backend/app/sandbox/builder.py` | `packageManager` 正则白名单 |
+| `backend/app/api/auth.py` | verify-email 限流 |
+| `backend/app/auth/services.py` | 验证码失败计数作废 |
+| `backend/app/auth/oauth.py` | `email_verified` 绑定门槛 |
+| `backend/app/llm/url_safety.py`（新建） | `base_url` SSRF 校验 |
+| `backend/app/llm/services.py` | 调用 URL 校验 |
+| `backend/app/messaging/worker.py` | decode/DLQ try、busy 退避、consume 重连 |
+| `docker-compose.yml` | `restart: unless-stopped`；RabbitMQ `consumer_timeout` |
+| `backend/app/core/db.py` / `redis.py` | 连接/命令超时 |
+| `backend/app/forge/reliability/policy.py` | `done` 策略、`retry_on`、code_or_repair 动态预算入口 |
+| `backend/app/forge/graph.py` | `done` 挂 TimeoutPolicy |
+| `backend/app/forge/guard.py` | audit `wait_for` |
+
+---
+
+### 任务 1：JWT 生产门禁（ADR-07 §1 / P0-1）
+
+**文件：**
+- 创建：`backend/app/core/security_boot.py`
+- 修改：`backend/app/main.py`（lifespan）、`backend/app/messaging/worker.py`（main 启动）
+- 测试：`backend/tests/test_security_boot.py`
+
+- [ ] **步骤 1：编写失败的测试**
+
+```python
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+from app.core.security_boot import assert_production_secrets, DEFAULT_JWT_SECRET
+
+
+def test_assert_rejects_default_jwt_in_production() -> None:
+    s = Settings(env="production", jwt_secret=DEFAULT_JWT_SECRET)
+    with pytest.raises(RuntimeError, match="JWT_SECRET"):
+        assert_production_secrets(s)
+
+
+def test_assert_rejects_short_jwt_in_production() -> None:
+    s = Settings(env="staging", jwt_secret="x" * 16)
+    with pytest.raises(RuntimeError, match="JWT_SECRET"):
+        assert_production_secrets(s)
+
+
+def test_assert_allows_default_in_development() -> None:
+    s = Settings(env="development", jwt_secret=DEFAULT_JWT_SECRET)
+    assert_production_secrets(s)  # no raise
+
+
+def test_assert_allows_strong_secret_in_production() -> None:
+    s = Settings(env="production", jwt_secret="a" * 32)
+    assert_production_secrets(s)
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：`cd backend && uv run pytest tests/test_security_boot.py -v`  
+预期：FAIL（模块不存在）
+
+- [ ] **步骤 3：编写最少实现**
+
+`security_boot.py`：
+
+```python
+DEFAULT_JWT_SECRET = "dev-secret-change-me-to-a-32-byte-random-string"
+
+def assert_production_secrets(settings) -> None:
+    if settings.env == "development":
+        return
+    secret = (settings.jwt_secret or "").strip()
+    if secret == DEFAULT_JWT_SECRET or len(secret) < 32:
+        raise RuntimeError(
+            "JWT_SECRET must be set to a non-default value of at least 32 characters "
+            f"when env={settings.env!r}"
+        )
+```
+
+`main.py` lifespan 开头与 `worker.py` `main()` 启动处调用 `assert_production_secrets(settings)`。
+
+- [ ] **步骤 4：运行测试验证通过**
+
+`uv run pytest tests/test_security_boot.py -v` → PASS
+
+- [ ] **步骤 5：Commit**
+
+`test(security): add JWT production fail-fast boot checks`  
+`feat(security): reject default JWT_SECRET outside development`
+
+---
+
+### 任务 2：manifest 黑名单 + packageManager 白名单（ADR-07 §2 / P0-2）
+
+**文件：**
+- 修改：`backend/app/forge/build/manifest.py`、`backend/app/sandbox/builder.py`
+- 测试：`backend/tests/test_build_p2.py`（追加）或 `backend/tests/test_manifest_protect.py`
+
+- [ ] **步骤 1：失败测试**
+
+```python
+from app.forge.build.manifest import merge_workspace, generate_manifest_files
+from app.forge.build.types import BuildRouting  # 按仓库实际类型导入
+
+def test_merge_workspace_ignores_protected_overrides(routing_fixture):
+    base = generate_manifest_files(routing_fixture)
+    poisoned = {
+        "package.json": '{"name":"evil"}',
+        "pnpm-workspace.yaml": "packages:\n  - evil",
+        "vite.config.ts": "export default {}",
+        "src/main.ts": "console.log(1)",
+    }
+    ws = merge_workspace(routing_fixture, poisoned)
+    assert ws["package.json"] == base["package.json"]
+    assert ws["src/main.ts"] == "console.log(1)"
+```
+
+```python
+from app.sandbox.builder import corepack_activate_shell, sanitize_package_manager_version
+from pathlib import Path
+
+def test_sanitize_package_manager_rejects_injection(tmp_path: Path):
+    assert sanitize_package_manager_version("pnpm@9.15.0") == "9.15.0"
+    assert sanitize_package_manager_version("pnpm@9.15.0; rm -rf /") is None
+    assert sanitize_package_manager_version("yarn@1.0.0") is None
+```
+
+- [ ] **步骤 2：跑测确认 FAIL**
+- [ ] **步骤 3：实现**
+
+`manifest.py`：
+
+```python
+import fnmatch
+
+PROTECTED_WORKSPACE_FILES = frozenset({
+    "package.json",
+    "pnpm-workspace.yaml",
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "yarn.lock",
+    "tsconfig.json",
+    "build-profile.json",
+})
+PROTECTED_WORKSPACE_GLOBS = ("vite.config.*",)
+
+def _is_protected(name: str) -> bool:
+    if name in PROTECTED_WORKSPACE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, g) for g in PROTECTED_WORKSPACE_GLOBS)
+
+def merge_workspace(...):
+    workspace = dict(generate_manifest_files(routing, profile))
+    for rel, content in source_files.items():
+        if _is_protected(rel.replace("\\", "/").lstrip("./")):
+            continue
+        workspace[rel] = content
+    ...
+```
+
+`builder.py`：`re.fullmatch(r"pnpm@\d+(\.\d+)*", pm)` 后才取版本。
+
+- [ ] **步骤 4：PASS**
+- [ ] **步骤 5：Commit** `fix(build): block LLM overrides of platform manifest files`
+
+---
+
+### 任务 3：verify-email 限流 + 失败作废（ADR-07 §3 / P1-17）
+
+**文件：**
+- 修改：`backend/app/api/auth.py`、`backend/app/auth/services.py`、`backend/app/core/config.py`（可选阈值）
+- 测试：`backend/tests/test_auth.py` 追加
+
+- [ ] **步骤 1：** 为 `verify_email` 路由加与 login 同级 `check_rate_limit`（IP + 邮箱归一化键）。
+- [ ] **步骤 2：** `services.verify_email`：失败时 Redis/DB 计数；达 `verify_email_max_failures`（默认 5）则 `used_at` 作废所有 pending 码并抛明确错误。
+- [ ] **步骤 3：** 测试：无限流键时 429；失败 N 次后旧码失效。
+- [ ] **步骤 4：Commit** `fix(auth): rate-limit verify-email and invalidate after failures`
+
+---
+
+### 任务 4：OAuth 仅绑定已验证邮箱（ADR-07 §3 / P1-18）
+
+**文件：** `backend/app/auth/oauth.py`  
+**测试：** `backend/tests/test_oauth_bind.py`（新建，mock db）
+
+- [ ] existing 用户且 `email_verified is False` → 抛 `AppError`（FORBIDDEN/VALIDATION），不 `add(OAuthAccount)`。
+- [ ] `email_verified is True` → 现有绑定行为保留。
+- [ ] Commit：`fix(auth): require email_verified before OAuth email bind`
+
+---
+
+### 任务 5：openai_compat base_url SSRF 防护（ADR-07 §4 / P1-19）
+
+**文件：**
+- 创建：`backend/app/llm/url_safety.py`
+- 修改：`backend/app/llm/services.py`
+- 测试：`backend/tests/test_url_safety.py`
+
+- [ ] 允许：`https://api.openai.com`；development 允许 `http://127.0.0.1:11434`。
+- [ ] 拒绝：`http://169.254.169.254/`、`http://10.0.0.1`、`http://192.168.1.1`、非 http(s)。
+- [ ] `test_draft_config` / `create_config` 在发请求前调用。
+- [ ] Commit：`fix(llm): block private and metadata hosts in openai_compat base_url`
+
+---
+
+### 任务 6：dev 路由显式开关（ADR-07 §5 / P1-20）
+
+**文件：** `config.py`、`main.py`、`.env.example`  
+**测试：** `backend/tests/test_dev_routes_gate.py`
+
+- [ ] 新增 `dev_routes_enabled: bool = False`。
+- [ ] 挂载条件：`settings.dev_routes_enabled`（不再仅靠 `env == "development"`）。
+- [ ] `.env.example` 注明本地可开；生产必须关。
+- [ ] 调整依赖 `env==development` 的现有测试（conftest 设 `DEV_ROUTES_ENABLED=true`）。
+- [ ] Commit：`fix(api): gate /dev routes behind DEV_ROUTES_ENABLED`
+
+---
+
+### 任务 7：Compose restart + RabbitMQ consumer_timeout（ADR-08 §1/§2A）
+
+**文件：** `docker-compose.yml`
+
+- [ ] `backend` / `worker` 加 `restart: unless-stopped`。
+- [ ] `rabbitmq` environment：`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: -rabbit consumer_timeout 7200000`（或等价，≥ 2h，覆盖 code_qa 外墙）。
+- [ ] Commit：`chore(compose): restart workers and raise consumer_timeout`
+
+---
+
+### 任务 8：Worker 消息路径加固（ADR-08 §1/§3/§4）
+
+**文件：** `backend/app/messaging/worker.py`  
+**测试：** `backend/tests/test_worker_run_one.py`（对 `_run_one` 用假 message）
+
+- [ ] `decode_task` 纳入 try；解码失败记日志并 `_publish_to_dlq`（或显式吞并 ack）。
+- [ ] `_republish_task` / `_publish_to_dlq` 外层 try/except + `log.exception`；失败不二次抛死进程。
+- [ ] `TaskLeaseBusy`：`retry` 递增或使用 `min(60, 2 ** retry)` sleep，且受 `worker_max_redeliveries` 约束后进 DLQ。
+- [ ] `_consume` 外层：连接/循环异常 → sleep 退避 → 重连（不要直接 `main` 退出后无 restart 依赖；compose 已补 restart 仍要代码层重连）。
+- [ ] Commit：`fix(worker): harden decode/DLQ paths and lease-busy backoff`
+
+---
+
+### 任务 9：基建超时 + done TimeoutPolicy + audit wait_for + retry_on（ADR-09）
+
+**文件：** `config.py`、`db.py`、`redis.py`、`policy.py`、`graph.py`、`guard.py`  
+**测试：** `backend/tests/test_reliability_policy.py`、`test_guard_audit_timeout.py`
+
+- [ ] config 增加：`db_pool_timeout`、`db_command_timeout`、`redis_socket_timeout`、`redis_connect_timeout`（合理默认，如 10/60/5/5）。
+- [ ] `create_async_engine(..., connect_args={"timeout": ..., "command_timeout": ...})`（asyncpg）。
+- [ ] Redis pool：`socket_connect_timeout` / `socket_timeout`。
+- [ ] `NODE_EXECUTION_POLICIES["done"] = NodeExecutionPolicy(fixed_run_timeout_s=30, max_attempts=1)`；`graph` 对 `done` 使用 `_node_kwargs("done")`。
+- [ ] `langgraph_retry_policy`：`retry_on` 排除 `AppError`、`ContentAttacked`、`RunFinalized`（按仓库实际异常类导入）。
+- [ ] `guard.audit` 调用包 `asyncio.wait_for(..., settings.audit_request_timeout)`。
+- [ ] `code_or_repair`：若 `build_pipeline_enabled`，`resolve_node_run_timeout` 加上 `build_max_retries * builder_timeout_s` 量级裕量。
+- [ ] Commit：`fix(reliability): unify IO timeouts and node retry_on policy`
+
+---
+
+## 本计划明确延后（勿在本 PR 膨胀）
+
+| 项 | 原因 |
+| --- | --- |
+| P1-21 store 租户隔离 | 需构建架构改动，属 ADR-11 交叉 |
+| P1-22/23 配额中途 + trial 全拦 | 触面广，可单独 PR |
+| P1-4/5/6/7 checkpoint HITL | Batch B / ADR-10 |
+| P1-8 邮件独立队列 | 需 broker 拓扑变更 |
+| P1-24～26 前端 | ADR-12 Section A |
+
+---
+
+## 验证总清单
+
+```bash
+cd backend && uv run pytest tests/test_security_boot.py tests/test_manifest_protect.py tests/test_url_safety.py tests/test_auth.py tests/test_dev_routes_gate.py tests/test_reliability_policy.py -q
+cd backend && uv run ruff check app/core/security_boot.py app/forge/build/manifest.py app/sandbox/builder.py app/messaging/worker.py app/llm/url_safety.py
+```
+
+---
+
+## 自检
+
+- ADR-07 §1–5 → 任务 1–6  
+- ADR-08 §1、§2A、§3、§4 busy → 任务 7–8  
+- ADR-09 核心 → 任务 9  
+- 无「TODO/后续补充」占位任务  

--- a/docs/superpowers/plans/2026-08-16-adr-batch-a-p0-security.md
+++ b/docs/superpowers/plans/2026-08-16-adr-batch-a-p0-security.md
@@ -38,6 +38,7 @@
 ### 任务 1：JWT 生产门禁（ADR-07 §1 / P0-1）
 
 **文件：**
+
 - 创建：`backend/app/core/security_boot.py`
 - 修改：`backend/app/main.py`（lifespan）、`backend/app/messaging/worker.py`（main 启动）
 - 测试：`backend/tests/test_security_boot.py`
@@ -76,7 +77,7 @@ def test_assert_allows_strong_secret_in_production() -> None:
 
 - [ ] **步骤 2：运行测试验证失败**
 
-运行：`cd backend && uv run pytest tests/test_security_boot.py -v`  
+运行：`cd backend && uv run pytest tests/test_security_boot.py -v`
 预期：FAIL（模块不存在）
 
 - [ ] **步骤 3：编写最少实现**
@@ -105,7 +106,7 @@ def assert_production_secrets(settings) -> None:
 
 - [ ] **步骤 5：Commit**
 
-`test(security): add JWT production fail-fast boot checks`  
+`test(security): add JWT production fail-fast boot checks`
 `feat(security): reject default JWT_SECRET outside development`
 
 ---
@@ -113,6 +114,7 @@ def assert_production_secrets(settings) -> None:
 ### 任务 2：manifest 黑名单 + packageManager 白名单（ADR-07 §2 / P0-2）
 
 **文件：**
+
 - 修改：`backend/app/forge/build/manifest.py`、`backend/app/sandbox/builder.py`
 - 测试：`backend/tests/test_build_p2.py`（追加）或 `backend/tests/test_manifest_protect.py`
 
@@ -188,6 +190,7 @@ def merge_workspace(...):
 ### 任务 3：verify-email 限流 + 失败作废（ADR-07 §3 / P1-17）
 
 **文件：**
+
 - 修改：`backend/app/api/auth.py`、`backend/app/auth/services.py`、`backend/app/core/config.py`（可选阈值）
 - 测试：`backend/tests/test_auth.py` 追加
 
@@ -200,7 +203,7 @@ def merge_workspace(...):
 
 ### 任务 4：OAuth 仅绑定已验证邮箱（ADR-07 §3 / P1-18）
 
-**文件：** `backend/app/auth/oauth.py`  
+**文件：** `backend/app/auth/oauth.py`
 **测试：** `backend/tests/test_oauth_bind.py`（新建，mock db）
 
 - [ ] existing 用户且 `email_verified is False` → 抛 `AppError`（FORBIDDEN/VALIDATION），不 `add(OAuthAccount)`。
@@ -212,6 +215,7 @@ def merge_workspace(...):
 ### 任务 5：openai_compat base_url SSRF 防护（ADR-07 §4 / P1-19）
 
 **文件：**
+
 - 创建：`backend/app/llm/url_safety.py`
 - 修改：`backend/app/llm/services.py`
 - 测试：`backend/tests/test_url_safety.py`
@@ -225,7 +229,7 @@ def merge_workspace(...):
 
 ### 任务 6：dev 路由显式开关（ADR-07 §5 / P1-20）
 
-**文件：** `config.py`、`main.py`、`.env.example`  
+**文件：** `config.py`、`main.py`、`.env.example`
 **测试：** `backend/tests/test_dev_routes_gate.py`
 
 - [ ] 新增 `dev_routes_enabled: bool = False`。
@@ -248,7 +252,7 @@ def merge_workspace(...):
 
 ### 任务 8：Worker 消息路径加固（ADR-08 §1/§3/§4）
 
-**文件：** `backend/app/messaging/worker.py`  
+**文件：** `backend/app/messaging/worker.py`
 **测试：** `backend/tests/test_worker_run_one.py`（对 `_run_one` 用假 message）
 
 - [ ] `decode_task` 纳入 try；解码失败记日志并 `_publish_to_dlq`（或显式吞并 ack）。
@@ -261,7 +265,7 @@ def merge_workspace(...):
 
 ### 任务 9：基建超时 + done TimeoutPolicy + audit wait_for + retry_on（ADR-09）
 
-**文件：** `config.py`、`db.py`、`redis.py`、`policy.py`、`graph.py`、`guard.py`  
+**文件：** `config.py`、`db.py`、`redis.py`、`policy.py`、`graph.py`、`guard.py`
 **测试：** `backend/tests/test_reliability_policy.py`、`test_guard_audit_timeout.py`
 
 - [ ] config 增加：`db_pool_timeout`、`db_command_timeout`、`redis_socket_timeout`、`redis_connect_timeout`（合理默认，如 10/60/5/5）。
@@ -298,7 +302,7 @@ cd backend && uv run ruff check app/core/security_boot.py app/forge/build/manife
 
 ## 自检
 
-- ADR-07 §1–5 → 任务 1–6  
-- ADR-08 §1、§2A、§3、§4 busy → 任务 7–8  
-- ADR-09 核心 → 任务 9  
-- 无「TODO/后续补充」占位任务  
+- ADR-07 §1–5 → 任务 1–6
+- ADR-08 §1、§2A、§3、§4 busy → 任务 7–8
+- ADR-09 核心 → 任务 9
+- 无「TODO/后续补充」占位任务


### PR DESCRIPTION
## Summary
- Land ADR-07/08/09 Batch A: JWT production fail-fast, manifest/packageManager hardening, verify-email rate limits + failure invalidation, OAuth `email_verified` bind gate, LLM `base_url` SSRF checks, and `DEV_ROUTES_ENABLED` for `/dev`.
- Harden worker/messaging paths (decode→DLQ, busy backoff, consume reconnect) and compose (`restart`, RabbitMQ `consumer_timeout`).
- Add DB/Redis/audit timeouts and LangGraph `done` / `retry_on` / build-pipeline budget policy updates.

## Background
Implements the accepted Batch A slice from `docs/adr/ADR-MODIFICATION-GUIDE-2026-08-16.md` and `docs/superpowers/plans/2026-08-16-adr-batch-a-p0-security.md`. Batch B/C (HITL/checkpoint, sandbox hosting, frontend) intentionally deferred.

## Test plan
- [ ] `cd backend && uv run pytest tests/test_security_boot.py tests/test_manifest_protect.py tests/test_oauth_bind.py tests/test_url_safety.py tests/test_dev_routes_gate.py tests/test_reliability_policy.py tests/test_auth.py -q`
- [ ] Confirm production/staging boot fails with default/short `JWT_SECRET`
- [ ] Confirm `/dev` is absent unless `DEV_ROUTES_ENABLED=true`
- [ ] Smoke: worker reconnect / invalid message path does not crash the consumer loop

## Impact & Risks
- Deployments without a strong `JWT_SECRET` will refuse to start outside development.
- Local/dev must set `DEV_ROUTES_ENABLED=true` (see `.env.example`) to keep `/dev` available.