### PR TITLE
fix(forge): logout to login, stream readable plan, pin log dock

### DIFF
--- a/backend/app/forge/design_doc.py
+++ b/backend/app/forge/design_doc.py
@@ -463,10 +463,59 @@ def validate_design_doc(value: Any) -> list[str]:
     return list(dict.fromkeys(errors))
 
 
+def design_doc_to_readable_text(value: Any) -> str:
+    """把 DesignDoc JSON 转成面向用户的可读方案文案（聊天打字机用）。"""
+    doc = coerce_design_doc(value)
+    lines: list[str] = [f"标题: {doc['title'] or '未命名游戏'}", ""]
+
+    gameplay = doc.get("gameplay") or ""
+    if gameplay:
+        lines.extend(["玩法概述:", str(gameplay), ""])
+
+    overview = _as_dict(doc.get("overview"))
+    if overview.get("genre"):
+        lines.append(f"类型: {overview['genre']}")
+    if overview.get("target_experience"):
+        lines.append(f"目标体验: {overview['target_experience']}")
+    if overview.get("session_length"):
+        lines.append(f"单局时长: {overview['session_length']}")
+    if overview.get("scope"):
+        lines.append(f"范围: {overview['scope']}")
+    if overview.get("assumptions"):
+        lines.append("")
+        lines.append("设计假设:")
+        for item in overview["assumptions"]:
+            lines.append(f"- {item}")
+
+    controls = doc.get("controls") or []
+    if controls:
+        lines.append("")
+        lines.append("操作控制:")
+        for item in controls:
+            lines.append(f"- {item}")
+
+    levels = doc.get("levels") or []
+    if levels:
+        lines.append("")
+        lines.append("关卡:")
+        for item in levels:
+            lines.append(f"- {item}")
+
+    core_loop = doc.get("core_loop") or []
+    if core_loop:
+        lines.append("")
+        lines.append("核心循环:")
+        for idx, item in enumerate(core_loop, start=1):
+            lines.append(f"{idx}. {item}")
+
+    return "\n".join(lines).strip()
+
+
 __all__ = [
     "SCHEMA_VERSION",
     "bilingual_title_errors",
     "coerce_design_doc",
+    "design_doc_to_readable_text",
     "design_doc_to_text",
     "parse_design_doc",
     "validate_design_doc",

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -6,6 +6,7 @@ CodeQaLoop 有界 code/playtest/diagnose，以及 skills 约定注入。
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -30,6 +31,7 @@ from app.forge.assets.picker import asset_pick
 from app.forge.code_candidate import claim_candidate_version, promote_candidate
 from app.forge.design_doc import (
     coerce_design_doc,
+    design_doc_to_readable_text,
     design_doc_to_text,
     parse_design_doc,
     validate_design_doc,
@@ -453,6 +455,26 @@ async def _streamed_llm_or_fallback(
     return await _llm(ctx, system, user_msg, kind=llm_kind)
 
 
+async def _emit_readable_plan_deltas(ctx: _Ctx, design_doc: dict[str, Any]) -> None:
+    """校验通过后，把可读方案按微批推成 LLM_DELTA（打字机），避免 JSON 原文刷屏。"""
+    if not settings.stream_enabled:
+        return
+    text = design_doc_to_readable_text(design_doc)
+    if not text:
+        return
+    size = max(1, settings.stream_batch_chars)
+    delay = max(0, settings.stream_batch_ms) / 1000.0
+    for start in range(0, len(text), size):
+        chunk = text[start : start + size]
+        await publish_event(
+            ctx.run.id,
+            WSEventType.LLM_DELTA,
+            {"phase": "plan", "delta": chunk},
+        )
+        if delay and start + size < len(text):
+            await asyncio.sleep(delay)
+
+
 async def _llm(ctx: _Ctx, system: str, user_msg: str, *, kind: str | None = None) -> str:
     stage = ctx.run.phase or "llm"
     llm_kind = kind or stage or "chat"
@@ -742,10 +764,14 @@ def _build_graph(ctx: _Ctx) -> Any:
                     + "\n返回完整修复后的 JSON 对象；"
                     "不要只返回修改片段，不要省略字段，不要改用同义字段。"
                 )
-            raw = await _streamed_llm_or_fallback(ctx, system_prompt, attempt_msg, "plan")
+            # plan JSON 不对用户打字机；校验通过后再流式推可读方案
+            raw = await _streamed_llm_or_fallback(
+                ctx, system_prompt, attempt_msg, "plan", emit_delta=False
+            )
             design_doc = parse_design_doc(raw, ctx.game.title)
             issues = validate_design_doc(design_doc)
             if not issues:
+                await _emit_readable_plan_deltas(ctx, design_doc)
                 return design_doc
             await publish_event(
                 ctx.run.id,

--- a/backend/app/forge/messages.py
+++ b/backend/app/forge/messages.py
@@ -8,6 +8,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.forge.design_doc import design_doc_to_readable_text
 from app.models.forge_message import ForgeMessage
 
 
@@ -60,16 +61,8 @@ async def add_message(
 def design_message_content(design_doc: dict | str) -> str:
     if not isinstance(design_doc, dict):
         return f"设计方案已生成：{design_doc}"
-    title = str(design_doc.get("title") or "本次游戏")
-    gameplay = str(design_doc.get("gameplay") or "").strip()
-    controls = str(design_doc.get("controls") or "").strip()
-    parts = [f"设计方案《{title}》已生成。"]
-    if gameplay:
-        parts.append(f"玩法：{gameplay}")
-    if controls:
-        parts.append(f"操作：{controls}")
-    parts.append("请确认方案，或填写修改意见。")
-    return "\n".join(parts)
+    body = design_doc_to_readable_text(design_doc)
+    return f"{body}\n\n请确认方案，或填写修改意见。"
 
 
 def stable_design_key(run_id: uuid.UUID, node: str, design_doc: dict | str) -> str:
@@ -92,9 +85,7 @@ async def list_messages(
     query = select(ForgeMessage).where(ForgeMessage.game_id == game_id)
     if before is not None:
         cursor = await db.scalar(
-            select(ForgeMessage).where(
-                ForgeMessage.id == before, ForgeMessage.game_id == game_id
-            )
+            select(ForgeMessage).where(ForgeMessage.id == before, ForgeMessage.game_id == game_id)
         )
         if cursor is None:
             return []

--- a/backend/tests/forge/design/test_design_doc.py
+++ b/backend/tests/forge/design/test_design_doc.py
@@ -130,3 +130,15 @@ def test_validate_requires_engine_version_for_cdn_engines() -> None:
     doc["engine"] = {"id": "phaser3", "rationale": "需要物理碰撞", "version": ""}
     errors = validate_design_doc(doc)
     assert any("engine.version" in e for e in errors)
+
+
+def test_design_doc_to_readable_text_covers_player_facing_fields() -> None:
+    from app.forge.design_doc import design_doc_to_readable_text
+    from tests.conftest import _valid_design_doc_json
+
+    doc = parse_design_doc(_valid_design_doc_json(), "T")
+    text = design_doc_to_readable_text(doc)
+    assert "标题:" in text
+    assert "玩法概述:" in text
+    assert "操作控制:" in text
+    assert "{" not in text  # 可读文案，不是 JSON 原文

--- a/frontend/src/components/forge/ForgeLogDock.test.tsx
+++ b/frontend/src/components/forge/ForgeLogDock.test.tsx
@@ -5,7 +5,7 @@ import { emptyStagePipeline } from '@/lib/stage-pipeline-state'
 import { ForgeLogDock } from './ForgeLogDock'
 
 describe('ForgeLogDock', () => {
-  it('展开时使用单一滚动容器，并以紧凑阶段条展示事件', () => {
+  it('展开时阶段条在滚动区外，事件流单独滚动', () => {
     const items = Array.from({ length: 12 }, (_, index) => ({
       id: `event-${index}`,
       label: `事件 ${index}`,
@@ -23,8 +23,10 @@ describe('ForgeLogDock', () => {
     )
 
     const scroll = container.querySelector('.gf-forge-log-dock-scroll')
+    const pipeline = container.querySelector('.gf-forge-log-dock-pipeline')
     expect(scroll).toBeInTheDocument()
-    expect(scroll?.querySelectorAll('.gf-forge-log-dock-scroll')).toHaveLength(0)
+    expect(pipeline).toBeInTheDocument()
+    expect(scroll?.contains(pipeline)).toBe(false)
     expect(screen.getByRole('list', { name: '生成流程' })).toBeInTheDocument()
     expect(screen.getByText('事件 11')).toBeInTheDocument()
     fireEvent.wheel(scroll!, { deltaY: 200 })

--- a/frontend/src/components/forge/ForgeLogDock.tsx
+++ b/frontend/src/components/forge/ForgeLogDock.tsx
@@ -50,8 +50,8 @@ function readStoredHeight(): number {
 
 /**
  * 底部横跨的「执行日志带」：标题栏常驻（折叠时仅 44px，显示最新事件与错误数），
- * 展开后顶部可垂直拖拽调整高度（120px ~ 45vh，持久化）。失败恢复条固定可见；
- * 紧凑阶段条（sticky 置顶）与事件流共享同一滚动容器，内容再多也能向下滚动到底。
+ * 展开后顶部可垂直拖拽调整高度（120px ~ 45vh，持久化）。
+ * 失败恢复条与阶段条固定在滚动区外；事件流 newest-first，默认钉住顶部跟随最新。
  */
 export function ForgeLogDock({
   open,
@@ -66,6 +66,8 @@ export function ForgeLogDock({
   const [height, setHeight] = useState(readStoredHeight)
   const draggingRef = useRef(false)
   const dockRef = useRef<HTMLElement | null>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const followLatestRef = useRef(true)
 
   const persistHeight = useCallback((next: number) => {
     const maxPx = Math.round(window.innerHeight * MAX_HEIGHT_RATIO)
@@ -105,6 +107,23 @@ export function ForgeLogDock({
     }
   }, [open, failureRecovery, height, persistHeight])
 
+  // newest-first：靠近顶部视为跟随；用户上翻后暂停自动钉顶
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || !open) return
+    function onScroll() {
+      followLatestRef.current = el.scrollTop < 24
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [open])
+
+  useEffect(() => {
+    if (!open || !followLatestRef.current) return
+    const el = scrollRef.current
+    if (el) el.scrollTop = 0
+  }, [items, open])
+
   const latest = items[0]
   const errorCount = items.filter((i) => i.tone === 'err').length
 
@@ -118,35 +137,30 @@ export function ForgeLogDock({
           tabIndex={0}
           className="gf-forge-dock-handle"
           onPointerDown={(event) => {
-            event.preventDefault()
             draggingRef.current = true
             document.body.classList.add('gf-forge-dock-resizing')
+            event.currentTarget.setPointerCapture(event.pointerId)
           }}
         />
       ) : null}
+
       <button
         type="button"
         onClick={onToggle}
-        aria-expanded={open}
         className="gf-interactive gf-forge-log-dock-header flex w-full cursor-pointer items-center justify-between gap-2 text-left transition hover:bg-black/[0.02]"
+        aria-expanded={open}
       >
-        <span className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--gf-text-muted)]">
-          {open ? (
-            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-          ) : (
-            <ChevronUp className="h-3.5 w-3.5 shrink-0" />
-          )}
-          <span className="shrink-0">{t('eventLog')}</span>
-          <span className="shrink-0 font-mono text-[11px]">· {items.length}</span>
+        <span className="gf-page-body flex min-w-0 items-center gap-2 text-sm font-medium">
+          {open ? <ChevronDown className="h-4 w-4 shrink-0" /> : <ChevronUp className="h-4 w-4 shrink-0" />}
+          <span className="truncate">{t('eventLog')}</span>
+        </span>
+        <span className="flex shrink-0 items-center gap-3">
           {!open && latest ? (
-            <span className="min-w-0 truncate normal-case text-[var(--gf-text)] opacity-80">
-              <span className="opacity-55">{t('forgeLogLatest')}:</span>{' '}
+            <span className="gf-page-muted max-w-[14rem] truncate text-[11px] sm:max-w-[20rem]">
               {latest.label}
             </span>
           ) : null}
-        </span>
-        <span className="flex shrink-0 items-center gap-2">
-          {!open && errorCount > 0 ? (
+          {errorCount > 0 ? (
             <span className="font-mono text-[11px] text-rose-600">
               {t('forgeLogErrors', { n: errorCount })}
             </span>
@@ -167,14 +181,12 @@ export function ForgeLogDock({
               onConfigureLlm={failureRecovery.onConfigureLlm}
             />
           ) : null}
-          {/* 失败恢复条固定可见；进度条与事件流共享同一滚动容器，
-              进度条 sticky 置顶，事件再多也能向下滚动到底。 */}
-          <div className="gf-forge-log-dock-scroll">
-            {showPipeline ? (
-              <div className="gf-forge-log-dock-sticky">
-                <StagePipeline runPhase={runPhase} stages={stages} variant="bar" />
-              </div>
-            ) : null}
+          {showPipeline ? (
+            <div className="gf-forge-log-dock-pipeline">
+              <StagePipeline runPhase={runPhase} stages={stages} variant="bar" />
+            </div>
+          ) : null}
+          <div ref={scrollRef} className="gf-forge-log-dock-scroll">
             <RunTimeline
               phase={runPhase}
               items={items}

--- a/frontend/src/components/layout/UserMenu.tsx
+++ b/frontend/src/components/layout/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { ChevronUp, Home, LogOut, Settings, Shield, User } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { Role } from '@/api/enums'
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/stores/auth-store'
 
 export function UserMenu({ collapsed = false }: { collapsed?: boolean }) {
   const t = useT()
+  const navigate = useNavigate()
   const user = useAuthStore((s) => s.user)
   const logout = useAuthStore((s) => s.logout)
   const [open, setOpen] = useState(false)
@@ -34,6 +35,13 @@ export function UserMenu({ collapsed = false }: { collapsed?: boolean }) {
   }, [open])
 
   if (!user) return null
+
+  function handleLogout() {
+    setOpen(false)
+    // 先离开受保护路由，避免 RequireAuth 带上 state.from 导致再登录回到深链
+    navigate('/login', { replace: true })
+    void logout()
+  }
 
   // 下拉菜单本体：展开态用 absolute（贴按钮上方、w-full），
   // 折叠态用 Portal + fixed（贴窄侧栏右侧、固定宽 16rem）。
@@ -86,10 +94,7 @@ export function UserMenu({ collapsed = false }: { collapsed?: boolean }) {
       <button
         type="button"
         role="menuitem"
-        onClick={() => {
-          setOpen(false)
-          void logout()
-        }}
+        onClick={handleLogout}
         className="gf-border-subtle flex w-full cursor-pointer items-center gap-2 border-t px-3 py-2.5 text-sm text-rose-600 transition hover:bg-rose-50"
       >
         <LogOut className="h-4 w-4" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -902,11 +902,11 @@ body.gf-forge-dock-resizing * {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overflow-anchor: none;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
   padding-top: 0.375rem;
 }
 
@@ -920,13 +920,10 @@ body.gf-forge-dock-resizing * {
   }
 }
 
-/* 进度条粘性置顶：事件流向下滚动时它始终可见；底色避免事件穿透 */
-.gf-forge-log-dock-sticky {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  background: rgba(255, 255, 255, 0.96);
-  backdrop-filter: blur(6px);
+/* 阶段条固定在滚动区外：不透底、不随事件滚动 */
+.gf-forge-log-dock-pipeline {
+  flex-shrink: 0;
+  background: #ffffff;
   padding: 0.375rem 0.25rem 0.5rem;
   border-bottom: 1px solid rgba(15, 23, 42, 0.06);
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowRight, ChevronRight, LogOut, MessageSquareText, Bot, Gamepad2, ShieldCheck } from 'lucide-react'
 import { publicGamesApi } from '@/api/public-games'
@@ -21,6 +21,7 @@ const HERO_VIDEO =
 
 export function LandingPage() {
   const t = useT()
+  const navigate = useNavigate()
   const locale = useLocaleStore((s) => s.locale)
   const token = useAuthStore((s) => s.access_token)
   const user = useAuthStore((s) => s.user)
@@ -135,7 +136,10 @@ export function LandingPage() {
                     type="button"
                     variant="secondary"
                     className="inline-flex items-center gap-1.5 rounded-md transition-transform duration-200 hover:scale-[1.03] active:scale-[0.98]"
-                    onClick={() => void logout()}
+                    onClick={() => {
+                      navigate('/login', { replace: true })
+                      void logout()
+                    }}
                   >
                     <LogOut className="h-3.5 w-3.5" />
                     {t('logout')}


### PR DESCRIPTION
## Summary
- Logout navigates to `/login` first (no `state.from`), so re-login does not restore a deep link.
- Plan generation no longer typewrites raw JSON; after validation it streams human-readable design text via `LLM_DELTA`.
- Event log auto-follows newest items (scrollTop pinned); stage pipeline sits outside the scroll area with an opaque background.

## Test plan
- [x] Logout from UserMenu / Landing → land on `/login`; login again stays on post-login default (not prior forge deep link)
- [x] Start a forge run: chat shows readable plan typewriter (title/gameplay/controls…), not JSON braces
- [x] Open event log: new events stay at top when following; scrolling up pauses auto-follow
- [x] Stage pipeline bar stays fixed while scrolling events; no content bleed through translucent sticky bar
- [x] Backend: `uv run pytest tests/forge/design/test_design_doc.py -q`
- [x] Frontend: `pnpm exec vitest run src/components/forge/ForgeLogDock.test.tsx`