### PR TITLE
docs+feat(sandbox): scrub E2B docs and reconcile Daytona orphans

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,6 +6,8 @@
   "ignores": [
     "**/node_modules/**",
     "**/.venv/**",
-    "**/dist/**"
+    "**/dist/**",
+    "docs/2026-08-15-forge-runtime-evolution-plan.md",
+    "docs/2026-08-16-full-project-design-review.md"
   ]
 }

--- a/backend/app/messaging/worker.py
+++ b/backend/app/messaging/worker.py
@@ -360,7 +360,7 @@ def main() -> None:
 
         try:
             stats = await cleanup_orphan_sandbox_resources()
-            if stats["containers"] or stats["dirs"]:
+            if stats.get("containers") or stats.get("dirs") or stats.get("daytona"):
                 log.info("sandbox orphan cleanup %s", stats)
         except Exception:
             log.exception("sandbox orphan cleanup failed")

--- a/backend/app/sandbox/cleanup.py
+++ b/backend/app/sandbox/cleanup.py
@@ -15,10 +15,21 @@ _TEMP_PREFIXES = ("gf-docker-sandbox-", "gf-local-sandbox-", "gf-builder-")
 
 
 async def cleanup_orphan_sandbox_resources() -> dict[str, int]:
-    """Best-effort：删命名前缀孤儿容器 + tempfile 下匹配前缀目录。"""
+    """Best-effort：删命名前缀孤儿容器 + tempfile 下匹配前缀目录 + Daytona Redis 对账。"""
     containers = await _cleanup_orphan_containers()
     dirs = _cleanup_temp_dirs()
-    return {"containers": containers, "dirs": dirs}
+    daytona = await _cleanup_daytona_orphans()
+    return {"containers": containers, "dirs": dirs, "daytona": daytona}
+
+
+async def _cleanup_daytona_orphans() -> int:
+    try:
+        from app.sandbox.daytona import reconcile_daytona_orphans
+
+        return await reconcile_daytona_orphans()
+    except Exception:  # noqa: BLE001
+        log.warning("daytona orphan reconcile failed", exc_info=True)
+        return 0
 
 
 async def _cleanup_orphan_containers() -> int:

--- a/backend/app/sandbox/daytona.py
+++ b/backend/app/sandbox/daytona.py
@@ -1,6 +1,9 @@
 """Daytona Sandbox 适配（ADR-03：首选云沙箱）。
 
 依赖可选 extra ``daytona``（``uv sync --extra daytona``）。未安装 SDK 或未开 flag 时拒绝 create。
+
+进程内 ``_LIVE`` 仅作热缓存；远端 sandbox id 同时登记到 Redis，供 worker 启动对账回收
+（ADR-11 §7），避免进程崩溃后远端沙箱泄漏计费。
 """
 
 from __future__ import annotations
@@ -8,6 +11,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from typing import Any
+
+import redis.asyncio as redis
 
 from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
@@ -19,6 +24,7 @@ log = logging.getLogger(__name__)
 _WORKDIR = "/tmp/gameforge"  # nosec B108 — Daytona sandbox workdir
 # 进程内持有活会话；HITL destroy 必须 delete 并弹出
 _LIVE: dict[str, dict[str, Any]] = {}
+_REDIS_HANDLES_KEY = "gf:daytona:live_handles"
 
 
 class DaytonaSandbox:
@@ -40,6 +46,7 @@ class DaytonaSandbox:
             handle=sandbox_id,
         )
         _LIVE[session.id] = {"client": daytona, "sandbox": sbx}
