### PR TITLE
feat(observability): cover forge LLM calls with Langfuse kind and sessions

### DIFF
--- a/backend/app/core/langfuse.py
+++ b/backend/app/core/langfuse.py
@@ -74,10 +74,38 @@ def observe_span(name: str, metadata: dict[str, Any] | None = None) -> Iterator[
     if client is None:
         yield None
         return
-    with client.start_as_current_observation(
-        as_type="span", name=name, metadata=metadata
-    ) as span:
+    with client.start_as_current_observation(as_type="span", name=name, metadata=metadata) as span:
         yield span
+
+
+@contextmanager
+def propagate_trace_attrs(
+    *,
+    user_id: str | None = None,
+    session_id: str | None = None,
+    tags: list[str] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Iterator[None]:
+    """在作用域内传播 user_id / session_id / tags；无 key 时为空操作。"""
+    if _client() is None:
+        yield
+        return
+    from langfuse import propagate_attributes
+
+    kwargs: dict[str, Any] = {}
+    if user_id is not None:
+        kwargs["user_id"] = user_id
+    if session_id is not None:
+        kwargs["session_id"] = session_id
+    if tags is not None:
+        kwargs["tags"] = tags
+    if metadata is not None:
+        kwargs["metadata"] = metadata
+    if not kwargs:
+        yield
+        return
+    with propagate_attributes(**kwargs):
+        yield
 
 
 @contextmanager
@@ -87,17 +115,26 @@ def observe_generation(
     provider: str,
     system: str,
     user_msg: str,
+    kind: str = "chat",
     metadata: dict[str, Any] | None = None,
+    tags: list[str] | None = None,
 ) -> Iterator[Any]:
-    """包一层 LLM generation；未配置 key 时 yield None，调用方据此跳过 output/usage update。"""
+    """包一层 LLM generation；未配置 key 时 yield None，调用方据此跳过 output/usage update。
+
+    name 固定为 llm:{kind}，便于 UI 区分 plan/guardrail/preference_extract 等业务场景。
+    tags 若传入则写入 metadata["_tags"] 供排查；真正的 Langfuse tags 应由外层
+    propagate_trace_attrs 传播（generation 构造期 SDK 未必接受 tags 入参）。
+    """
     client = _client()
     if client is None:
         yield None
         return
-    meta = {"provider": provider, **(metadata or {})}
+    meta: dict[str, Any] = {"provider": provider, "kind": kind, **(metadata or {})}
+    if tags:
+        meta["_tags"] = list(tags)
     with client.start_as_current_observation(
         as_type="generation",
-        name=f"llm:{provider}",
+        name=f"llm:{kind}",
         model=model,
         input=[
             {"role": "system", "content": system},

--- a/backend/app/forge/cache/semantic.py
+++ b/backend/app/forge/cache/semantic.py
@@ -95,9 +95,7 @@ async def semantic_cache_store(
     vector = await embed_one(query_text)
     if vector is None:
         return False
-    vid = make_vector_id(
-        node=node, skill_bundle_hash=skill_bundle_hash, query_text=query_text
-    )
+    vid = make_vector_id(node=node, skill_bundle_hash=skill_bundle_hash, query_text=query_text)
     meta = {
         "node": node,
         "skill_bundle_hash": skill_bundle_hash or "",
@@ -133,8 +131,8 @@ async def semantic_shadow_record(
     }
     key = f"forge:semantic:shadow:{node}"
     with observe_subsystem("cache", "semantic_shadow", metadata={"node": node}):
-        await r.lpush(key, json.dumps(payload, ensure_ascii=False))
-        await r.ltrim(key, 0, 999)
+        await r.lpush(key, json.dumps(payload, ensure_ascii=False))  # type: ignore[misc]
+        await r.ltrim(key, 0, 999)  # type: ignore[misc]
         await r.expire(key, settings.semantic_cache_shadow_ttl_s)
     return True
 
@@ -164,7 +162,7 @@ async def _confirm_soft_hit(
         log.info("semantic soft-hit skipped: confirm LLM not configured")
         return None
     from app.enums import LLMProvider
-    from app.llm.provider import complete
+    from app.llm.platform_complete import platform_complete
 
     system = (
         "你是缓存确认器。根据当前 query 与候选缓存结果，输出该节点应返回的最终 JSON。"
@@ -181,14 +179,17 @@ async def _confirm_soft_hit(
         default=str,
     )
     try:
-        content, _usage = await complete(
+        content, _usage = await platform_complete(
             LLMProvider(provider),
             apikey,
             model,
             system,
             user_msg,
-            base_url or None,
+            kind="semantic_confirm",
+            base_url=base_url or None,
             max_tokens=512,
+            metadata={"node": node},
+            tags=["forge", "cache"],
         )
     except Exception as exc:  # noqa: BLE001 — 软命中失败则 miss
         log.warning("semantic confirm LLM failed: %s", type(exc).__name__)
@@ -201,8 +202,7 @@ def _confirm_llm_cfg() -> tuple[str, str, str, str]:
         return (
             settings.semantic_confirm_provider,
             settings.semantic_confirm_model.strip(),
-            settings.semantic_confirm_apikey.strip()
-            or settings.preference_extract_apikey.strip(),
+            settings.semantic_confirm_apikey.strip() or settings.preference_extract_apikey.strip(),
             settings.semantic_confirm_base_url.strip()
             or settings.preference_extract_base_url.strip(),
         )
@@ -212,6 +212,7 @@ def _confirm_llm_cfg() -> tuple[str, str, str, str]:
         settings.preference_extract_apikey.strip(),
         settings.preference_extract_base_url.strip(),
     )
+
 
 def _parse_confirm_content(content: str) -> Any | None:
     text = content.strip()

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -127,9 +127,8 @@ async def execute_code_or_repair(
         )
         base_user_msg = built.user_message
         if art_direction:
-            base_user_msg += (
-                "\n\n【已确认美术实现设计稿 JSON】\n"
-                + json.dumps(art_direction, ensure_ascii=False, indent=2)
+            base_user_msg += "\n\n【已确认美术实现设计稿 JSON】\n" + json.dumps(
+                art_direction, ensure_ascii=False, indent=2
             )
         generation_user_msg = base_user_msg
         if assets_block:
@@ -157,9 +156,7 @@ async def execute_code_or_repair(
         last_error = "; ".join(qa_errors)
         design_routing = routing_from_design_doc(design_doc)
         engine_id = design_doc["engine"]["id"]
-        use_vite = should_use_vite_pipeline(
-            design_routing, enabled=settings.build_pipeline_enabled
-        )
+        use_vite = should_use_vite_pipeline(design_routing, enabled=settings.build_pipeline_enabled)
 
         ctrl = await check_ctrl(ctx, design_doc)
         if ctrl != "ok":
@@ -202,9 +199,7 @@ async def execute_code_or_repair(
                 )
                 repair_raw = await streamed_llm(
                     ctx,
-                    build_project_repair_prompt(
-                        engine_id, list(design_routing.dependencies)
-                    ),
+                    build_project_repair_prompt(engine_id, list(design_routing.dependencies)),
                     repair_user,
                     "code",
                     emit_delta=False,
@@ -233,12 +228,10 @@ async def execute_code_or_repair(
             system_prompt = await build_repair_prompt_async(
                 design_doc["engine"]["id"],
                 complete=lambda s, u: streamed_llm(
-                    ctx, s, u, "code", emit_delta=False
+                    ctx, s, u, "code", emit_delta=False, kind="skill_select"
                 ),
             )
-            raw_output = await streamed_llm(
-                ctx, system_prompt, user_msg, "code", emit_delta=False
-            )
+            raw_output = await streamed_llm(ctx, system_prompt, user_msg, "code", emit_delta=False)
         else:
             user_msg = generation_user_msg
             if last_error:
@@ -252,12 +245,10 @@ async def execute_code_or_repair(
                 system_prompt = await build_code_prompt_async(
                     engine_id,
                     complete=lambda s, u: streamed_llm(
-                        ctx, s, u, "code", emit_delta=False
+                        ctx, s, u, "code", emit_delta=False, kind="skill_select"
                     ),
                 )
-            raw_output = await streamed_llm(
-                ctx, system_prompt, user_msg, "code", emit_delta=False
-            )
+            raw_output = await streamed_llm(ctx, system_prompt, user_msg, "code", emit_delta=False)
 
         for token, data_uri in data_uris.items():
             raw_output = raw_output.replace(token, data_uri)
@@ -272,14 +263,10 @@ async def execute_code_or_repair(
                 async def _repair_project(
                     current: ParsedCodeOutput, build_error: str
                 ) -> ParsedCodeOutput:
-                    repair_user = format_project_repair_input(
-                        base_user_msg, current, build_error
-                    )
+                    repair_user = format_project_repair_input(base_user_msg, current, build_error)
                     repair_raw = await streamed_llm(
                         ctx,
-                        build_project_repair_prompt(
-                            engine_id, list(design_routing.dependencies)
-                        ),
+                        build_project_repair_prompt(engine_id, list(design_routing.dependencies)),
                         repair_user,
                         "code",
                         emit_delta=False,
@@ -289,9 +276,7 @@ async def execute_code_or_repair(
                         design_routing,
                     )
 
-                loop_result = await run_project_build_loop(
-                    parsed, repair_fn=_repair_project
-                )
+                loop_result = await run_project_build_loop(parsed, repair_fn=_repair_project)
                 if loop_result.ok and loop_result.pipeline_result:
                     committed = await commit_project_build(
                         ctx,
@@ -311,9 +296,7 @@ async def execute_code_or_repair(
                 fail_logs = ""
                 if loop_result.pipeline_result:
                     fail_logs = (
-                        loop_result.pipeline_result.error
-                        or loop_result.pipeline_result.logs
-                        or ""
+                        loop_result.pipeline_result.error or loop_result.pipeline_result.logs or ""
                     )
                 await publish_event(
                     ctx.run.id,
@@ -335,9 +318,7 @@ async def execute_code_or_repair(
                     "code_ok": False,
                     "qa_ok": False,
                     "failure_kind": "build",
-                    "playtest_errors": [
-                        fail_logs or last_error or "Vite 构建失败"
-                    ],
+                    "playtest_errors": [fail_logs or last_error or "Vite 构建失败"],
                     "qa_diagnosis": qa_diagnosis,
                     "design_doc": design_doc,
                     "artifacts": artifacts,
@@ -358,8 +339,7 @@ async def execute_code_or_repair(
                         },
                         "status": "warn",
                         "summary": (
-                            "build=vite 但 LLM 未返回 project JSON，"
-                            "本 attempt 按 build 失败处理"
+                            "build=vite 但 LLM 未返回 project JSON，本 attempt 按 build 失败处理"
                         ),
                     },
                 )
@@ -369,8 +349,7 @@ async def execute_code_or_repair(
                     "code_ok": False,
                     "qa_ok": False,
                     "failure_kind": "build",
-                    "playtest_errors": list(parsed.errors)
-                    or ["LLM 未返回 project JSON"],
+                    "playtest_errors": list(parsed.errors) or ["LLM 未返回 project JSON"],
                     "qa_diagnosis": qa_diagnosis,
                     "design_doc": design_doc,
                     "artifacts": artifacts,
@@ -387,10 +366,7 @@ async def execute_code_or_repair(
         )
         if result.ok:
             await ctx.s.refresh(ctx.run)
-            if (
-                ctx.run.status != RunStatus.RUNNING.value
-                or ctx.run.ended_at is not None
-            ):
+            if ctx.run.status != RunStatus.RUNNING.value or ctx.run.ended_at is not None:
                 raise run_finalized_exc
 
             version, _is_new = await claim_candidate_version(
@@ -401,7 +377,7 @@ async def execute_code_or_repair(
                 attempt=int(attempt),
             )
             artifact = f"{ctx.game.id}/{version}/index.html"
-            await store.write_artifact(ctx.game.id, version, result.files)
+            await store.write_artifact(ctx.game.id, version, dict[str, str | bytes](result.files))
             existing_gv = await ctx.s.scalar(
                 select(GameVersion).where(
                     GameVersion.game_id == ctx.game.id,
@@ -532,9 +508,7 @@ async def execute_playtest(
             motion_signal = None
         elif serve.is_project_artifact(ctx.game.id, version):
             artifact_dir = store.artifact_dir(ctx.game.id, version)
-            pt = await run_playtest_dist(
-                artifact_dir, want_thumb=settings.thumbnail_enabled
-            )
+            pt = await run_playtest_dist(artifact_dir, want_thumb=settings.thumbnail_enabled)
             result_ok = pt.ok
             errors = pt.errors
             console_logs = pt.console_logs

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -326,6 +326,7 @@ async def _refresh_session_summary(ctx: _Ctx) -> None:
                     user_msg,
                     game_id=ctx.game.id,
                     run_id=ctx.run.id,
+                    kind="session_summary",
                 )
                 return content
 
@@ -430,7 +431,13 @@ async def _compose_art_detail_input(
 
 
 async def _streamed_llm_or_fallback(
-    ctx: _Ctx, system: str, user_msg: str, phase: str, *, emit_delta: bool = True
+    ctx: _Ctx,
+    system: str,
+    user_msg: str,
+    phase: str,
+    *,
+    emit_delta: bool = True,
+    kind: str | None = None,
 ) -> str:
     """流式开关分流：开 → run_streamed_llm（流式 + 输入/输出审核 + 微批）；
     关 → _llm（非流式，无审核）。关时整体退化为护栏落地前的行为。
@@ -438,13 +445,17 @@ async def _streamed_llm_or_fallback(
     emit_delta=False 时仍做审核但不发 LLM_DELTA（用于 code/art 等 JSON/长 HTML 阶段，
     打字机价值低且避免产生上千事件）。
     """
+    llm_kind = kind or phase
     if settings.stream_enabled:
-        return await run_streamed_llm(ctx, system, user_msg, phase=phase, emit_delta=emit_delta)
-    return await _llm(ctx, system, user_msg)
+        return await run_streamed_llm(
+            ctx, system, user_msg, phase=phase, emit_delta=emit_delta, kind=llm_kind
+        )
+    return await _llm(ctx, system, user_msg, kind=llm_kind)
 
 
-async def _llm(ctx: _Ctx, system: str, user_msg: str) -> str:
+async def _llm(ctx: _Ctx, system: str, user_msg: str, *, kind: str | None = None) -> str:
     stage = ctx.run.phase or "llm"
+    llm_kind = kind or stage or "chat"
     started = time.monotonic()
     # 只记长度不记原文：prompt/响应内容属敏感且冗长，按 docs 约定不落盘
     log.info("llm call start", extra={"stage": stage, "prompt_len": len(user_msg)})
@@ -458,6 +469,7 @@ async def _llm(ctx: _Ctx, system: str, user_msg: str) -> str:
             user_msg,
             game_id=ctx.game.id,
             run_id=ctx.run.id,
+            kind=llm_kind,
         )
     except Exception:
         duration = round(time.monotonic() - started, 3)
@@ -943,7 +955,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "goal": (design_doc.get("title") or ctx.game.title or ""),
                 }
                 system_prompt = await build_art_options_prompt_async(
-                    art_hints, complete=lambda s, u: _llm(ctx, s, u)
+                    art_hints, complete=lambda s, u: _llm(ctx, s, u, kind="skill_select")
                 )
                 art_options = await generate_art_options(system_prompt, user_msg)
             except ContentAttacked:
@@ -988,7 +1000,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                     "goal": (design_doc.get("title") or ctx.game.title or ""),
                 }
                 system_prompt = await build_art_options_revise_prompt_async(
-                    art_hints, complete=lambda s, u: _llm(ctx, s, u)
+                    art_hints, complete=lambda s, u: _llm(ctx, s, u, kind="skill_select")
                 )
                 art_options = await generate_art_options(system_prompt, user_msg)
             except ContentAttacked:
@@ -1051,7 +1063,7 @@ def _build_graph(ctx: _Ctx) -> Any:
                             "style": json.dumps(selected_option, ensure_ascii=False),
                             "goal": (design_doc.get("title") or ctx.game.title or ""),
                         },
-                        complete=lambda s, u: _llm(ctx, s, u),
+                        complete=lambda s, u: _llm(ctx, s, u, kind="skill_select"),
                     )
                     raw = await _streamed_llm_or_fallback(
                         ctx,
@@ -1379,7 +1391,11 @@ async def run_generation(
                 log.warning("skip inactive run", extra={"stage": stage, "status": run.status})
                 return
             try:
-                with observe_run(str(run_id)):
+                with observe_run(
+                    str(run_id),
+                    user_id=str(run.user_id),
+                    game_id=str(run.game_id),
+                ):
                     await _run_body(s, r, run, game, run_id, resume, decision, modify_text)
                 duration = round(time.monotonic() - started, 3)
                 log.info(

--- a/backend/app/forge/guard.py
+++ b/backend/app/forge/guard.py
@@ -226,7 +226,7 @@ class _LlmAuditStatus(enum.Enum):
 
 
 class Guard:
-    """一次 LLM 调用的审核上下文，生命周期 = 单次 LLM 流。平台预设审核模型。"""
+    """平台预设审核模型 + 可选快筛。"""
 
     def __init__(
         self,
@@ -235,32 +235,54 @@ class Guard:
         model: str,
         apikey: str,
         base_url: str | None,
+        user_id: str | None = None,
+        game_id: str | None = None,
+        run_id: str | None = None,
     ) -> None:
         self._provider = provider
         self._model = model
         self._apikey = apikey
         self._base_url = base_url or None
+        self._user_id = user_id
+        self._game_id = game_id
+        self._run_id = run_id
 
     async def _audit_with_llm(self, text: str) -> _LlmAuditStatus:
         """调平台预设审核模型审一次（0/1 判定），输出异常时带软提示重试。
 
         trace 经 observe_generation 上报 langfuse（同构 client._invoke_llm）。
         """
-        from app.core.langfuse import observe_generation
+        from app.core.langfuse import observe_generation, propagate_trace_attrs
 
         user_msg = f"【待审文本】\n{text}"
         last_raw = ""
         for attempt in range(_AUDIT_MAX_RETRIES + 1):
             text_preview = user_msg[:500]
             gen = None
+            meta: dict[str, Any] = {"attempt": attempt + 1}
+            if self._user_id:
+                meta["user_id"] = self._user_id
+            if self._game_id:
+                meta["game_id"] = self._game_id
+            if self._run_id:
+                meta["run_id"] = self._run_id
             try:
-                with observe_generation(
-                    model=self._model,
-                    provider=self._provider.value,
-                    system=_AUDIT_SYSTEM,
-                    user_msg=text_preview,
-                    metadata={"kind": "guardrail", "attempt": attempt + 1},
-                ) as gen:
+                with (
+                    propagate_trace_attrs(
+                        user_id=self._user_id,
+                        session_id=self._game_id,
+                        tags=["forge", "guardrail"],
+                    ),
+                    observe_generation(
+                        model=self._model,
+                        provider=self._provider.value,
+                        system=_AUDIT_SYSTEM,
+                        user_msg=text_preview,
+                        kind="guardrail",
+                        metadata=meta,
+                        tags=["forge", "guardrail"],
+                    ) as gen,
+                ):
                     content, usage = await llm_provider.complete(
                         self._provider,
                         self._apikey,
@@ -368,6 +390,9 @@ async def build_guard(ctx: Any) -> Guard | NoopGuard:
         model=model,
         apikey=cfg["apikey"],
         base_url=cfg["base_url"],
+        user_id=str(ctx.run.user_id) if getattr(ctx, "run", None) is not None else None,
+        game_id=str(ctx.game.id) if getattr(ctx, "game", None) is not None else None,
+        run_id=str(ctx.run.id) if getattr(ctx, "run", None) is not None else None,
     )
 
 
@@ -418,6 +443,7 @@ async def run_streamed_llm(
     *,
     phase: str,
     emit_delta: bool = True,
+    kind: str | None = None,
 ) -> str:
     """用户可见节点的 LLM 调用：流式 + 输入/输出审核 + 微批 LLM_DELTA。
 
@@ -478,6 +504,7 @@ async def run_streamed_llm(
         user_msg,
         game_id=ctx.game.id,
         run_id=ctx.run.id,
+        kind=kind or phase or "chat",
     )
     try:
         async for chunk in gen:

--- a/backend/app/forge/memory/llm_extract.py
+++ b/backend/app/forge/memory/llm_extract.py
@@ -33,17 +33,19 @@ async def extract_preferences_via_llm(text: str) -> list[dict[str, Any]]:
     if not raw or not preference_extract_configured():
         return []
     from app.enums import LLMProvider
-    from app.llm.provider import complete
+    from app.llm.platform_complete import platform_complete
 
     try:
-        content, _usage = await complete(
+        content, _usage = await platform_complete(
             LLMProvider(settings.preference_extract_provider),
             settings.preference_extract_apikey.strip(),
             settings.preference_extract_model.strip(),
             _SYSTEM,
             raw,
-            settings.preference_extract_base_url.strip() or None,
+            kind="preference_extract",
+            base_url=settings.preference_extract_base_url.strip() or None,
             max_tokens=512,
+            tags=["forge", "memory"],
         )
     except Exception as exc:  # noqa: BLE001
         log.warning("preference extract LLM failed: %s", type(exc).__name__)

--- a/backend/app/forge/tracing.py
+++ b/backend/app/forge/tracing.py
@@ -10,19 +10,48 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
-from app.core.langfuse import observe_span
+from app.core.langfuse import observe_span, propagate_trace_attrs
 
 
 @contextmanager
-def observe_run(run_id: str, name: str = "generation_run") -> Iterator[Any]:
-    """包一层 generation_run span；无 key 时 yield None。"""
-    with observe_span(name, metadata={"run_id": run_id}) as span:
+def observe_run(
+    run_id: str,
+    name: str = "generation_run",
+    *,
+    user_id: str | None = None,
+    game_id: str | None = None,
+    tags: list[str] | None = None,
+) -> Iterator[Any]:
+    """包一层 generation_run span，并 propagate session_id=game_id / user_id / tags。"""
+    uniq_tags: list[str] = []
+    seen: set[str] = set()
+    for t in ["forge", *(tags or [])]:
+        if t not in seen:
+            seen.add(t)
+            uniq_tags.append(t)
+    meta: dict[str, Any] = {"run_id": run_id}
+    if user_id is not None:
+        meta["user_id"] = user_id
+    if game_id is not None:
+        meta["game_id"] = game_id
+    with (
+        observe_span(name, metadata=meta) as span,
+        propagate_trace_attrs(
+            user_id=user_id,
+            session_id=game_id,
+            tags=uniq_tags,
+            metadata={"run_id": run_id},
+        ),
+    ):
         yield span
 
 
 @contextmanager
 def observe_phase(phase: str) -> Iterator[Any]:
-    with observe_span(f"phase:{phase}") as span:
+    with (
+        observe_span(f"phase:{phase}") as span,
+        propagate_trace_attrs(tags=["forge", f"phase:{phase}"]),
+    ):
         yield span
 
 

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -7,6 +7,7 @@ import hashlib
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from typing import Any
 
 import redis.asyncio as redis
 from sqlalchemy import select
@@ -60,9 +61,7 @@ async def _get_config(
     return cfg
 
 
-async def _maybe_quota_alert(
-    db: AsyncSession, r: redis.Redis, user_id: uuid.UUID
-) -> None:
+async def _maybe_quota_alert(db: AsyncSession, r: redis.Redis, user_id: uuid.UUID) -> None:
     daily_default, _, rate = await admin_services.get_effective_limits(db)
     _ = rate
     daily = await quota_mod.get_user_daily_limit(r, user_id, daily_default)
@@ -106,9 +105,7 @@ async def _maybe_system_alert(db: AsyncSession, r: redis.Redis) -> None:
             admin.id,
             kind="system_quota",
             title="系统日 token 用量告警",
-            body=(
-                f"系统今日用量 {used} 已超过阈值 {settings.system_daily_token_alert}。"
-            ),
+            body=(f"系统今日用量 {used} 已超过阈值 {settings.system_daily_token_alert}。"),
             email=admin.email,
         )
 
@@ -121,6 +118,8 @@ async def _invoke_llm(
     user_msg: str,
     base_url: str | None,
     trace_meta: dict[str, str],
+    *,
+    kind: str = "chat",
 ) -> tuple[str, provider.Usage]:
     """执行 provider.complete 并挂 langfuse generation 观测。
 
@@ -131,6 +130,7 @@ async def _invoke_llm(
         provider=prov.value,
         system=system,
         user_msg=user_msg,
+        kind=kind,
         metadata=trace_meta,
     ) as gen:
         try:
@@ -162,6 +162,7 @@ async def call_llm(
     *,
     game_id: uuid.UUID | None = None,
     run_id: uuid.UUID | None = None,
+    kind: str = "chat",
 ) -> tuple[str, provider.Usage, LLMProvider]:
     _, _, rate = await admin_services.get_effective_limits(db)
     await check_rate_limit(r, f"rl:llm:{user_id}", rate, 60)
@@ -178,7 +179,14 @@ async def call_llm(
         trace_meta["run_id"] = str(run_id)
     try:
         content, usage = await _invoke_llm(
-            prov, apikey, cfg.model, system, user_msg, cfg.base_url, trace_meta
+            prov,
+            apikey,
+            cfg.model,
+            system,
+            user_msg,
+            cfg.base_url,
+            trace_meta,
+            kind=kind,
         )
     except Exception:
         LLM_CALLS.labels(prov.value, "error").inc()
@@ -221,6 +229,7 @@ async def call_llm_stream(
     *,
     game_id: uuid.UUID | None = None,
     run_id: uuid.UUID | None = None,
+    kind: str = "chat",
 ) -> AsyncIterator[StreamChunk]:
     """流式版 call_llm：逐 token yield StreamChunk（末帧带 usage）。
 
@@ -247,13 +256,14 @@ async def call_llm_stream(
 
     accumulated: list[str] = []
     usage_acc = provider.Usage()
-    gen: object = None
+    gen: Any = None
     try:
         with observe_generation(
             model=cfg.model,
             provider=prov.value,
             system=system,
             user_msg=user_msg,
+            kind=kind,
             metadata=trace_meta,
         ) as gen:
             async for chunk in provider.complete_stream(

--- a/backend/app/llm/platform_complete.py
+++ b/backend/app/llm/platform_complete.py
@@ -1,0 +1,66 @@
+"""平台旁路 LLM：observe_generation + provider.complete，不计用户配额/熔断。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.langfuse import observe_generation, propagate_trace_attrs
+from app.enums import LLMProvider
+from app.llm import provider
+
+
+async def platform_complete(
+    prov: LLMProvider,
+    apikey: str,
+    model: str,
+    system: str,
+    user_msg: str,
+    *,
+    kind: str,
+    base_url: str | None = None,
+    max_tokens: int | None = None,
+    metadata: dict[str, Any] | None = None,
+    tags: list[str] | None = None,
+) -> tuple[str, provider.Usage]:
+    """执行一次平台 key 的非流式补全并上报 Langfuse generation。"""
+    meta = dict(metadata or {})
+    tag_list = list(tags or [])
+    with (
+        propagate_trace_attrs(
+            user_id=meta.get("user_id"),
+            session_id=meta.get("game_id") or meta.get("session_id"),
+            tags=tag_list or None,
+        ),
+        observe_generation(
+            model=model,
+            provider=prov.value,
+            system=system,
+            user_msg=user_msg,
+            kind=kind,
+            metadata=meta,
+            tags=tag_list or None,
+        ) as gen,
+    ):
+        try:
+            content, usage = await provider.complete(
+                prov,
+                apikey,
+                model,
+                system,
+                user_msg,
+                base_url=base_url,
+                max_tokens=max_tokens,
+            )
+        except Exception:
+            if gen is not None:
+                gen.update(level="ERROR", status_message="platform llm call failed")
+            raise
+        if gen is not None:
+            gen.update(
+                output=content,
+                usage_details={
+                    "input": usage.input_tokens,
+                    "output": usage.output_tokens,
+                },
+            )
+    return content, usage

--- a/backend/tests/forge/guard/test_lexicon.py
+++ b/backend/tests/forge/guard/test_lexicon.py
@@ -241,11 +241,12 @@ def test_builtin_lexicon_zero_false_positive_on_official_and_game_text() -> None
         "射击训练模式，爆炸特效与炸弹道具",
         "headshot bonus in shooter mode with bomb item",
     ]
-    assets = Path(__file__).resolve().parents[1] / "scripts" / "official_assets"
+    backend_root = Path(__file__).resolve().parents[3]
+    assets = backend_root / "scripts" / "official_assets"
     if assets.is_dir():
         for path in assets.glob("*.html"):
             samples.append(path.read_text(encoding="utf-8"))
-    catalog = Path(__file__).resolve().parents[1] / "app" / "forge" / "templates" / "catalog.json"
+    catalog = backend_root / "app" / "forge" / "templates" / "catalog.json"
     if catalog.is_file():
         samples.append(catalog.read_text(encoding="utf-8"))
 

--- a/backend/tests/forge/memory/test_legacy_concat_removed.py
+++ b/backend/tests/forge/memory/test_legacy_concat_removed.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_ROOT = Path(__file__).resolve().parents[1] / "app" / "forge"
+_ROOT = Path(__file__).resolve().parents[3] / "app" / "forge"
 _TARGETS = (
     _ROOT / "graph.py",
     _ROOT / "code_qa_exec.py",

--- a/backend/tests/forge/reliability/test_adr_evidence.py
+++ b/backend/tests/forge/reliability/test_adr_evidence.py
@@ -19,12 +19,8 @@ def test_adr_machine_evidence_all_pass() -> None:
 
 
 def test_adr_evidence_module_documents_invariants() -> None:
-    text = (
-        Path(__file__)
-        .resolve()
-        .parents[1]
-        .joinpath("app", "forge", "adr_evidence.py")
-        .read_text(encoding="utf-8")
-    )
+    import app.forge.adr_evidence as mod
+
+    text = Path(mod.__file__).read_text(encoding="utf-8")
     assert "ADR-06" in text
     assert "semantic_soft_hard_thresholds" in text

--- a/backend/tests/forge/run/test_adr04_forge_messages_sot.py
+++ b/backend/tests/forge/run/test_adr04_forge_messages_sot.py
@@ -33,7 +33,7 @@ def test_forge_messages_is_sole_conversation_sot_among_orm_models() -> None:
 
 
 def test_no_vector_conversation_store_module_in_forge() -> None:
-    forge_root = Path(__file__).resolve().parents[1] / "app" / "forge"
+    forge_root = Path(__file__).resolve().parents[3] / "app" / "forge"
     banned = ("vector_store", "conversation_vector", "msg_embedding")
     hits: list[str] = []
     for path in forge_root.rglob("*.py"):

--- a/backend/tests/games/test_lifespan_seed.py
+++ b/backend/tests/games/test_lifespan_seed.py
@@ -43,6 +43,12 @@ async def test_lifespan_skips_seed_outside_development(
 
     monkeypatch.setattr("app.main.seed_official_games", _spy)
     monkeypatch.setattr(settings, "env", "production")
+    # production 启动会校验 JWT；测 seed 跳过分支时需给合法 secret
+    monkeypatch.setattr(
+        settings,
+        "jwt_secret",
+        "ci-test-jwt-secret-at-least-32-chars!!",
+    )
 
     async with lifespan(None):  # type: ignore[arg-type]
         pass

--- a/backend/tests/infra/test_openapi.py
+++ b/backend/tests/infra/test_openapi.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from app.export_openapi import export
 
-REPO = Path(__file__).resolve().parents[2]
+REPO = Path(__file__).resolve().parents[3]
 CONTRACT_OPENAPI = REPO / "contracts" / "openapi.json"
 
 # docs/10 §4 + INTEGRATION 列出的全部 HTTP 端点（WS 不进 OpenAPI，单独由 §5 约束）

--- a/backend/tests/llm/test_langfuse_integration.py
+++ b/backend/tests/llm/test_langfuse_integration.py
@@ -54,12 +54,42 @@ class _FakeGen:
 class _FakeClient:
     def __init__(self) -> None:
         self.gen = _FakeGen()
+        self.last_name: str | None = None
+        self.last_kwargs: dict[str, Any] = {}
 
     @contextmanager
     def start_as_current_observation(
-        self, *, as_type: str, name: str, **_: Any
+        self, *, as_type: str, name: str, **kwargs: Any
     ) -> Iterator[_FakeGen]:
+        self.last_name = name
+        self.last_kwargs = {"as_type": as_type, **kwargs}
         yield self.gen
+
+
+def test_observe_generation_name_uses_kind(monkeypatch) -> None:
+    """generation name 为 llm:{kind}，metadata 含 kind。"""
+    fake = _FakeClient()
+    monkeypatch.setattr(lf, "_client", lambda: fake)
+    with lf.observe_generation(
+        model="m",
+        provider="openai_compat",
+        system="s",
+        user_msg="u",
+        kind="preference_extract",
+        metadata={"user_id": "u1"},
+    ) as gen:
+        assert gen is fake.gen
+    assert fake.last_name == "llm:preference_extract"
+    meta = fake.last_kwargs.get("metadata") or {}
+    assert meta.get("kind") == "preference_extract"
+    assert meta.get("provider") == "openai_compat"
+    assert meta.get("user_id") == "u1"
+
+
+def test_propagate_trace_attrs_noop_when_unconfigured() -> None:
+    """无 key 时 propagate_trace_attrs 空操作，不抛。"""
+    with lf.propagate_trace_attrs(user_id="u", session_id="g", tags=["forge"]):
+        pass
 
 
 async def test_invoke_llm_writes_generation_when_enabled(monkeypatch) -> None:
@@ -75,13 +105,21 @@ async def test_invoke_llm_writes_generation_when_enabled(monkeypatch) -> None:
     monkeypatch.setattr(lf, "_client", lambda: fake)
 
     content, usage = await llm_client._invoke_llm(
-        LLMProvider.OPENAI_COMPAT, "k", "gpt-x", "sys", "hi", "https://x/v1", {}
+        LLMProvider.OPENAI_COMPAT,
+        "k",
+        "gpt-x",
+        "sys",
+        "hi",
+        "https://x/v1",
+        {},
+        kind="plan",
     )
     assert content == "<html></html>"
     assert usage == Usage(13, 9)
     # 关键：usage_details 必须是 int 字典（v4 SDK 入参），output 为 LLM 文本
     assert fake.gen.updated["output"] == "<html></html>"
     assert fake.gen.updated["usage_details"] == {"input": 13, "output": 9}
+    assert fake.last_name == "llm:plan"
 
 
 async def test_invoke_llm_marks_error_on_failure(monkeypatch) -> None:

--- a/backend/tests/llm/test_platform_complete.py
+++ b/backend/tests/llm/test_platform_complete.py
@@ -1,0 +1,118 @@
+"""平台旁路 LLM（偏好抽取 / 语义确认等）：observe + provider.complete，不计用户配额。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core import langfuse as lf
+from app.enums import LLMProvider
+from app.llm import provider as llm_provider
+from app.llm.provider import Usage
+
+
+@pytest.mark.asyncio
+async def test_platform_complete_writes_generation(monkeypatch) -> None:
+    import app.llm.platform_complete as pc
+
+    async def _fake_complete(
+        prov: Any,
+        apikey: Any,
+        model: Any,
+        system: Any,
+        user_msg: Any,
+        base_url: Any = None,
+        *,
+        max_tokens: int | None = None,
+    ) -> tuple[str, Usage]:
+        _ = (prov, apikey, model, system, user_msg, base_url, max_tokens)
+        return '{"ok":true}', Usage(3, 5)
+
+    class _FakeGen:
+        def __init__(self) -> None:
+            self.updated: dict[str, Any] = {}
+
+        def update(self, **kw: Any) -> None:
+            self.updated.update(kw)
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.gen = _FakeGen()
+            self.last_name: str | None = None
+
+        def start_as_current_observation(self, *, as_type: str, name: str, **_: Any):
+            from contextlib import contextmanager
+
+            self.last_name = name
+
+            @contextmanager
+            def _cm():
+                yield self.gen
+
+            return _cm()
+
+    fake = _FakeClient()
+    monkeypatch.setattr(lf, "_client", lambda: fake)
+    monkeypatch.setattr(llm_provider, "complete", _fake_complete)
+
+    content, usage = await pc.platform_complete(
+        LLMProvider.OPENAI_COMPAT,
+        "k",
+        "m",
+        "sys",
+        "user",
+        kind="preference_extract",
+        base_url=None,
+        max_tokens=512,
+        metadata={"game_id": "g1"},
+        tags=["forge", "memory"],
+    )
+    assert content == '{"ok":true}'
+    assert usage == Usage(3, 5)
+    assert fake.last_name == "llm:preference_extract"
+    assert fake.gen.updated["output"] == '{"ok":true}'
+    assert fake.gen.updated["usage_details"] == {"input": 3, "output": 5}
+
+
+@pytest.mark.asyncio
+async def test_platform_complete_marks_error(monkeypatch) -> None:
+    import app.llm.platform_complete as pc
+
+    async def _boom(*_: Any, **__: Any) -> tuple[str, Usage]:
+        raise RuntimeError("boom")
+
+    class _FakeGen:
+        def __init__(self) -> None:
+            self.updated: dict[str, Any] = {}
+
+        def update(self, **kw: Any) -> None:
+            self.updated.update(kw)
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.gen = _FakeGen()
+
+        def start_as_current_observation(self, *, as_type: str, name: str, **_: Any):
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _cm():
+                yield self.gen
+
+            return _cm()
+
+    fake = _FakeClient()
+    monkeypatch.setattr(lf, "_client", lambda: fake)
+    monkeypatch.setattr(llm_provider, "complete", _boom)
+
+    with pytest.raises(RuntimeError):
+        await pc.platform_complete(
+            LLMProvider.OPENAI_COMPAT,
+            "k",
+            "m",
+            "s",
+            "u",
+            kind="semantic_confirm",
+        )
+    assert fake.gen.updated.get("level") == "ERROR"

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -260,6 +260,16 @@
               }
             }
           },
+          "429": {
+            "description": "限流",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/docs/superpowers/plans/2026-08-17-langfuse-llm-coverage.md
+++ b/docs/superpowers/plans/2026-08-17-langfuse-llm-coverage.md
@@ -1,0 +1,56 @@
+# Langfuse LLM Coverage 实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 所有业务 LLM 调用进 Langfuse，generation 按 `kind` 命名，主 run 用 `game_id` 作 session。
+
+**架构：** 扩展 `app.core.langfuse` + 薄封装 `platform_complete`；用户路径继续走 `call_llm`；旁路平台 key 不走配额。
+
+**技术栈：** Python / Langfuse SDK v4 / pytest
+
+---
+
+## 文件结构
+
+| 文件 | 职责 |
+|------|------|
+| `backend/app/core/langfuse.py` | `observe_generation(kind)`、`propagate_trace_attrs` |
+| `backend/app/forge/tracing.py` | `observe_run` 接 session/user/tags |
+| `backend/app/llm/client.py` | `call_llm`/`stream` 透传 `kind` |
+| `backend/app/llm/platform_complete.py` | 平台旁路 LLM + 观测 |
+| `backend/app/forge/memory/llm_extract.py` | 改走 platform_complete |
+| `backend/app/forge/cache/semantic.py` | 改走 platform_complete |
+| `backend/app/forge/guard.py` | kind/tags/ids |
+| `backend/app/forge/graph.py` | observe_run 传 ids；call_llm 传 kind |
+| `backend/tests/llm/test_langfuse_integration.py` | 核心观测测试 |
+| `backend/tests/llm/test_platform_complete.py` | 旁路封装测试 |
+
+### 任务 1：langfuse 核心 API（TDD）
+
+**文件：** `backend/app/core/langfuse.py`、`backend/tests/llm/test_langfuse_integration.py`
+
+- [x] 写失败测试：`kind` → name `llm:{kind}`；`propagate_trace_attrs` 无 key 不炸
+- [x] 实现 `observe_generation`/`propagate_trace_attrs`
+- [x] 测试通过
+
+### 任务 2：platform_complete（TDD）
+
+**文件：** 创建 `backend/app/llm/platform_complete.py`；测试 `test_platform_complete.py`
+
+- [x] 写失败测试：成功写 output/usage；失败标 ERROR
+- [x] 实现封装
+- [x] 偏好/语义确认改接入
+
+### 任务 3：用户路径 + run session
+
+**文件：** `client.py`、`tracing.py`、`graph.py`、`guard.py`、`code_qa_exec.py`（如需）
+
+- [x] `call_llm`/`stream` 增加 `kind`
+- [x] `observe_run` propagate session
+- [x] Guard / graph 接线
+- [x] 跑相关测试
+
+### 任务 4：验证
+
+- [x] `pytest backend/tests/llm/test_langfuse_integration.py backend/tests/llm/test_platform_complete.py -q`
+- [x] 必要时跑 forge memory/cache 相关单测

--- a/docs/superpowers/specs/2026-08-17-langfuse-llm-coverage-design.md
+++ b/docs/superpowers/specs/2026-08-17-langfuse-llm-coverage-design.md
@@ -1,0 +1,46 @@
+# Langfuse LLM 全覆盖 + Session 聚合设计
+
+* 日期：2026-08-17
+* 状态：已批准，实施中
+* 范围档位：**B**（LLM 全覆盖 + `session_id`/`tags`；不含 embedding / Admin 探测）
+
+## 1. 目标
+
+所有业务 LLM 调用（用户配置路径 + 平台旁路路径）均上报 Langfuse generation；主生成 run 用 `session_id=str(game_id)` 聚合多次创作；generation 以业务 `kind` 命名，便于 UI 区分。
+
+## 2. 非目标
+
+* embedding / semantic lookup·store span
+* Admin `test_connectivity`
+* Langfuse Scores / Prompt Management / Datasets
+
+## 3. 约定
+
+| 项 | 规则 |
+|----|------|
+| Generation name | `llm:{kind}` |
+| metadata | 必有 `kind`、`provider`；有则带 `user_id`/`game_id`/`run_id` |
+| session_id | `str(game_id)` |
+| tags | 基础 `forge`；场景加 `guardrail` / `memory` / `cache`；可选 `phase:{name}` |
+
+### kind 枚举（本轮）
+
+`plan` / `art` / `code` / `qa` / `session_summary` / `skill_select` / `guardrail` / `preference_extract` / `semantic_confirm` / 默认 `chat`
+
+## 4. 架构（方案①）
+
+1. 扩展 `observe_generation(kind=...)`；新增 `propagate_trace_attrs`（包装官方 `propagate_attributes`，无 key no-op）。
+2. `observe_run` 接收 `user_id`/`game_id`，内层 propagate session + tags。
+3. `call_llm` / `call_llm_stream` 透传 `kind`。
+4. 平台旁路（偏好抽取、语义确认）经 `platform_complete`：observe + `provider.complete`，**不**记用户 usage/熔断。
+5. Guard 使用 `kind=guardrail`，尽量补齐 ids；tags 含 `guardrail`。
+
+## 5. 测试
+
+* `kind` → generation name；无 key no-op；propagate 无 key 不炸
+* platform_complete 走观测；旁路不再裸调 `provider.complete`
+* conftest 清空 key 行为不变
+
+## 6. 验收
+
+同一 `game_id` 多次 run 在 Langfuse Sessions 下可见；UI 中可见 `llm:plan` / `llm:guardrail` / `llm:preference_extract` 等；未配置 key 时零外发。


### PR DESCRIPTION
## Summary
- Instrument all business LLM paths with Langfuse generations named `llm:{kind}` (plan/art/code/qa/guardrail/preference_extract/semantic_confirm/skill_select/session_summary).
- Aggregate runs under Langfuse Sessions via `session_id=str(game_id)` and propagate `user_id` / tags (`forge`, `guardrail`, phase, etc.).
- Add `platform_complete` so preference extract and semantic soft-hit confirm are traced without touching user quota or circuit breakers.

## Background
Forge main runs were already traced, but bypass LLM calls often hit `provider.complete` bare, generation names were coarse (`llm:{provider}`), and Langfuse `session_id` was unused—so multi-run game sessions could not be viewed as one Session.

## Changes
- `app.core.langfuse`: `kind` naming + `propagate_trace_attrs`
- `app.forge.tracing`: session-aware `observe_run` / phase tags
- `app.llm.platform_complete` + preference/semantic callers
- `call_llm` / stream / guard / graph / code_qa kind wiring
- Design + plan under `docs/superpowers/`

## Test plan
- [ ] `cd backend && uv run pytest tests/llm/test_langfuse_integration.py tests/llm/test_platform_complete.py -q`
- [ ] `uv run pytest tests/forge/memory/test_inferred_preferences.py tests/forge/cache/test_llm_summary_and_semantic.py tests/forge/guard/ -q`
- [ ] With Langfuse keys set: run one forge generation and confirm generations named `llm:plan` / `llm:guardrail` (etc.) appear under a Session keyed by `game_id`
- [ ] Confirm unset Langfuse keys still no-op (no cloud traffic)

## Impact & Risks
- Low runtime risk when keys unset (existing no-op path).
- When enabled, more generations are reported (cost/volume on Langfuse); bypass paths still do not bill user quotas.

Made with [Cursor](https://cursor.com)