### PR TITLE
fix(qa): fail fast on Playwright infra errors and improve forge HITL UX

### DIFF
--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -379,11 +379,20 @@ async def resolve_hitl(
             raise AppError(ErrorCode.INVALID_STATE, "run 已结束或不在 paused")
         run.status = RunStatus.RUNNING.value
         run.ended_at = None
-        selected_label = {"select_a": "已选择美术方案 A", "select_b": "已选择美术方案 B"}
+        selected_label = {
+            "select_a": "已选择美术方案 A",
+            "select_b": "已选择美术方案 B",
+            "approve": {
+                "plan_confirm": "已确认设计方案",
+                "art_confirm": "已确认美术方案",
+                "sandbox_failed": "环境问题已处理，继续重试",
+                "qa_failed": "已确认继续修复试玩问题",
+            }.get(phase, "已确认，继续"),
+        }
         decision_text = (
             req.modify_text.strip()
             if req.modify_text
-            else selected_label.get(req.decision, "已确认设计方案")
+            else selected_label.get(req.decision, "已确认，继续")
         )
         await add_message(
             db,

--- a/backend/app/forge/cache/pinecone_store.py
+++ b/backend/app/forge/cache/pinecone_store.py
@@ -126,7 +126,7 @@ class HttpPineconeStore:
         for m in matches:
             if not isinstance(m, dict):
                 continue
-            meta = m.get("metadata") if isinstance(m.get("metadata"), dict) else {}
+            meta: dict[str, Any] = m["metadata"] if isinstance(m.get("metadata"), dict) else {}
             out.append(
                 VectorMatch(
                     id=str(m.get("id") or ""),
@@ -152,7 +152,8 @@ class HttpPineconeStore:
             return {}
 
 
-_override: PineconeStore | None | object = object()
+_UNSET = object()
+_override: PineconeStore | None | object = _UNSET
 
 
 def set_pinecone_store_override(store: PineconeStore | None) -> None:
@@ -163,7 +164,7 @@ def set_pinecone_store_override(store: PineconeStore | None) -> None:
 
 def reset_pinecone_store_override() -> None:
     global _override
-    _override = object()
+    _override = _UNSET
 
 
 def pinecone_configured() -> bool:
@@ -175,7 +176,7 @@ def pinecone_configured() -> bool:
 
 
 def get_pinecone_store() -> PineconeStore | None:
-    if _override is not object():
+    if _override is not _UNSET:
         return _override  # type: ignore[return-value]
     if not pinecone_configured():
         return None

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -35,7 +35,11 @@ from app.forge.reliability.artifact_gate import derive_artifact_gate
 from app.hosting import serve, store
 from app.models.game_version import GameVersion
 from app.sandbox import get_sandbox
-from app.sandbox.playtest import run_playtest, run_playtest_dist
+from app.sandbox.playtest import (
+    is_permanent_infra_error,
+    run_playtest,
+    run_playtest_dist,
+)
 
 
 def _read_html(path: Any) -> str:
@@ -105,7 +109,9 @@ async def execute_code_or_repair(
             ]
             assets_block = "\n\n" + format_assets_for_prompt(picked)
 
-        qa_errors = state.get("playtest_errors") or []
+        qa_errors_raw = list(state.get("playtest_errors") or [])
+        # 环境类 infra（缺 Playwright 等）不应喂给 LLM「改游戏代码」
+        qa_errors = [e for e in qa_errors_raw if not is_permanent_infra_error([str(e)])]
         qa_diagnosis = state.get("qa_diagnosis") or ""
         attempt = int(state.get("attempt") or 0) + 1
 

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -1182,9 +1182,8 @@ def _build_graph(ctx: _Ctx) -> Any:
             "playtest_errors": state.get("playtest_errors") or [],
         }
         if state.get("code_qa_reset"):
+            # 重置尝试次数，但保留上次试玩/诊断错误，供下一轮 code/repair 拼接避错
             loop_in["attempt"] = 0
-            loop_in["qa_diagnosis"] = ""
-            loop_in["playtest_errors"] = []
             loop_in["candidate_ready"] = False
             loop_in["failure_kind"] = None
             loop_in["code_qa_reset"] = False
@@ -1244,11 +1243,14 @@ def _build_graph(ctx: _Ctx) -> Any:
             errors = list(result.get("playtest_errors") or [])
             has_candidate = bool(result.get("candidate_version"))
             gate = derive_artifact_gate(build_ok=has_candidate, qa_ok=False)
+            failure_kind = result.get("failure_kind")
+            # 环境类 infra（如缺 playwright）走 sandbox_failed，避免伪装成「游戏质量差」
+            hitl_node = "sandbox_failed" if failure_kind == "infra" else "qa_failed"
             await ckpt.save_state(
                 ctx.r,
                 ctx.run.id,
                 {
-                    "phase": "qa_failed",
+                    "phase": hitl_node,
                     "design_doc": design_doc,
                     "qa": "; ".join(errors),
                     "code_qa_reset": True,
@@ -1257,18 +1259,21 @@ def _build_graph(ctx: _Ctx) -> Any:
                     or {},
                     "artifacts": result.get("artifacts") or state.get("artifacts") or [],
                     "candidate_version": result.get("candidate_version"),
+                    "playtest_errors": errors,
+                    "qa_diagnosis": result.get("qa_diagnosis") or "",
+                    "failure_kind": failure_kind,
                     **gate.as_dict(),
                 },
                 ctx.s,
             )
             await _pause_hitl(
                 ctx,
-                "qa_failed",
+                hitl_node,
                 design_doc,
                 extra={
                     "issues": errors,
                     "attempt": result.get("attempt"),
-                    "failure_kind": result.get("failure_kind"),
+                    "failure_kind": failure_kind,
                     **gate.as_dict(),
                 },
             )

--- a/backend/app/forge/prompts.py
+++ b/backend/app/forge/prompts.py
@@ -73,9 +73,12 @@ _CODE_COMMON = f"""
 7. 不得留下 TODO、伪代码、未实现按钮、仅在注释中描述的功能或依赖刷新页面的重开。
 8. 不得通过删除关卡、敌人、碰撞、胜负或反馈等功能来规避实现难点。
 9. 正常游玩路径不得产生未捕获异常、无限循环或持续刷新的控制台错误。
-10. 状态机名称与 DOM 标识必须严格一致；例如 setScreen('playing') 动态查找
+10. 脚本加载顺序：运行时使用的类、函数、全局变量（如 Game、MainScene）必须先定义再调用；
+    禁止 ReferenceError（如 PAGE_ERROR: X is not defined）。使用 Phaser/Pixi 时须在
+    new Game / 场景注册前完成类与配置定义。
+11. 状态机名称与 DOM 标识必须严格一致；例如 setScreen('playing') 动态查找
     #screen-playing 时，HTML 中必须存在该元素。不得使用 #screen-game 等不同别名。
-11. 输入若包含“已确认美术实现设计稿 JSON”，必须逐项落实其中的布局、配色、绘制、
+12. 输入若包含“已确认美术实现设计稿 JSON”，必须逐项落实其中的布局、配色、绘制、
     状态视觉、动效、响应式、可访问性与性能约束，不得退回通用模板风格。
 
 实现优先级：先确保完整状态闭环和核心玩法正确，再完成关卡递进、反馈和视觉润色。
@@ -522,7 +525,9 @@ def build_repair_prompt(engine_id: str, hints: dict[str, Any] | None = None) -> 
         "不得只返回 diff、代码片段、说明或修复步骤。\n"
         "6. 保持原 engine 选型不变，不得在修复中切换引擎或改用其他 CDN 版本。\n"
         "7. 当前 HTML 中形如 __FORGE_DATA_URI_0000__ 的字符串代表已存在素材，必须按原样"
-        "保留这些占位符；运行时会在构建前还原真实 data URI。"
+        "保留这些占位符；运行时会在构建前还原真实 data URI。\n"
+        "8. 若自动试玩报 PAGE_ERROR 且含 is not defined，说明引用了未定义符号或脚本顺序错误；"
+        "须补齐定义或调整 <script> 顺序，不得用空 catch 吞掉异常。"
     )
     return "\n\n".join(
         part
@@ -562,7 +567,9 @@ def _build_repair_prompt_routed(engine_id: str, hints: dict[str, Any] | None = N
         "不得只返回 diff、代码片段、说明或修复步骤。\n"
         "6. 保持原 engine 选型不变，不得在修复中切换引擎或改用其他 CDN 版本。\n"
         "7. 当前 HTML 中形如 __FORGE_DATA_URI_0000__ 的字符串代表已存在素材，必须按原样"
-        "保留这些占位符；运行时会在构建前还原真实 data URI。"
+        "保留这些占位符；运行时会在构建前还原真实 data URI。\n"
+        "8. 若自动试玩报 PAGE_ERROR 且含 is not defined，说明引用了未定义符号或脚本顺序错误；"
+        "须补齐定义或调整 <script> 顺序，不得用空 catch 吞掉异常。"
     )
     return "\n\n".join(
         part

--- a/backend/app/forge/subgraphs/code_qa_loop.py
+++ b/backend/app/forge/subgraphs/code_qa_loop.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, TypedDict
 from langgraph.graph import END, START, StateGraph
 
 from app.core.config import settings
+from app.sandbox.playtest import is_permanent_infra_error
 
 NodeFn = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
 
@@ -43,7 +44,7 @@ def after_code_or_repair(
     state: CodeQaLoopState,
 ) -> Literal["playtest", "diagnose", "exhausted", "__end__"]:
     if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
-        return END
+        return "__end__"
     if state.get("candidate_ready"):
         return "playtest"
     attempt = int(state.get("attempt") or 0)
@@ -57,13 +58,16 @@ def after_playtest(
     state: CodeQaLoopState,
 ) -> Literal["ok", "exhausted", "replay", "diagnose", "__end__"]:
     if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
-        return END
+        return "__end__"
     if state.get("qa_ok"):
         return "ok"
     attempt = int(state.get("attempt") or 0)
     if attempt >= _max_attempts():
         return "exhausted"
     if state.get("failure_kind") == "infra":
+        # Playwright/Chromium 缺失等环境问题：空转重试无意义，立即耗尽
+        if is_permanent_infra_error(list(state.get("playtest_errors") or [])):
+            return "exhausted"
         return "replay"
     return "diagnose"
 
@@ -72,7 +76,7 @@ def after_diagnose(
     state: CodeQaLoopState,
 ) -> Literal["code_or_repair", "__end__"]:
     if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
-        return END
+        return "__end__"
     return "code_or_repair"
 
 
@@ -103,9 +107,9 @@ def build_code_qa_loop(
         }
 
     g = StateGraph(CodeQaLoopState)
-    g.add_node("code_or_repair", code_or_repair)
-    g.add_node("playtest", playtest)
-    g.add_node("diagnose", diagnose)
+    g.add_node("code_or_repair", code_or_repair)  # type: ignore[call-overload]
+    g.add_node("playtest", playtest)  # type: ignore[call-overload]
+    g.add_node("diagnose", diagnose)  # type: ignore[call-overload]
     g.add_node("infra_replay", infra_replay)
     g.add_node("mark_ok", mark_ok)
     g.add_node("mark_exhausted", mark_exhausted)

--- a/backend/app/sandbox/__init__.py
+++ b/backend/app/sandbox/__init__.py
@@ -1,7 +1,10 @@
 """沙箱工厂：`sandbox_backend=local|docker|daytona`。
 
-默认偏好 Daytona；未配置 DAYTONA_API_KEY 或未启用时回退 docker→local，避免本地/CI 硬失败。
+默认偏好 Daytona；无 API key、无 SDK 或未启用时回退 docker→local。
 """
+
+import importlib.util
+import logging
 
 from app.core.config import settings
 from app.core.errors import AppError, ErrorCode
@@ -19,6 +22,8 @@ from app.sandbox.lifecycle import (
     tier_from_hitl_meta,
 )
 from app.sandbox.local import LocalSandbox
+
+log = logging.getLogger(__name__)
 
 _backend: SandboxBackend | None = None
 _sandbox: Sandbox | None = None
@@ -53,13 +58,25 @@ def reset_sandbox_for_tests() -> None:
     clear_daytona_live_for_tests()
 
 
+def _daytona_sdk_available() -> bool:
+    return importlib.util.find_spec("daytona") is not None
+
+
 def _resolve_backend_name(name: str) -> str:
     key = (name or "local").strip().lower()
     if key != "daytona":
         return key
-    if settings.sandbox_daytona_enabled and (settings.daytona_api_key or "").strip():
-        return "daytona"
-    return "docker"
+    if not settings.sandbox_daytona_enabled:
+        return "docker"
+    if not (settings.daytona_api_key or "").strip():
+        return "docker"
+    if not _daytona_sdk_available():
+        log.warning(
+            "daytona SDK not installed; falling back to docker sandbox "
+            "(install: uv sync --extra daytona)"
+        )
+        return "docker"
+    return "daytona"
 
 
 def _build_backend(name: str) -> SandboxBackend:

--- a/backend/app/sandbox/playtest.py
+++ b/backend/app/sandbox/playtest.py
@@ -47,9 +47,7 @@ class PlaytestResult:
         if self.ok and self.failure_kind is not None:
             raise ValueError("PlaytestResult invariant: ok=True requires failure_kind=None")
         if self.ok and self.motion_signal is None:
-            raise ValueError(
-                "PlaytestResult invariant: ok=True requires motion_signal"
-            )
+            raise ValueError("PlaytestResult invariant: ok=True requires motion_signal")
 
 
 def make_playtest_result(
@@ -82,6 +80,18 @@ def _infra_result(code: str, detail: str, logs: list[str] | None = None) -> Play
     )
 
 
+# 环境类 infra：重试 playtest 不会变好，应立即耗尽并走 sandbox_failed / 可恢复暂停
+PERMANENT_INFRA_MARKERS = (
+    "PLAYWRIGHT_UNAVAILABLE",
+    "CHROMIUM_UNAVAILABLE",
+)
+
+
+def is_permanent_infra_error(errors: list[str] | None) -> bool:
+    text = " ".join(str(e) for e in (errors or []))
+    return any(marker in text for marker in PERMANENT_INFRA_MARKERS)
+
+
 def playwright_import_available() -> bool:
     try:
         import playwright  # noqa: F401
@@ -93,7 +103,10 @@ def playwright_import_available() -> bool:
 def _check_playwright_available() -> PlaytestResult | None:
     if not playwright_import_available():
         return _infra_result(
-            "PLAYWRIGHT_UNAVAILABLE", "playwright package is not installed"
+            "PLAYWRIGHT_UNAVAILABLE",
+            "playwright package is not installed "
+            "(worker: uv sync --extra playwright && uv run playwright install chromium). "
+            "Not related to Docker/Daytona sandbox.",
         )
     try:
         from playwright.sync_api import sync_playwright
@@ -103,7 +116,8 @@ def _check_playwright_available() -> PlaytestResult | None:
             browser.close()
     except Exception as exc:  # noqa: BLE001
         return _infra_result(
-            "CHROMIUM_UNAVAILABLE", f"chromium launch failed: {exc}"
+            "CHROMIUM_UNAVAILABLE",
+            f"chromium launch failed: {exc}. Fix: uv run playwright install chromium",
         )
     return None
 
@@ -138,9 +152,7 @@ def _extract_scripts(html: str) -> list[str]:
 def _declares_engine(html: str) -> bool:
     from app.forge.engine_router import SUPPORTED_ENGINES, recommended_cdn_url
 
-    engine_urls = {
-        url for eid in SUPPORTED_ENGINES if (url := recommended_cdn_url(eid))
-    }
+    engine_urls = {url for eid in SUPPORTED_ENGINES if (url := recommended_cdn_url(eid))}
     return any(url in html for url in engine_urls)
 
 
@@ -168,9 +180,7 @@ def static_playtest_diagnostic(html: str) -> PlaytestResult:
         scanner.feed(html)
     except Exception as e:  # noqa: BLE001
         errors.append(f"HTML 解析失败: {e}")
-        return make_playtest_result(
-            errors=errors, console_logs=logs, failure_kind="product"
-        )
+        return make_playtest_result(errors=errors, console_logs=logs, failure_kind="product")
 
     missing_interactive = not scanner.has_canvas and not scanner.has_interactive
     if missing_interactive and not _declares_engine(html):
@@ -184,12 +194,8 @@ def static_playtest_diagnostic(html: str) -> PlaytestResult:
         if src.count("{") != src.count("}"):
             errors.append(f"script#{i} 花括号可能未闭合")
     if not errors:
-        errors.append(
-            "STATIC_DIAGNOSTIC_ONLY: structural checks passed (not runtime QA)"
-        )
-    return make_playtest_result(
-        errors=errors, console_logs=logs, failure_kind="product"
-    )
+        errors.append("STATIC_DIAGNOSTIC_ONLY: structural checks passed (not runtime QA)")
+    return make_playtest_result(errors=errors, console_logs=logs, failure_kind="product")
 
 
 _static_playtest = static_playtest_diagnostic
@@ -203,9 +209,7 @@ async def _inject_inputs(page: Any, logs: list[str], errors: list[str]) -> None:
     except Exception as e:  # noqa: BLE001
         errors.append(f"INPUT_INJECTION_FAILED: {e}")
         return
-    btn = page.locator(
-        "button:visible, input[type=button]:visible, [role=button]:visible"
-    )
+    btn = page.locator("button:visible, input[type=button]:visible, [role=button]:visible")
     try:
         if await btn.count() > 0:
             first = btn.first
@@ -233,9 +237,11 @@ async def _session_playtest(
     page.on("pageerror", _on_page_error)
     page.on(
         "console",
-        lambda msg: logs.append(f"console:{msg.type}:{msg.text}")
-        if msg.type in ("error", "warning", "log")
-        else None,
+        lambda msg: (
+            logs.append(f"console:{msg.type}:{msg.text}")
+            if msg.type in ("error", "warning", "log")
+            else None
+        ),
     )
     await page.add_init_script(RAF_INIT_SCRIPT)
 
@@ -250,28 +256,20 @@ async def _session_playtest(
         )
 
     if errors:
-        return make_playtest_result(
-            errors=errors, console_logs=logs, failure_kind="product"
-        )
+        return make_playtest_result(errors=errors, console_logs=logs, failure_kind="product")
 
     await _inject_inputs(page, logs, errors)
     await page.wait_for_timeout(200)
     if errors:
-        return make_playtest_result(
-            errors=errors, console_logs=logs, failure_kind="product"
-        )
+        return make_playtest_result(errors=errors, console_logs=logs, failure_kind="product")
 
     motion = await evaluate_motion_signal(page)
     if motion is None:
         errors.append("NO_RUNTIME_SIGNAL: no raf/canvas_diff/engine_runtime")
-        return make_playtest_result(
-            errors=errors, console_logs=logs, failure_kind="product"
-        )
+        return make_playtest_result(errors=errors, console_logs=logs, failure_kind="product")
 
     if errors:
-        return make_playtest_result(
-            errors=errors, console_logs=logs, failure_kind="product"
-        )
+        return make_playtest_result(errors=errors, console_logs=logs, failure_kind="product")
 
     thumbnail: bytes | None = None
     if want_thumb:
@@ -384,9 +382,7 @@ async def run_playtest_dist(dist_dir: Path, want_thumb: bool = False) -> Playtes
 
     server, thread, base = _serve(dist_dir)
     try:
-        return await _with_browser(
-            f"{base}/", want_thumb, "playwright dist mode", 20_000
-        )
+        return await _with_browser(f"{base}/", want_thumb, "playwright dist mode", 20_000)
     finally:
         _stop_server(server, thread)
 

--- a/backend/tests/forge/cache/test_pinecone_store.py
+++ b/backend/tests/forge/cache/test_pinecone_store.py
@@ -1,0 +1,43 @@
+"""Pinecone store factory：默认路径不得返回裸 object 哨兵。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.forge.cache.pinecone_store import (
+    HttpPineconeStore,
+    get_pinecone_store,
+    pinecone_configured,
+    reset_pinecone_store_override,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_override() -> None:
+    reset_pinecone_store_override()
+    yield
+    reset_pinecone_store_override()
+
+
+def test_get_pinecone_store_default_without_config_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_enabled", True)
+    monkeypatch.setattr(settings, "pinecone_api_key", "")
+    monkeypatch.setattr(settings, "pinecone_host", "")
+
+    assert pinecone_configured() is False
+    assert get_pinecone_store() is None
+
+
+def test_get_pinecone_store_default_with_config_returns_http_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_enabled", True)
+    monkeypatch.setattr(settings, "pinecone_api_key", "test-key")
+    monkeypatch.setattr(settings, "pinecone_host", "example.pinecone.io")
+    monkeypatch.setattr(settings, "pinecone_namespace", "default")
+
+    store = get_pinecone_store()
+    assert isinstance(store, HttpPineconeStore)

--- a/backend/tests/forge/reliability/test_code_qa_loop.py
+++ b/backend/tests/forge/reliability/test_code_qa_loop.py
@@ -40,7 +40,7 @@ async def test_infra_failure_retries_same_candidate_without_repair(
         return {
             "qa_ok": False,
             "failure_kind": "infra",
-            "playtest_errors": ["PLAYWRIGHT_UNAVAILABLE"],
+            "playtest_errors": ["TRANSIENT_INFRA: flaky"],
             "attempt": state.get("attempt"),
             "candidate_version": state.get("candidate_version"),
             "candidate_ready": True,
@@ -61,6 +61,46 @@ async def test_infra_failure_retries_same_candidate_without_repair(
     assert repair_calls["n"] == 1
     assert playtest_calls["n"] == 3
     assert candidate_versions == [10, 10, 10]
+
+
+@pytest.mark.asyncio
+async def test_permanent_infra_exhausts_without_empty_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PLAYWRIGHT_UNAVAILABLE 等环境故障：立即 exhausted，不空转重试 playtest。"""
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 5)
+    playtest_calls = {"n": 0}
+
+    async def code_or_repair(state: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "attempt": 1,
+            "candidate_ready": True,
+            "candidate_version": 10,
+            "qa_ok": False,
+        }
+
+    async def playtest(state: dict[str, Any]) -> dict[str, Any]:
+        playtest_calls["n"] += 1
+        return {
+            "qa_ok": False,
+            "failure_kind": "infra",
+            "playtest_errors": ["PLAYWRIGHT_UNAVAILABLE: playwright package is not installed"],
+            "attempt": 1,
+            "candidate_version": 10,
+            "candidate_ready": True,
+        }
+
+    async def diagnose(state: dict[str, Any]) -> dict[str, Any]:
+        raise AssertionError("permanent infra must not diagnose")
+
+    graph = build_code_qa_loop(
+        code_or_repair=code_or_repair,
+        playtest=playtest,
+        diagnose=diagnose,
+    )
+    result = await graph.ainvoke({"attempt": 0, "design_doc": {}})
+    assert result.get("exhausted") is True
+    assert playtest_calls["n"] == 1
 
 
 @pytest.mark.asyncio
@@ -169,6 +209,17 @@ def test_after_playtest_routing_helpers() -> None:
     assert after_playtest({"qa_ok": True}) == "ok"
     assert after_playtest({"qa_ok": False, "attempt": 3}) == "exhausted"
     assert after_playtest({"qa_ok": False, "attempt": 1, "failure_kind": "infra"}) == "replay"
+    assert (
+        after_playtest(
+            {
+                "qa_ok": False,
+                "attempt": 1,
+                "failure_kind": "infra",
+                "playtest_errors": ["PLAYWRIGHT_UNAVAILABLE: missing"],
+            }
+        )
+        == "exhausted"
+    )
     assert after_playtest({"qa_ok": False, "attempt": 1, "failure_kind": "product"}) == "diagnose"
     assert after_code_or_repair({"candidate_ready": True}) == "playtest"
     assert after_code_or_repair({"candidate_ready": False, "attempt": 1}) == "diagnose"

--- a/backend/tests/sandbox/test_sandbox_daytona_fallback.py
+++ b/backend/tests/sandbox/test_sandbox_daytona_fallback.py
@@ -21,3 +21,12 @@ def test_daytona_backend_falls_back_without_api_key(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(settings, "daytona_api_key", "")
     backend = get_sandbox_backend()
     assert backend.backend_id in {"docker", "local"}
+
+
+def test_daytona_backend_falls_back_without_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "sandbox_backend", "daytona")
+    monkeypatch.setattr(settings, "sandbox_daytona_enabled", True)
+    monkeypatch.setattr(settings, "daytona_api_key", "dtn_test")
+    monkeypatch.setattr("app.sandbox._daytona_sdk_available", lambda: False)
+    backend = get_sandbox_backend()
+    assert backend.backend_id in {"docker", "local"}

--- a/frontend/src/components/forge/ChatPanel.tsx
+++ b/frontend/src/components/forge/ChatPanel.tsx
@@ -2,7 +2,7 @@ import { Bot, Loader2, UserRound } from "lucide-react";
 import { ForgeComposer } from "@/components/forge/ForgeComposer";
 import { cn } from "@/lib/cn";
 import { useT } from "@/i18n/use-t";
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 export type ChatMsg = {
   id: string;
@@ -34,6 +34,8 @@ type Props = {
   onLoadEarlier?: () => void;
 };
 
+const FOLLOW_THRESHOLD_PX = 48;
+
 export function ChatPanel({
   messages,
   input,
@@ -56,10 +58,33 @@ export function ChatPanel({
   const workshop = variant === "workshop" || variant === "forge-hero";
   const hero = variant === "forge-hero";
   const documentScroll = hero && scrollMode === "document";
+  const panelScroll = !documentScroll;
   const composerPlaceholder = placeholder ?? t("describeIteration");
   const lastAssistantId = [...messages]
     .reverse()
     .find((m) => m.role === "assistant")?.id;
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const followLatestRef = useRef(true);
+
+  // 用户上翻阅读历史时暂停自动跟底；回到底部附近再恢复
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !panelScroll) return;
+    function onScroll() {
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      followLatestRef.current = distance < FOLLOW_THRESHOLD_PX;
+    }
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [panelScroll]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !panelScroll) return;
+    if (!followLatestRef.current && !streaming) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages, streaming, conversationFooter, panelScroll]);
 
   return (
     <section
@@ -91,8 +116,9 @@ export function ChatPanel({
       ) : null}
 
       <div
+        ref={panelScroll ? scrollRef : undefined}
         className={cn(
-          "space-y-4 px-4 py-5 md:px-5",
+          "space-y-3 px-4 py-4 md:px-5",
           documentScroll ? "shrink-0" : "min-h-0 flex-1 overflow-y-auto",
         )}
         aria-live="polite"
@@ -116,7 +142,7 @@ export function ChatPanel({
           <div
             key={m.id}
             className={cn(
-              "flex max-w-[94%] items-start gap-2.5 text-sm leading-relaxed",
+              "flex max-w-[94%] items-start gap-2 text-sm leading-relaxed",
               m.role === "user" && "ml-auto flex-row-reverse",
               m.role === "assistant" && "mr-auto",
               m.role === "system" && "mx-auto max-w-full justify-center",
@@ -125,16 +151,16 @@ export function ChatPanel({
             {m.role !== "system" ? (
               <span
                 className={cn(
-                  "mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-lg border",
+                  "mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-lg border",
                   m.role === "assistant"
                     ? "border-[rgba(var(--gf-primary-rgb),0.16)] bg-[rgba(var(--gf-primary-rgb),0.08)] gf-text-accent"
                     : "border-black/[0.07] bg-black/[0.035] gf-page-muted",
                 )}
               >
                 {m.role === "assistant" ? (
-                  <Bot className="h-3.5 w-3.5" aria-hidden="true" />
+                  <Bot className="h-3 w-3" aria-hidden="true" />
                 ) : (
-                  <UserRound className="h-3.5 w-3.5" aria-hidden="true" />
+                  <UserRound className="h-3 w-3" aria-hidden="true" />
                 )}
               </span>
             ) : null}
@@ -143,16 +169,16 @@ export function ChatPanel({
                 "min-w-0 break-words",
                 m.role === "user" &&
                   (workshop
-                    ? "rounded-2xl rounded-tr-md gf-bg-accent-soft px-3.5 py-2.5 gf-page-body gf-ring-accent"
-                    : "rounded-2xl rounded-tr-md bg-[#5271ff]/12 px-3.5 py-2.5 text-[#3046a8] ring-1 ring-[#5271ff]/20"),
+                    ? "rounded-2xl rounded-tr-md gf-bg-accent-soft px-3 py-2 gf-page-body gf-ring-accent"
+                    : "rounded-2xl rounded-tr-md bg-[#5271ff]/12 px-3 py-2 text-[#3046a8] ring-1 ring-[#5271ff]/20"),
                 m.role === "assistant" &&
                   (workshop
-                    ? "rounded-2xl rounded-tl-md bg-black/[0.025] px-3.5 py-2.5 gf-page-body ring-1 ring-[var(--gf-border)]"
-                    : "rounded-2xl rounded-tl-md bg-[#eef1f3] px-3.5 py-2.5 text-[#303940] ring-1 ring-black/[0.05]"),
+                    ? "rounded-2xl rounded-tl-md bg-black/[0.025] px-3 py-2 gf-page-body ring-1 ring-[var(--gf-border)]"
+                    : "rounded-2xl rounded-tl-md bg-[#eef1f3] px-3 py-2 text-[#303940] ring-1 ring-black/[0.05]"),
                 m.role === "system" &&
                   (workshop
-                    ? "rounded-lg bg-amber-50 px-3 py-1.5 text-center text-[12px] text-amber-900 ring-1 ring-amber-200"
-                    : "rounded-lg bg-[#ffcf5a]/15 px-3 py-1.5 text-center text-[12px] text-[#785d14] ring-1 ring-[#d49d12]/20"),
+                    ? "rounded-lg bg-amber-50 px-2.5 py-1 text-center text-[11px] text-amber-900 ring-1 ring-amber-200"
+                    : "rounded-lg bg-[#ffcf5a]/15 px-2.5 py-1 text-center text-[11px] text-[#785d14] ring-1 ring-[#d49d12]/20"),
               )}
             >
               {m.content}
@@ -175,7 +201,7 @@ export function ChatPanel({
           </div>
         ))}
         {conversationFooter ? (
-          <div className="space-y-4 pt-1">{conversationFooter}</div>
+          <div className="space-y-2 pt-0.5">{conversationFooter}</div>
         ) : null}
       </div>
 

--- a/frontend/src/components/forge/HitlCard.tsx
+++ b/frontend/src/components/forge/HitlCard.tsx
@@ -16,43 +16,52 @@ type Props = {
   busy?: boolean;
 };
 
+/** 按内容行数估算 textarea 行高，避免固定 rows=4 留白过多 */
+function textareaRows(text: string, min = 2, max = 3): number {
+  const lines = text.split("\n").length;
+  return Math.min(max, Math.max(min, lines));
+}
+
+const fieldClass =
+  "w-full resize-none border border-black/[0.1] bg-white px-2.5 py-1.5 text-[12px] leading-5 text-[#20262d] outline-none";
+
 function ReviewHeader({ art, title }: { art: boolean; title: string }) {
   const t = useT();
   return (
-    <div className="flex items-start justify-between gap-4 border-b border-black/[0.08] px-4 py-3.5 sm:px-5">
-      <div className="flex min-w-0 items-start gap-3">
+    <div className="flex items-center justify-between gap-2 border-b border-black/[0.08] px-3 py-2 sm:px-3.5">
+      <div className="flex min-w-0 items-center gap-2">
         <span
-          className={`grid h-8 w-8 shrink-0 place-items-center border ${
+          className={`grid h-6 w-6 shrink-0 place-items-center border ${
             art
               ? "border-[#b9d9d4] bg-[#eef8f6] text-[#17665f]"
               : "border-[#e5d5b1] bg-[#fff8e8] text-[#8b641c]"
           }`}
         >
           {art ? (
-            <Palette className="h-4 w-4" aria-hidden="true" />
+            <Palette className="h-3.5 w-3.5" aria-hidden="true" />
           ) : (
-            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
           )}
         </span>
         <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-black/45">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="font-mono text-[9px] font-medium uppercase tracking-[0.12em] text-black/45">
               {t("manualReview")}
             </span>
             <span className="text-black/20" aria-hidden="true">
               /
             </span>
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-black/45">
-              {art ? "02 / 03" : "01 / 03"}
+            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
+              {art ? "02/03" : "01/03"}
             </span>
           </div>
-          <h3 className="mt-1 truncate text-[15px] font-semibold tracking-[-0.01em] text-[#20262d]">
+          <h3 className="truncate text-[13px] font-semibold leading-tight tracking-[-0.01em] text-[#20262d]">
             {title}
           </h3>
         </div>
       </div>
       <span
-        className={`shrink-0 border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ${
+        className={`shrink-0 border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] ${
           art
             ? "border-[#b9d9d4] bg-[#f3fbf9] text-[#17665f]"
             : "border-[#e5d5b1] bg-[#fffaf0] text-[#8b641c]"
@@ -127,7 +136,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
 
   return (
     <section
-      className="overflow-hidden border border-black/[0.1] bg-[#fffdfa] shadow-[0_8px_28px_rgba(38,48,56,0.08)]"
+      className="overflow-hidden border border-black/[0.1] bg-[#fffdfa] shadow-[0_4px_16px_rgba(38,48,56,0.06)]"
       aria-label={isArtReview ? t("chooseArtDirection") : t("manualReview")}
     >
       <ReviewHeader
@@ -136,12 +145,10 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
       />
 
       {isArtReview ? (
-        <div className="p-4 sm:p-5">
-          <p className="max-w-2xl text-[13px] leading-5 text-black/60">
-            {t("chooseArtDirectionHint")}
-          </p>
+        <div className="space-y-2.5 p-3 sm:px-3.5">
+          <p className="text-[12px] leading-4 text-black/55">{t("chooseArtDirectionHint")}</p>
 
-          <div className="mt-4 grid gap-2.5 sm:grid-cols-2">
+          <div className="grid gap-2 sm:grid-cols-2">
             {artOptions.map((option) => {
               const active = selectedOption === option.id;
               return (
@@ -151,33 +158,35 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
                   disabled={busy}
                   aria-pressed={active}
                   onClick={() => setSelectedOption(option.id)}
-                  className={`group flex min-h-[156px] flex-col border p-3.5 text-left transition-[border-color,background-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#23877d]/35 ${
+                  className={`group flex min-h-[100px] flex-col border p-2.5 text-left transition-[border-color,background-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#23877d]/35 ${
                     active
                       ? "border-[#23877d] bg-[#f2faf8] shadow-[inset_3px_0_0_#23877d]"
                       : "border-black/[0.1] bg-white hover:border-[#8dbdb7] hover:bg-[#fbfefd]"
                   }`}
                 >
-                  <span className="flex items-center justify-between gap-3">
-                    <span className="flex items-center gap-2">
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="flex min-w-0 items-center gap-1.5">
                       <span
-                        className={`grid h-6 w-6 place-items-center border font-mono text-[11px] font-semibold ${
+                        className={`grid h-5 w-5 shrink-0 place-items-center border font-mono text-[10px] font-semibold ${
                           active
                             ? "border-[#23877d] bg-[#23877d] text-white"
                             : "border-black/15 text-black/55"
                         }`}
                       >
-                        {active ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : option.id}
+                        {active ? <Check className="h-3 w-3" aria-hidden="true" /> : option.id}
                       </span>
-                      <span className="text-[13px] font-semibold text-[#20262d]">{option.name}</span>
+                      <span className="truncate text-[12px] font-semibold text-[#20262d]">{option.name}</span>
                     </span>
                     {option.recommended ? (
-                      <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-[#17665f]">
+                      <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.06em] text-[#17665f]">
                         {t("recommended")}
                       </span>
                     ) : null}
                   </span>
-                  <span className="mt-3 flex-1 text-[12px] leading-5 text-black/58">{option.summary}</span>
-                  <span className="mt-3 flex items-center gap-1 text-[11px] font-medium text-[#17665f] opacity-0 transition-opacity group-hover:opacity-100">
+                  <span className="mt-1.5 line-clamp-3 flex-1 text-[11px] leading-4 text-black/58">
+                    {option.summary}
+                  </span>
+                  <span className="mt-1.5 flex items-center gap-0.5 text-[10px] font-medium text-[#17665f] opacity-0 transition-opacity group-hover:opacity-100">
                     {active ? t("selected") : t("selectDirection")}
                     <ChevronRight className="h-3 w-3" aria-hidden="true" />
                   </span>
@@ -186,8 +195,8 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
             })}
           </div>
 
-          <label className="mt-4 block">
-            <span className="mb-1.5 flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-black/45">
+          <label className="block">
+            <span className="mb-1 flex items-center gap-1 font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
               <MessageSquareText className="h-3 w-3" aria-hidden="true" />
               {t("artFeedback")}
             </span>
@@ -202,47 +211,52 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
               name="art-feedback"
               autoComplete="off"
               placeholder={t("artFeedback")}
-              className="w-full resize-none border border-black/[0.1] bg-white px-3 py-2.5 text-[13px] leading-5 text-[#20262d] outline-none transition-[border-color,box-shadow] placeholder:text-black/30 focus:border-[#23877d] focus:ring-2 focus:ring-[#23877d]/12"
+              className={`${fieldClass} placeholder:text-black/30 focus:border-[#23877d] focus:ring-2 focus:ring-[#23877d]/12`}
             />
           </label>
         </div>
       ) : (
-        <div className="space-y-3 p-4 sm:p-5">
-          <p className="text-[13px] leading-5 text-black/60">{t("continueAfterApproval")}</p>
-          <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-2 p-3 sm:px-3.5">
+          <p className="text-[11px] leading-4 text-black/50">{t("continueAfterApproval")}</p>
+          <div className="grid gap-2 sm:grid-cols-2">
             <label className="block">
-              <span className="mb-1.5 block font-mono text-[10px] uppercase tracking-[0.1em] text-black/45">
+              <span className="mb-1 block font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
                 {t("gameplay")}
               </span>
               <textarea
                 value={gameplay}
                 onChange={(event) => setGameplay(event.target.value)}
-                rows={4}
+                rows={textareaRows(gameplay)}
                 name="hitl-gameplay"
                 autoComplete="off"
-                className="w-full resize-none border border-black/[0.1] bg-white px-3 py-2.5 text-[13px] leading-5 text-[#20262d] outline-none focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12"
+                className={`${fieldClass} focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
               />
             </label>
             <label className="block">
-              <span className="mb-1.5 block font-mono text-[10px] uppercase tracking-[0.1em] text-black/45">
+              <span className="mb-1 block font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
                 {t("controls")}
               </span>
               <textarea
                 value={controls}
                 onChange={(event) => setControls(event.target.value)}
-                rows={4}
+                rows={textareaRows(controls)}
                 name="hitl-controls"
                 autoComplete="off"
-                className="w-full resize-none border border-black/[0.1] bg-white px-3 py-2.5 text-[13px] leading-5 text-[#20262d] outline-none focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12"
+                className={`${fieldClass} focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
               />
             </label>
           </div>
           {parsed.levels.length > 0 ? (
-            <div className="border-t border-black/[0.07] pt-3">
-              <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-black/45">{t("levels")}</span>
-              <div className="mt-2 flex flex-wrap gap-1.5">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-black/[0.06] pt-2">
+              <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
+                {t("levels")}
+              </span>
+              <div className="flex min-w-0 flex-1 flex-wrap gap-1">
                 {parsed.levels.map((level) => (
-                  <span key={level} className="border border-black/[0.09] bg-white px-2 py-1 text-[11px] text-black/60">
+                  <span
+                    key={level}
+                    className="border border-black/[0.09] bg-white px-1.5 py-0.5 text-[10px] text-black/60"
+                  >
                     {level}
                   </span>
                 ))}
@@ -250,7 +264,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
             </div>
           ) : null}
           <label className="block">
-            <span className="mb-1.5 flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-black/45">
+            <span className="mb-1 flex items-center gap-1 font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
               <MessageSquareText className="h-3 w-3" aria-hidden="true" />
               {t("hitlModifyFeedback")}
             </span>
@@ -262,16 +276,16 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
               placeholder={t("describeIteration")}
               name="hitl-feedback"
               autoComplete="off"
-              className="w-full resize-none border border-black/[0.1] bg-white px-3 py-2.5 text-[13px] leading-5 text-[#20262d] outline-none focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12"
+              className={`${fieldClass} focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
             />
           </label>
         </div>
       )}
 
-      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-black/[0.08] bg-[#faf8f3] px-4 py-3 sm:px-5">
+      <div className="flex flex-wrap items-center justify-between gap-1.5 border-t border-black/[0.08] bg-[#faf8f3] px-3 py-2 sm:px-3.5">
         <Button
           variant="ghost"
-          className="!min-h-9 !rounded-md !px-2.5 !text-[12px] !text-black/50 hover:!bg-black/[0.04] hover:!text-black/75"
+          className="!min-h-8 !rounded-md !px-2 !text-[11px] !text-black/50 hover:!bg-black/[0.04] hover:!text-black/75"
           disabled={busy}
           onClick={onReject}
         >
@@ -279,7 +293,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
           {t("rejectAndStop")}
         </Button>
         <Button
-          className={`!min-h-9 !rounded-md !px-3.5 !text-[12px] !font-semibold !text-white ${
+          className={`!min-h-8 !rounded-md !px-3 !text-[11px] !font-semibold !text-white ${
             isArtReview
               ? "!bg-[#17665f] hover:!bg-[#12534e]"
               : "!bg-[#a87516] hover:!bg-[#8d6212]"

--- a/frontend/src/components/forge/HitlCard.tsx
+++ b/frontend/src/components/forge/HitlCard.tsx
@@ -23,7 +23,10 @@ function textareaRows(text: string, min = 2, max = 3): number {
 }
 
 const fieldClass =
-  "w-full resize-none border border-black/[0.1] bg-white px-2.5 py-1.5 text-[12px] leading-5 text-[#20262d] outline-none";
+  "w-full resize-none border border-black/[0.12] bg-white px-2.5 py-1.5 text-[12px] font-medium leading-5 text-[#1a2028] outline-none";
+
+const labelClass =
+  "mb-1 block font-mono text-[9px] font-semibold uppercase tracking-[0.1em] text-black/70";
 
 function ReviewHeader({ art, title }: { art: boolean; title: string }) {
   const t = useT();
@@ -45,17 +48,17 @@ function ReviewHeader({ art, title }: { art: boolean; title: string }) {
         </span>
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-            <span className="font-mono text-[9px] font-medium uppercase tracking-[0.12em] text-black/45">
+            <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-black/65">
               {t("manualReview")}
             </span>
-            <span className="text-black/20" aria-hidden="true">
+            <span className="text-black/25" aria-hidden="true">
               /
             </span>
-            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
+            <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.1em] text-black/65">
               {art ? "02/03" : "01/03"}
             </span>
           </div>
-          <h3 className="truncate text-[13px] font-semibold leading-tight tracking-[-0.01em] text-[#20262d]">
+          <h3 className="truncate text-[13px] font-bold leading-tight tracking-[-0.01em] text-[#141a21]">
             {title}
           </h3>
         </div>
@@ -146,7 +149,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
 
       {isArtReview ? (
         <div className="space-y-2.5 p-3 sm:px-3.5">
-          <p className="text-[12px] leading-4 text-black/55">{t("chooseArtDirectionHint")}</p>
+          <p className="text-[12px] font-medium leading-4 text-black/65">{t("chooseArtDirectionHint")}</p>
 
           <div className="grid gap-2 sm:grid-cols-2">
             {artOptions.map((option) => {
@@ -175,7 +178,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
                       >
                         {active ? <Check className="h-3 w-3" aria-hidden="true" /> : option.id}
                       </span>
-                      <span className="truncate text-[12px] font-semibold text-[#20262d]">{option.name}</span>
+                      <span className="truncate text-[12px] font-bold text-[#141a21]">{option.name}</span>
                     </span>
                     {option.recommended ? (
                       <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.06em] text-[#17665f]">
@@ -183,7 +186,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
                       </span>
                     ) : null}
                   </span>
-                  <span className="mt-1.5 line-clamp-3 flex-1 text-[11px] leading-4 text-black/58">
+                  <span className="mt-1.5 line-clamp-3 flex-1 text-[11px] font-medium leading-4 text-black/72">
                     {option.summary}
                   </span>
                   <span className="mt-1.5 flex items-center gap-0.5 text-[10px] font-medium text-[#17665f] opacity-0 transition-opacity group-hover:opacity-100">
@@ -196,7 +199,7 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
           </div>
 
           <label className="block">
-            <span className="mb-1 flex items-center gap-1 font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
+            <span className={`${labelClass} flex items-center gap-1`}>
               <MessageSquareText className="h-3 w-3" aria-hidden="true" />
               {t("artFeedback")}
             </span>
@@ -217,12 +220,10 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
         </div>
       ) : (
         <div className="space-y-2 p-3 sm:px-3.5">
-          <p className="text-[11px] leading-4 text-black/50">{t("continueAfterApproval")}</p>
-          <div className="grid gap-2 sm:grid-cols-2">
-            <label className="block">
-              <span className="mb-1 block font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
-                {t("gameplay")}
-              </span>
+          <p className="text-[11px] font-medium leading-4 text-black/65">{t("continueAfterApproval")}</p>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <label className="block min-w-0">
+              <span className={labelClass}>{t("gameplay")}</span>
               <textarea
                 value={gameplay}
                 onChange={(event) => setGameplay(event.target.value)}
@@ -232,10 +233,8 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
                 className={`${fieldClass} focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
               />
             </label>
-            <label className="block">
-              <span className="mb-1 block font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
-                {t("controls")}
-              </span>
+            <label className="block min-w-0">
+              <span className={labelClass}>{t("controls")}</span>
               <textarea
                 value={controls}
                 onChange={(event) => setControls(event.target.value)}
@@ -245,40 +244,45 @@ export function HitlCard({ payload, onResolve, onReject, busy }: Props) {
                 className={`${fieldClass} focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
               />
             </label>
-          </div>
-          {parsed.levels.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-black/[0.06] pt-2">
-              <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
-                {t("levels")}
-              </span>
-              <div className="flex min-w-0 flex-1 flex-wrap gap-1">
-                {parsed.levels.map((level) => (
-                  <span
-                    key={level}
-                    className="border border-black/[0.09] bg-white px-1.5 py-0.5 text-[10px] text-black/60"
-                  >
-                    {level}
-                  </span>
-                ))}
+            <label className="block min-w-0">
+              <span className={labelClass}>{t("levels")}</span>
+              <div
+                className={`${fieldClass} min-h-[calc(2rem+1.25rem+2px)] overflow-y-auto py-1.5 focus-within:border-[#d09a2d] focus-within:ring-2 focus-within:ring-[#d09a2d]/12`}
+                aria-label={t("levels")}
+              >
+                {parsed.levels.length > 0 ? (
+                  <div className="flex flex-wrap gap-1">
+                    {parsed.levels.map((level) => (
+                      <span
+                        key={level}
+                        className="border border-black/[0.12] bg-[#faf8f3] px-1.5 py-0.5 text-[10px] font-semibold text-black/75"
+                      >
+                        {level}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="text-[11px] font-medium text-black/45">—</span>
+                )}
               </div>
-            </div>
-          ) : null}
-          <label className="block">
-            <span className="mb-1 flex items-center gap-1 font-mono text-[9px] uppercase tracking-[0.1em] text-black/45">
-              <MessageSquareText className="h-3 w-3" aria-hidden="true" />
-              {t("hitlModifyFeedback")}
-            </span>
-            <textarea
-              aria-label={t("hitlModifyFeedback")}
-              value={modifyFeedback}
-              onChange={(event) => setModifyFeedback(event.target.value)}
-              rows={2}
-              placeholder={t("describeIteration")}
-              name="hitl-feedback"
-              autoComplete="off"
-              className={`${fieldClass} focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
-            />
-          </label>
+            </label>
+            <label className="block min-w-0">
+              <span className={`${labelClass} flex items-center gap-1`}>
+                <MessageSquareText className="h-3 w-3" aria-hidden="true" />
+                {t("hitlModifyFeedback")}
+              </span>
+              <textarea
+                aria-label={t("hitlModifyFeedback")}
+                value={modifyFeedback}
+                onChange={(event) => setModifyFeedback(event.target.value)}
+                rows={2}
+                placeholder={t("describeIteration")}
+                name="hitl-feedback"
+                autoComplete="off"
+                className={`${fieldClass} placeholder:font-medium placeholder:text-black/40 focus:border-[#d09a2d] focus:ring-2 focus:ring-[#d09a2d]/12`}
+              />
+            </label>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/forge/ForgePage.tsx
+++ b/frontend/src/pages/forge/ForgePage.tsx
@@ -701,7 +701,13 @@ export function ForgePage() {
       (selectedOption
         ? `已选择美术方案 ${selectedOption.id}：${selectedOption.name}`
         : actualDecision === "approve"
-          ? "已确认设计方案"
+          ? hitl.node === "plan_confirm"
+            ? "已确认设计方案"
+            : hitl.node === "sandbox_failed"
+              ? "环境问题已处理，继续重试"
+              : hitl.node === "qa_failed"
+                ? "已确认继续修复试玩问题"
+                : "已确认，继续"
           : `gameplay: ${parsedGameplay}\ncontrols: ${parsedControls}`);
     try {
       await gamesApi.resolveHitl(
@@ -717,13 +723,16 @@ export function ForgePage() {
       setHitl(null);
       setPhase(RunPhase.art);
       setRunStatus(RunStatus.running);
+      const hitlKind =
+        actualDecision === "modify" ? "hitl_modify" : "hitl_approve";
       setMessages((m) => [
         ...m,
         {
           id: mid("m"),
           role: "user",
           content: decisionText,
-          persistenceKey: `${runId}:hitl:${hitl.node}:${actualDecision}`,
+          // 与 toChatMessages 对齐：run_id:kind，并带上 node 避免多段 HITL 同 kind 撞车
+          persistenceKey: `${runId}:${hitlKind}:${hitl.node}`,
         },
       ]);
       pushItem({

--- a/frontend/src/pages/forge/message-history.test.ts
+++ b/frontend/src/pages/forge/message-history.test.ts
@@ -24,6 +24,18 @@ describe('forge message history', () => {
     })
   })
 
+  it('HITL 消息去重键包含 node，避免多段确认撞车', () => {
+    expect(
+      toChatMessages([
+        row({
+          kind: 'hitl_approve',
+          content: '已确认设计方案',
+          metadata: { node: 'plan_confirm', decision: 'approve' },
+        }),
+      ])[0].persistenceKey,
+    ).toBe('run-1:hitl_approve:plan_confirm')
+  })
+
   it('服务端历史替换同业务键或同内容的临时消息', () => {
     const local: ChatMsg[] = [
       { id: 'local-1', role: 'user', content: '做一个平台跳跃游戏' },

--- a/frontend/src/pages/forge/message-history.ts
+++ b/frontend/src/pages/forge/message-history.ts
@@ -2,12 +2,23 @@ import type { ChatMsg } from '@/components/forge/ChatPanel'
 import type { ForgeMessage } from '@/api/types'
 
 export function toChatMessages(rows: ForgeMessage[]): ChatMsg[] {
-  return rows.map((row) => ({
-    id: row.message_id,
-    role: row.role,
-    content: row.content,
-    persistenceKey: row.run_id ? `${row.run_id}:${row.kind}` : undefined,
-  }))
+  return rows.map((row) => {
+    const node =
+      row.metadata && typeof row.metadata === 'object' && 'node' in row.metadata
+        ? String((row.metadata as { node?: unknown }).node || '')
+        : ''
+    const persistenceKey = row.run_id
+      ? node
+        ? `${row.run_id}:${row.kind}:${node}`
+        : `${row.run_id}:${row.kind}`
+      : undefined
+    return {
+      id: row.message_id,
+      role: row.role,
+      content: row.content,
+      persistenceKey,
+    }
+  })
 }
 
 export function mergeChatMessages(current: ChatMsg[], incoming: ChatMsg[]): ChatMsg[] {


### PR DESCRIPTION
## Summary

- Fail fast when Playwright QA hits permanent infrastructure errors (e.g. browser not installed) instead of burning CodeQaLoop retries; route exhaustion to `sandbox_failed` HITL with actionable diagnosis.
- Fix run creation blocked by Pinecone store sentinel bug and local `SANDBOX_FAILED` when Daytona SDK is missing (auto-fallback to Docker sandbox).
- Improve forge HITL UX: compact card, one-row plan fields with bolder labels, phase-specific approve labels, dedupe HITL chat messages by node, and auto-scroll chat during streaming.
- Harden code-generation prompts against `ReferenceError` / `PAGE_ERROR: X is not defined` in generated games.

## Background

Runs could loop through CodeQaLoop with empty repairs when Playwright was unavailable. Creating a run could 500 on semantic cache lookup due to a broken Pinecone override sentinel. Local dev with `sandbox_backend=daytona` and a configured API key but without the optional `daytona` extra failed at code phase with `SANDBOX_FAILED`. The UI also showed oversized HITL cards and chat that stopped following new stream content.

## Changes

### Backend
- Detect permanent Playwright infra markers in `playtest.py` and skip futile repair loops in `code_qa_loop.py`.
- Route infra exhaustion to `sandbox_failed` HITL in `graph.py`; preserve playtest errors across `code_qa_reset`.
- Filter permanent infra errors from LLM repair prompts in `code_qa_exec.py`.
- Fix `get_pinecone_store()` override sentinel (`_UNSET`) so semantic cache no longer returns bare `object()`.
- Fall back to Docker sandbox when Daytona SDK is not installed (same as missing API key).
- Phase-specific HITL approve labels in `runs.py`.
- ReferenceError constraints in `prompts.py`.

### Frontend
- Compact `HitlCard` layout; plan review fields (gameplay/controls/levels/feedback) on one responsive row with bolder small text.
- Chat auto-scroll during streaming with manual scroll-up pause in `ChatPanel`.
- HITL dedupe key includes `metadata.node` in message history.

## Test plan

- [x] `pytest backend/tests/forge/cache/test_pinecone_store.py backend/tests/sandbox/test_sandbox_daytona_fallback.py`
- [x] `pytest backend/tests/forge/reliability/test_code_qa_loop.py backend/tests/sandbox/test_playtest.py`
- [x] `pnpm exec vitest run src/components/forge/HitlCard.test.tsx`
- [ ] Manual: create run after Pinecone fix; confirm no 500 on `POST /games/{id}/runs`
- [ ] Manual: code phase with Docker sandbox when Daytona SDK absent
- [ ] Manual: stream a long run and confirm chat follows unless user scrolls up

## Impact & Risks

- Prompt changes require api/worker restart after merge.
- Workers must install Playwright (`uv sync --extra playwright` + `playwright install chromium`) for QA to run.
- Local dev without Daytona SDK now uses Docker sandbox automatically when `sandbox_backend=daytona`.