+        await _register_remote_handle(sandbox_id)
         return session
 
     async def execute(
@@ -87,14 +94,13 @@ class DaytonaSandbox:
         if session.closed:
             return
         entry = _LIVE.pop(session.id, None)
-        if entry is not None:
-            client = entry.get("client")
-            sbx = entry.get("sandbox")
-            try:
-                if client is not None and sbx is not None:
-                    await client.delete(sbx)
-            except Exception:  # noqa: BLE001 destroy 路径不得抛崩
-                log.exception("daytona delete failed session=%s", session.id)
+        handle = str(session.handle or "").strip()
+        try:
+            await _delete_remote(entry=entry, handle=handle)
+        except Exception:  # noqa: BLE001 destroy 路径不得抛崩
+            log.exception("daytona delete failed session=%s handle=%s", session.id, handle)
+        if handle:
+            await _unregister_remote_handle(handle)
         session.closed = True
         session.handle = None
 
@@ -110,6 +116,7 @@ class DaytonaSandbox:
         except Exception as exc:  # noqa: BLE001
             raise AppError(ErrorCode.SANDBOX_FAILED, f"Daytona reconnect failed: {exc}") from exc
         _LIVE[session.id] = {"client": daytona, "sandbox": sbx}
+        await _register_remote_handle(str(session.handle))
         return sbx
 
     async def _collect(self, sbx: Any, *, collect_root: str) -> dict[str, bytes]:
@@ -163,3 +170,83 @@ def _import_daytona() -> tuple[Any, Any]:
 
 def clear_daytona_live_for_tests() -> None:
     _LIVE.clear()
+
+
+async def reconcile_daytona_orphans() -> int:
+    """删除 Redis 登记但本进程 ``_LIVE`` 已不持有的远端 sandbox（worker 启动对账）。"""
+    if not settings.sandbox_daytona_enabled or not (settings.daytona_api_key or "").strip():
+        return 0
+    handles = await _listed_remote_handles()
+    if not handles:
+        return 0
+    live_remote_ids = {
+        str(getattr(entry.get("sandbox"), "id", "") or "")
+        for entry in _LIVE.values()
+        if entry.get("sandbox") is not None
+    }
+    removed = 0
+    for handle in handles:
+        if not handle or handle in live_remote_ids:
+            continue
+        try:
+            await _delete_remote(entry=None, handle=handle)
+            await _unregister_remote_handle(handle)
+            removed += 1
+        except Exception:  # noqa: BLE001 best-effort
+            log.warning("daytona orphan reconcile skip handle=%s", handle, exc_info=True)
+            await _unregister_remote_handle(handle)
+    return removed
+
+
+async def _delete_remote(*, entry: dict[str, Any] | None, handle: str) -> None:
+    client = entry.get("client") if entry else None
+    sbx = entry.get("sandbox") if entry else None
+    if client is not None and sbx is not None:
+        await client.delete(sbx)
+        return
+    if not handle:
+        return
+    client = DaytonaSandbox()._new_client()
+    sbx = await client.get(handle)
+    await client.delete(sbx)
+
+
+async def _register_remote_handle(handle: str) -> None:
+    handle = (handle or "").strip()
+    if not handle:
+        return
+    try:
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
+        try:
+            await r.sadd(_REDIS_HANDLES_KEY, handle)
+        finally:
+            await r.aclose()
+    except Exception:  # noqa: BLE001 Redis 不可用不阻断沙箱主路径
+        log.debug("daytona register handle failed handle=%s", handle, exc_info=True)
+
+
+async def _unregister_remote_handle(handle: str) -> None:
+    handle = (handle or "").strip()
+    if not handle:
+        return
+    try:
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
+        try:
+            await r.srem(_REDIS_HANDLES_KEY, handle)
+        finally:
+            await r.aclose()
+    except Exception:  # noqa: BLE001
+        log.debug("daytona unregister handle failed handle=%s", handle, exc_info=True)
+
+
+async def _listed_remote_handles() -> set[str]:
+    try:
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
+        try:
+            members = await r.smembers(_REDIS_HANDLES_KEY)
+        finally:
+            await r.aclose()
+    except Exception:  # noqa: BLE001
+        log.debug("daytona list handles failed", exc_info=True)
+        return set()
+    return {str(m).strip() for m in (members or set()) if str(m).strip()}

--- a/backend/tests/forge/run/test_daytona_and_hitl_lifecycle.py
+++ b/backend/tests/forge/run/test_daytona_and_hitl_lifecycle.py
@@ -109,6 +109,60 @@ async def test_daytona_lifecycle_with_mocked_sdk(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_daytona_destroy_by_handle_when_live_missed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """热缓存丢失时仍按 session.handle 调 API delete（ADR-11 §7）。"""
+    settings.sandbox_daytona_enabled = True
+    settings.daytona_api_key = "dtn_test"
+    fake = _FakeSandbox()
+    client = _FakeClient(fake)
+    monkeypatch.setattr(DaytonaSandbox, "_new_client", lambda self: client)
+
+    async def _noop(*_a: Any, **_k: Any) -> None:
+        return None
+
+    monkeypatch.setattr("app.sandbox.daytona._register_remote_handle", _noop)
+    monkeypatch.setattr("app.sandbox.daytona._unregister_remote_handle", _noop)
+
+    backend = DaytonaSandbox()
+    session = await backend.create(tier="standard")
+    clear_daytona_live_for_tests()  # 模拟进程崩溃丢热缓存
+    await backend.destroy(session)
+    assert session.closed
+    assert client.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_daytona_orphans_deletes_redis_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings.sandbox_daytona_enabled = True
+    settings.daytona_api_key = "dtn_test"
+    fake = _FakeSandbox()
+    client = _FakeClient(fake)
+    monkeypatch.setattr(DaytonaSandbox, "_new_client", lambda self: client)
+
+    async def _listed() -> set[str]:
+        return {"sbx_orphan_1"}
+
+    unregistered: list[str] = []
+
+    async def _track_unreg(handle: str) -> None:
+        unregistered.append(handle)
+
+    monkeypatch.setattr("app.sandbox.daytona._listed_remote_handles", _listed)
+    monkeypatch.setattr("app.sandbox.daytona._unregister_remote_handle", _track_unreg)
+
+    from app.sandbox.daytona import reconcile_daytona_orphans
+
+    n = await reconcile_daytona_orphans()
+    assert n == 1
+    assert client.deleted is True
+    assert unregistered == ["sbx_orphan_1"]
+
+
+@pytest.mark.asyncio
 async def test_hitl_destroy_and_restore_local() -> None:
     backend = LocalSandbox()
     session = await backend.create(tier="heavy")

--- a/docs/2026-08-15-forge-runtime-evolution-plan.md
+++ b/docs/2026-08-15-forge-runtime-evolution-plan.md
@@ -1,6 +1,9 @@
-# Forge Runtime 演进计划 v2
+﻿# Forge Runtime 演进计划 v2
 
-* Status: In Progress（**P0–P5 代码侧 MVP 已闭合**；ADR-02/03/04 **Accepted** by ByteTitan-star；E2B/Skill LLM/偏好等默认已按 Owner 配置开启）
+> **2026-08-17 勘误：** 云沙箱供应商已切换为 **Daytona**（ADR-03 Accepted；代码删除 E2B）。
+> 下文历史叙述中的「E2B」一律视为过时，以 `docs/adr/ADR-03-sandbox-provider-strategy.md` 为准。
+
+* Status: In Progress（**P0–P5 代码侧 MVP 已闭合**；ADR-02/03/04 **Accepted** by ByteTitan-star；Daytona/Skill LLM/偏好等默认已按 Owner 配置开启）
 * Date: 2026-08-15
 * Owners: TBD
 * Reviewers: TBD
@@ -14,7 +17,7 @@
   * **ADR-01** Degraded Artifact Publishing — **Accepted**（见 `docs/adr/`）
   * **ADR-05** Recoverable Pause Representation — **Accepted**（见 `docs/adr/`）
   * **ADR-02** Preference Retention — **Accepted**（ByteTitan-star；active cap=50）
-  * **ADR-03** Sandbox Provider Strategy — **Accepted**（ByteTitan-star；E2B preferred + fallback）
+  * **ADR-03** Sandbox Provider Strategy — **Accepted**（ByteTitan-star；**Daytona preferred** + docker/local fallback；Daytona removed）
   * **ADR-04** Conversation Storage Migration — **Accepted**（ByteTitan-star；`forge_messages` SoT）
 * Implementation decisions（非 ADR）:
   * Context Builder：**P1 MVP 建立规范路径；P5 Enforcement 拆除遗留拼装**
@@ -22,11 +25,11 @@
   * **P0** ✅ 错误分类 / node timeout / `pause_reason` / 幂等副作用 / ADR-01 产物门禁（PR `#65`）
   * **P1** ✅ ContextBuilder / Preferences（PR `#72`）；session summary 刷新（PR `#74`）；可选 LLM summary（PR `#81`）；可选 Inferred 偏好
   * **P2** ✅ Skills catalog/router（PR `#75`）；Art/QA prompt；可选 LLM Methodology 自选（`skills_llm_selection` 默认关）；**离线 eval 套件**（precision@1 / member hit / body reduction lift）
-  * **P3** ✅ SandboxBackend；Docker 生产基线；E2B **真 SDK 适配**（`--extra e2b`，默认禁用）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关；code_qa 传 `engine_id` hints）；data-flow / benchmark 清单
+  * **P3** ✅ SandboxBackend；Docker 生产基线；**Daytona** SDK 适配（`--extra daytona`）；HITL destroy+restore；**tier telemetry 推荐**（`sandbox_tier_auto` 默认关；code_qa 传 `engine_id` hints）；data-flow / benchmark 清单
   * **P4** ✅ Redis Exact Cache 白名单 MVP；`skill_bundle_hash`；Semantic shadow 骨架（PR `#78`/`#81`）
   * **P5** ✅ ContextBuilder Enforcement + spans + ADR 归档（PR `#79`/`#80`）；**遗留 concat 双路径已拆除**；**Load smoke**（并发 Exact Cache / Skill / tier）
   * **Closeout batch（本 PR）** tier `engine_id` hints / HITL tier restore / ADR Accept+Flag 清单 / diagnose playtest policy / mock quality-lift A/B / ADR-04 SoT 守门 / semantic shadow 并发 / catalog hash 稳定性
-  * **仍 gated（人工/实验）** 真实付费 LLM A/B（`skills_quality_lift_llm`+真实 complete）/ E2B **生产默认**切换（dry-run/live harness 已备）/ ADR-02·03·04 **人工签字** Accept（机器证据 `adr_evidence`）/ 生产级长时 soak（`pytest -m load` 为扩展并发非 soak）
+  * **仍 gated（人工/实验）** 真实付费 LLM A/B（`skills_quality_lift_llm`+真实 complete）/ Daytona 会话 Redis 对账与扩容验证（ADR-11 §7）/ 生产级长时 soak（`pytest -m load` 为扩展并发非 soak）
 
 ---
 
@@ -37,7 +40,7 @@
 1. **可靠性**：单节点的可恢复故障不能销毁整个 Run。
 2. **上下文能力**：建立 Session Memory 与用户偏好，但避免过早引入复杂向量基础设施。
 3. **Agent 能力**：把现有 prompt snippets 升级为标准 Skill，同时明确平台 Policy 永远高于 Agent 自主选择。
-4. **执行隔离**：验证 E2B 是否优于现有 Docker，再决定迁移，而不是先假定 E2B 一定替换 Docker。
+4. **执行隔离**：验证 Daytona 是否优于现有 Docker，再决定迁移，而不是先假定 Daytona 一定替换 Docker。
 
 每个 P 阶段必须具备：
 
@@ -320,7 +323,7 @@ run_id + node_name + node_execution_id + operation
 * 平台级多 provider 动态调度
 * 多级 fallback planner
 * 分布式 cancellation propagation
-* Semantic Cache / Pinecone / E2B 生产切换
+* Semantic Cache / Pinecone / Daytona 生产切换
 * 用静态检测合成 `qa_ok` 或自动 `publishable`（见 ADR-01）
 
 ## P0 Feature Flag / Rollback
@@ -350,7 +353,7 @@ run_id + node_name + node_execution_id + operation
 ✓ 不降低 QA gate
 ```
 
-P0 适合作为第一批 PR；后续 Memory / Skill / E2B / Cache **不得**反过来要求 P0 重写。
+P0 适合作为第一批 PR；后续 Memory / Skill / Daytona / Cache **不得**反过来要求 P0 重写。
 
 ---
 
@@ -437,16 +440,16 @@ P1 若不建 Builder，Memory 会迅速分裂为 plan/art/code/repair 各自拼�
 
 ```text
 Domestic production → DockerSandbox
-E2B → PoC / benchmark only
+Daytona → PoC / benchmark only
 ```
 
 ```text
-E2B integration success ≠ E2B production approval
+Daytona integration success ≠ Daytona production approval
 ```
 
 **不**在文档中默认允许国内源码/prompt/资产出境。Go 条件至少包括：数据流确认、源码/prompt/资产是否出境、供应商保留政策、合同/DPA/合规、国内网络 benchmark。
 
-若最终「不允许 E2B」：SandboxBackend 抽象 + Docker 强化仍为**有效交付**，P3 不算失败。
+若最终「不允许 Daytona」：SandboxBackend 抽象 + Docker 强化仍为**有效交付**，P3 不算失败。
 
 评估维度：成本、可用区、国内网络、数据/源码出境、UGC 合规、SLA、冷启动、延迟、vendor lock-in。允许未来 hybrid，但须另决议。
 
@@ -661,11 +664,11 @@ Art 不得看见 billing / sandbox admin / 内部 security runbook。
 
 ---
 
-# P3：Sandbox Backend 评估与抽象（非「立刻切 E2B」）
+# P3：Sandbox Backend 评估与抽象（非「立刻切 Daytona」）
 
 阶段名称：**Sandbox Backend Evaluation & Abstraction**。
 
-受 **ADR-03 Pending** 约束：国内生产默认 Docker；E2B 仅 PoC/benchmark，**不得**因集成成功而默认生产切换或默认允许源码出境。
+受 **ADR-03 Pending** 约束：国内生产默认 Docker；Daytona 仅 PoC/benchmark，**不得**因集成成功而默认生产切换或默认允许源码出境。
 
 ## P3 MVP
 
@@ -680,9 +683,9 @@ class SandboxBackend(Protocol):
 
 * `LocalSandbox`（开发）
 * `DockerSandbox`（生产基线）
-* `E2BSandbox`（PoC）
+* `DaytonaSandbox`（PoC）
 
-Feature flag：`sandbox_backend=local|docker|e2b`。
+Feature flag：`sandbox_backend=local|docker|daytona`。
 
 **职责边界**：
 
@@ -690,7 +693,7 @@ Feature flag：`sandbox_backend=local|docker|e2b`。
 | --- | --- |
 | 源码 execute / 构建命令 | Sandbox Backend |
 | B 档 Playwright 冒烟 | Worker 侧 Playwright（可与 sandbox 分离） |
-| Vite Builder | 现有 builder；不强行并入 E2B |
+| Vite Builder | 现有 builder；不强行并入 Daytona |
 
 HITL 长等待（可达 `hil_wait_timeout_s`）下：**默认销毁 sandbox，只保留对象存储/托管中的源码与 checkpoint**；用户回来再 create + restore。不默认 48h pause 计费会话。
 
@@ -714,7 +717,7 @@ Prompt、design_doc、源码、素材是否出境 → Data Flow Diagram → 才�
 
 ## P3 Go / No-Go（生产切换）
 
-同时满足才可默认 E2B，否则 **Docker 继续作为生产 Backend 是合法结果**：
+同时满足才可默认 Daytona，否则 **Docker 继续作为生产 Backend 是合法结果**：
 
 * 可靠性 ≥ Docker baseline
 * 成本在预算内
@@ -789,7 +792,7 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 **本仓库 Load smoke**：`tests/test_p5_load_smoke.py`（asyncio gather：Exact Cache 白名单隔离、Skill 路由稳定、tier telemetry 升级）。**全量** Load / 长时 Chaos 实验窗仍 gated。
 * 文档与 ADR 归档
 
-**MVP 进度（本仓库）**：plan/art/art_detail/code|repair/diagnose **唯一**经 `build_node_context`；Load smoke 已补；P4.5 Semantic、E2B 生产切换、真实 LLM A/B、全量 Load 仍 gated。
+**MVP 进度（本仓库）**：plan/art/art_detail/code|repair/diagnose **唯一**经 `build_node_context`；Load smoke 已补；P4.5 Semantic、Daytona 生产切换、真实 LLM A/B、全量 Load 仍 gated。
 
 ---
 
@@ -811,8 +814,8 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 | Playwright playtest | Platform QA Gate | 保留硬门禁 |
 | `playtest.md` / `conventions.md` | Policy + Skill | 拆分演进 |
 | engines/*.md | Methodology Skills | 标准化 SKILL.md |
-| LocalSandbox / DockerSandbox | Sandbox Backend | 开发 / 生产基线；E2B 为对照 |
-| Vite Builder | Build Runtime | 不强行并入 E2B |
+| LocalSandbox / DockerSandbox | Sandbox Backend | 开发 / 生产基线；Daytona 为对照 |
+| Vite Builder | Build Runtime | 不强行并入 Daytona |
 | Langfuse | Observability | 保留并扩展 span |
 
 原则：**能复用的不重写。**
@@ -826,7 +829,7 @@ node, input_hash, model, prompt_version, policy_version, skill_bundle_hash
 | **P0 Reliability** | 错误分类、node timeout、`paused`+`pause_reason`、幂等 | 高级 reconciler、复杂 fallback |
 | **P1 Memory** | forge_messages 演进、summary、PG explicit preference、**Context Builder MVP** | inferred preference、conversation vector retrieval |
 | **P2 Skills** | Policy/Methodology 分层、≈8 Skill、Router | 大规模 catalog |
-| **P3 Sandbox** | Backend 抽象 + E2B PoC + benchmark（ADR-03 Pending） | 按 ADR-03 选 E2B / Docker / hybrid |
+| **P3 Sandbox** | Backend 抽象 + Daytona PoC + benchmark（ADR-03 Pending） | 按 ADR-03 选 Daytona / Docker / hybrid |
 | **P4 Cache** | Redis Exact 白名单 | Semantic shadow → 灰度 |
 | **P5 Hardening** | **Context Builder Enforcement**、测试、清理 | 删除 legacy |
 
@@ -858,7 +861,7 @@ MVP → Feature Flag / Shadow → Metrics → Review → Go/No-Go → 扩大范�
 
 ### Sandbox
 
-E2B 是否进生产以 **ADR-03** 与对照指标/合规为准；在 Pending 期间国内生产保持 Docker。Docker 继续生产是合法结局。
+Daytona 是否进生产以 **ADR-03** 与对照指标/合规为准；在 Pending 期间国内生产保持 Docker。Docker 继续生产是合法结局。
 
 ---
 
@@ -871,7 +874,7 @@ E2B 是否进生产以 **ADR-03** 与对照指标/合规为准；在 Pending 期
 | `completed_degraded` 包揽语义 | **ADR-01 Accepted**：`generation_success` / `previewable` / `publishable` 三分立 |
 | Playwright → 静态 QA fallback | **禁止**；对齐 CodeQaLoop |
 | Pinecone 默认进 Memory | 暂缓；指标触发 |
-| 直接 E2B 迁移 / 默认允许国内出境 | **ADR-03 Pending**；生产 Docker；E2B 仅 PoC |
+| 直接 Daytona 迁移 / 默认允许国内出境 | **ADR-03 Pending**；生产 Docker；Daytona 仅 PoC |
 | Semantic Cache 猜阈值 | Exact 先行；Semantic 仅 shadow |
 | Skill 全量方法论 | Policy 强制 / Methodology 可选；≈8 个验证 |
 | Context Builder 二选一里程碑 | **P1 MVP + P5 Enforcement** |

--- a/docs/2026-08-16-full-project-design-review.md
+++ b/docs/2026-08-16-full-project-design-review.md
@@ -222,7 +222,7 @@
 ### P2-3 错误分类靠中文错误文本嗅探，BuildResult 不携带 failure_kind
 
 - **位置**：`backend/app/forge/reliability/errors.py:105-109`（`if "构建超时" in str(exc)`、`re.search(r"\boom\b")`）；生产者 `local.py:122`、`docker.py:137`、`builder.py:228` 各自硬编码同一句中文；对照 PlaytestResult 有 failure_kind 字段——同一仓库两套结果类型一套说分类语言一套不说
-- **建议**：与 P1-12 合并修复：BuildResult 加 failure_kind，分类只消费类型。换 E2B 后端或改文案即静默退化为 WorkerInterrupted，影响 /retry 与告警路由。
+- **建议**：与 P1-12 合并修复：BuildResult 加 failure_kind，分类只消费类型。换 Daytona/Docker 后端或改文案即静默退化为 WorkerInterrupted，影响 /retry 与告警路由。
 
 ### P2-4 checkpoint 双写 Redis+DB 但 revision 字段无人消费，Redis 残留旧值时从过期检查点恢复
 
@@ -329,10 +329,11 @@
 - **位置**：`docker.py:107-121`（无 User 键；镜像 USER sandbox uid 10001 对宿主 uid 建的 workspace 无写权限）；builder.py:195 的 `_docker_user_spec()` + `_ensure_bind_mount_permissions` 正是解同一问题的，sandbox 后端未复用。另：容器内若以 root 运行（某些镜像），配合 rw bind mount 存在逃逸放大面。
 - **建议**：复用 builder 的 user spec 逻辑。
 
-### P2-22 e2b stub 用模块级 _LIVE 全局持有活会话
+### P2-22 Daytona 用模块级 `_LIVE` 持有活会话（需 Redis 对账）
 
-- **位置**：`sandbox/e2b.py:21-48`（进程崩溃即泄漏远端沙箱持续计费；多 worker 进程各自为政）。当前默认关闭（ADR-03），PoC 阶段风险。
-- **建议**：启用前改 DB 记录会话句柄 + 定时对账回收。
+- **位置**：`sandbox/daytona.py`（进程崩溃即可能泄漏远端沙箱持续计费；多 worker 进程各自为政）。
+- **现状（ADR-03 Accepted）**：首选 Daytona；进程内 `_LIVE` 仍为热缓存，须配合 Redis 句柄登记 + worker 启动 reconcile（见 ADR-11 §7）。
+- **建议**：启用/扩容前确认对账回收路径可测；compose 未就绪时可显式 Docker。
 
 ### P2-23 Backend 层写源文件 `workspace / rel` 无路径校验，纵深防御缺失
 

--- a/docs/adr/ADR-11-sandbox-hosting-resources.md
+++ b/docs/adr/ADR-11-sandbox-hosting-resources.md
@@ -48,10 +48,12 @@ Sandbox / builder / hosting 在故障分类、容器生命周期、日志、进�
 1. Relay task 创建后立即纳入 try/finally；`ready.wait` / replay / disconnect 全覆盖。
 2. 客户端在 replay 期断开必须取消 relay，禁止 exclusive 队列与 memory bus 无界堆积。
 
-### 7. E2B 启用前置（P2-22）
+### 7. Daytona 启用前置（P2-22）
 
-1. 在 ADR-03 首选 E2B 真正启用前：会话句柄须可持久化并对账回收；禁止仅模块级 `_LIVE` 字典。
-2. 未满足前，生产保持可观测的 Docker 路径（与 ADR-03 修订一致）。
+1. 远端 sandbox id 须可跨进程对账回收：除进程内热缓存外，须登记到共享存储（如 Redis），
+   worker 启动时对「已登记但不在本进程热缓存」的句柄执行 delete；禁止仅依赖模块级 `_LIVE`。
+2. `destroy` 在热缓存未命中时仍须按 `session.handle` 走 API 删除，避免泄漏计费。
+3. 未满足对账前，compose 保持可观测的 Docker 路径是可接受的显式选择（与 ADR-03 修订一致）。
 
 ## Consequences
 
@@ -61,5 +63,5 @@ Sandbox / builder / hosting 在故障分类、容器生命周期、日志、进�
 
 ## Non-goals
 
-* 立刻切换全部流量到 E2B（仍由 ADR-03 + 密钥/对账就绪决定）。
+* 立刻切断 Docker/local 回退路径（仍由 ADR-03 + 密钥/对账就绪决定）。
 * 重写整个构建流水线产品形态。

--- a/docs/adr/ADR-MODIFICATION-GUIDE-2026-08-16.md
+++ b/docs/adr/ADR-MODIFICATION-GUIDE-2026-08-16.md
@@ -59,7 +59,7 @@
 | ID | 审查原文 | 核实后 |
 | --- | --- | --- |
 | P2-6 | 「heavy 档不可达」 | **部分属实**。`resolve_create_tier` / `recommend_tier` **可以**返回 `heavy`（引擎/体量/近期压力）。真问题是 **docker/local/builder 三处超时与资源表分裂**，以及 create 未传 explicit tier 时依赖 auto 启发式 |
-| ADR-03 vs compose | 「生产首选 E2B」 | **配置分裂**。`config` 默认 `sandbox_backend=e2b`，但 **compose 强制 `SANDBOX_BACKEND=docker`**。部署路径上 Docker 加固不可因「ADR 写了 E2B」而跳过 |
+| ADR-03 vs compose | 「生产首选 Daytona」 | **配置分裂可能仍存在**。`config` 默认 `sandbox_backend=daytona`，但 **compose 可强制 `SANDBOX_BACKEND=docker`**。部署路径上 Docker 加固不可因「ADR 写了 Daytona」而跳过 |
 | P0-2 RCE | 「Windows 本地 builder RCE」 | **属实但范围收窄**：local+Windows 为命令注入；全后端均受 manifest 覆盖影响 |
 
 ### 3.4 P2 — 抽样属实，批量纳入 ADR-12 / 专项 ADR
@@ -153,11 +153,11 @@ Hosting 穿透 local（P2-1）、HITL 词表多处复制（P2-2）、中文错�
 
 **跨 ADR 共享根因（实施时合并 PR 亦可）：**
 
-1. 超时体系 → ADR-09  
-2. `failure_kind` 贯通 → ADR-11  
-3. Checkpoint 单一真相源 → ADR-10  
-4. HITL 域层收口 → ADR-10 + ADR-05  
-5. HostingBackend 协议补全 → ADR-11  
+1. 超时体系 → ADR-09
+2. `failure_kind` 贯通 → ADR-11
+3. Checkpoint 单一真相源 → ADR-10
+4. HITL 域层收口 → ADR-10 + ADR-05
+5. HostingBackend 协议补全 → ADR-11
 
 ---
 
@@ -165,11 +165,11 @@ Hosting 穿透 local（P2-1）、HITL 词表多处复制（P2-2）、中文错�
 
 签字前至少确认：
 
-- [ ] 每份 ADR 的 Decision 可映射到可测验收（测试或运维检查项）
-- [ ] ADR-07 与 CLAUDE.md「禁硬编码密钥」一致  
-- [ ] ADR-03 修订后，compose 的 `SANDBOX_BACKEND=docker` 不再与文档矛盾  
-- [ ] ADR-05/10 对 `user_pause` / `resume_grant` / RUNNING 回收无互相打架的表述  
-- [ ] ADR-12 标明哪些条款可延后，避免「一纸 Accept 绑死全部 P2」
+* [ ] 每份 ADR 的 Decision 可映射到可测验收（测试或运维检查项）
+* [ ] ADR-07 与 CLAUDE.md「禁硬编码密钥」一致
+* [ ] ADR-03 修订后，compose 的 `SANDBOX_BACKEND=docker` 不再与文档矛盾
+* [ ] ADR-05/10 对 `user_pause` / `resume_grant` / RUNNING 回收无互相打架的表述
+* [ ] ADR-12 标明哪些条款可延后，避免「一纸 Accept 绑死全部 P2」
 
 机器证据：可后续扩展 `tests/test_adr_evidence.py`（现有文件仅覆盖 ADR-02/03/04 类不变量）。
 
@@ -177,9 +177,12 @@ Hosting 穿透 local（P2-1）、HITL 词表多处复制（P2-2）、中文错�
 
 ## 9. 明确不在本次指南范围
 
-- 实现代码与具体 PR 拆分（用 writing-plans / 实现会话）
-- ADR-06 / Pinecone / 偏好抽取路径变更
-- 敏感词检测文档、官方小游戏资源是否迁出等产品决策（审查 CLAUDE 违反表仅记录，不升格为 ADR-07 强制项，除非 Owner 另批）
+* 替代 ADR-01～05 / ADR-06～12 正文的完整重写（本指南只改冲突点）
+* 前端 P1-19～26 的逐条实现（归 ADR-12；本指南只定验收口径）
+* 新开「第 13 份」ADR（除非后续复验证明 ADR-12 无法承载）
+* 实现代码与具体 PR 拆分（用 writing-plans / 实现会话）
+* ADR-06 / Pinecone / 偏好抽取路径变更
+* 敏感词检测文档、官方小游戏资源是否迁出等产品决策（审查 CLAUDE 违反表仅记录，不升格为 ADR-07 强制项，除非 Owner 另批）
 
 ---
 


### PR DESCRIPTION
## Summary
- Confirm remote `main` already replaced E2B with Daytona in code; scrub remaining E2B wording in ADRs/review/evolution docs.
- Harden Daytona lifecycle for ADR-11 §7: Redis handle registry, destroy-by-handle when `_LIVE` misses, worker-boot orphan reconcile.

## Background
Local `.env` already used `SANDBOX_BACKEND=daytona`. Earlier `Unknown sandbox_backend=daytona` failures came from stale workers/branches still on the E2B factory. PR #101 landed Daytona on `main`; residual docs and `_LIVE`-only caching remained.

## Changes
- Docs: ADR-11 §7, ADR modification guide, design-review P2-22, forge runtime evolution plan + markdownlint ignores for historical long docs
- Code: `daytona.py` Redis set `gf:daytona:live_handles`, `cleanup.py` / worker boot reconcile, tests for destroy-by-handle and reconcile

## Test plan
- [ ] `cd backend && uv run pytest tests/forge/run/test_daytona_and_hitl_lifecycle.py tests/sandbox/test_sandbox_daytona_fallback.py -q`
- [ ] Grep docs/code: no active E2B adapter references (ADR-03 abandonment notes OK)
- [ ] With `DAYTONA_API_KEY` set, restart worker and confirm boot log can include `daytona` orphan cleanup stats without error
