### PR TITLE
feat(forge): code LLM truncation detection and continuation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -111,6 +111,12 @@ LLM_HTTP_MAX_RETRIES=3
 LLM_HTTP_RETRY_BASE_DELAY_S=0.5
 # 默认 max_tokens；推理模型的「思考 token」也计入此预算，默认 8192，大游戏可调到 16384
 LLM_MAX_TOKENS=8192
+# Code 阶段单独上限（整段 HTML / project JSON）
+LLM_CODE_MAX_TOKENS=32768
+# 输出截断后最多续写轮数
+LLM_CONTINUATION_MAX_ROUNDS=3
+# 续写 prompt 携带的已生成内容尾部字符数
+LLM_CONTINUATION_TAIL_CHARS=8000
 # 命中以下 host（逗号分隔的子串）则强制直连、绕过桌面/系统代理。Windows 上 httpx 会读
 # 注册表代理（即便无 *_PROXY 环境变量），国内 provider 走它常因无出口而超时；默认列国内厂商。
 # 海外/未知 host 仍沿用系统代理，保留「用代理访问 OpenAI 等」的能力。

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -203,6 +203,12 @@ class Settings(BaseSettings):
     llm_http_retry_base_delay_s: float = 0.5
     # 默认 max_tokens；推理模型的「思考 token」也计入此预算，故默认调高
     llm_max_tokens: int = 8192
+    # Code 阶段单独上限（整段 HTML / project JSON 体量大）
+    llm_code_max_tokens: int = 32768
+    # 输出截断后最多续写轮数（每轮独立 LLM 调用）
+    llm_continuation_max_rounds: int = 3
+    # 续写 prompt 携带的已生成内容尾部字符数
+    llm_continuation_tail_chars: int = 8000
     # 默认「直连（绕过桌面/系统代理）」的国内 LLM host，逗号分隔。
     # httpx 0.28 在 Windows 上会读注册表代理（即便无 *_PROXY 环境变量），
     # 国内 provider 走该代理常因代理无对应出口而超时；命中此处则强制直连。

--- a/backend/app/forge/build/integration.py
+++ b/backend/app/forge/build/integration.py
@@ -17,9 +17,7 @@ def parse_llm_code_output(raw: str, *, engine_id: str) -> ParsedCodeOutput:
     return parse_code_output(raw, default_engine=engine_id)
 
 
-async def load_stored_project_source(
-    game_id: uuid.UUID, version: int
-) -> dict[str, str]:
+async def load_stored_project_source(game_id: uuid.UUID, version: int) -> dict[str, str]:
     """从已落盘的 source/ 层加载工程源码（QA 重试 vite 修复基线）。"""
     from app.hosting import store
 
@@ -54,6 +52,7 @@ class ProjectBuildLoopResult:
     final_parsed: ParsedCodeOutput | None = None
     build_attempts: int = 0
     fallback_required: bool = False
+    output_truncated: bool = False
 
 
 def format_project_repair_input(
@@ -113,7 +112,21 @@ async def run_project_build_loop(
         if attempt >= limit or repair_fn is None:
             break
 
-        current = await repair_fn(current, build_error.strip())
+        try:
+            current = await repair_fn(current, build_error.strip())
+        except Exception as exc:
+            from app.forge.llm_continuation import OutputTruncatedError
+
+            if isinstance(exc, OutputTruncatedError):
+                return ProjectBuildLoopResult(
+                    ok=False,
+                    pipeline_result=last_result,
+                    final_parsed=current,
+                    build_attempts=attempt,
+                    fallback_required=True,
+                    output_truncated=True,
+                )
+            raise
 
     return ProjectBuildLoopResult(
         ok=False,
@@ -124,9 +137,7 @@ async def run_project_build_loop(
     )
 
 
-def merge_routing(
-    design_routing: BuildRouting, parsed: ParsedCodeOutput
-) -> BuildRouting:
+def merge_routing(design_routing: BuildRouting, parsed: ParsedCodeOutput) -> BuildRouting:
     """design_doc routing 为基线，LLM project JSON 可覆盖 dependencies 等。"""
     if parsed.routing is None:
         return design_routing
@@ -138,9 +149,7 @@ def merge_routing(
     )
 
 
-def with_design_routing(
-    parsed: ParsedCodeOutput, design_routing: BuildRouting
-) -> ParsedCodeOutput:
+def with_design_routing(parsed: ParsedCodeOutput, design_routing: BuildRouting) -> ParsedCodeOutput:
     if parsed.routing is None:
         return parsed
     return ParsedCodeOutput(

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -71,12 +71,26 @@ async def _code_llm(
     system: str,
     user_msg: str,
     *,
+    context_summary: str | None = None,
     emit_delta: bool = False,
     kind: str | None = None,
 ) -> tuple[str, bool]:
     from app.forge.llm_continuation import generate_code_output
 
-    return await generate_code_output(ctx, system, user_msg, emit_delta=emit_delta, kind=kind)
+    return await generate_code_output(
+        ctx,
+        system,
+        user_msg,
+        context_summary=context_summary,
+        emit_delta=emit_delta,
+        kind=kind,
+    )
+
+
+def _continuation_context_summary(design_doc: dict[str, Any], game_title: str) -> str:
+    engine = (design_doc.get("engine") or {}).get("id", "canvas")
+    title = design_doc.get("title") or game_title
+    return f"游戏：{title}；引擎：{engine}"
 
 
 def _truncation_failure(
@@ -94,7 +108,7 @@ def _truncation_failure(
         "candidate_ready": False,
         "code_ok": False,
         "qa_ok": False,
-        "failure_kind": "build",
+        "failure_kind": "truncated",
         "playtest_errors": [OUTPUT_TRUNCATED_ERROR],
         "qa_diagnosis": qa_diagnosis,
         "design_doc": design_doc,
@@ -148,10 +162,17 @@ async def execute_code_or_repair(
             assets_block = "\n\n" + format_assets_for_prompt(picked)
 
         qa_errors_raw = list(state.get("playtest_errors") or [])
+        from app.forge.llm_continuation import is_output_truncated_error
+
         # 环境类 infra（缺 Playwright 等）不应喂给 LLM「改游戏代码」
-        qa_errors = [e for e in qa_errors_raw if not is_permanent_infra_error([str(e)])]
+        qa_errors = [
+            e
+            for e in qa_errors_raw
+            if not is_permanent_infra_error([str(e)]) and not is_output_truncated_error([str(e)])
+        ]
         qa_diagnosis = state.get("qa_diagnosis") or ""
         attempt = int(state.get("attempt") or 0) + 1
+        ctx_summary = _continuation_context_summary(design_doc, ctx.game.title)
 
         # P5：Memory/设计稿唯一经 ContextBuilder；assets/scaffold/repair 为任务载荷追加
         from app.forge.memory.loader import build_node_context
@@ -245,6 +266,7 @@ async def execute_code_or_repair(
                     ctx,
                     build_project_repair_prompt(engine_id, list(design_routing.dependencies)),
                     repair_user,
+                    context_summary=ctx_summary,
                 )
                 if truncated:
                     return _truncation_failure(
@@ -281,7 +303,9 @@ async def execute_code_or_repair(
                     ctx, s, u, "code", emit_delta=False, kind="skill_select"
                 ),
             )
-            raw_output, truncated = await _code_llm(ctx, system_prompt, user_msg)
+            raw_output, truncated = await _code_llm(
+                ctx, system_prompt, user_msg, context_summary=ctx_summary
+            )
             if truncated:
                 return _truncation_failure(
                     attempt=attempt,
@@ -306,7 +330,9 @@ async def execute_code_or_repair(
                         ctx, s, u, "code", emit_delta=False, kind="skill_select"
                     ),
                 )
-            raw_output, truncated = await _code_llm(ctx, system_prompt, user_msg)
+            raw_output, truncated = await _code_llm(
+                ctx, system_prompt, user_msg, context_summary=ctx_summary
+            )
             if truncated:
                 return _truncation_failure(
                     attempt=attempt,
@@ -334,17 +360,26 @@ async def execute_code_or_repair(
                         ctx,
                         build_project_repair_prompt(engine_id, list(design_routing.dependencies)),
                         repair_user,
+                        context_summary=ctx_summary,
                     )
                     if truncated:
-                        from app.forge.llm_continuation import OUTPUT_TRUNCATED_ERROR
+                        from app.forge.llm_continuation import OutputTruncatedError
 
-                        raise RuntimeError(OUTPUT_TRUNCATED_ERROR)
+                        raise OutputTruncatedError()
                     return with_design_routing(
                         parse_llm_code_output(repair_raw, engine_id=engine_id),
                         design_routing,
                     )
 
                 loop_result = await run_project_build_loop(parsed, repair_fn=_repair_project)
+                if loop_result.output_truncated:
+                    return _truncation_failure(
+                        attempt=attempt,
+                        design_doc=design_doc,
+                        artifacts=artifacts,
+                        art_direction=art_direction,
+                        qa_diagnosis=qa_diagnosis,
+                    )
                 if loop_result.ok and loop_result.pipeline_result:
                     committed = await commit_project_build(
                         ctx,

--- a/backend/app/forge/code_qa_exec.py
+++ b/backend/app/forge/code_qa_exec.py
@@ -66,6 +66,44 @@ def _mask_data_uris(source: str) -> tuple[str, dict[str, str]]:
     return masked, replacements
 
 
+async def _code_llm(
+    ctx: Any,
+    system: str,
+    user_msg: str,
+    *,
+    emit_delta: bool = False,
+    kind: str | None = None,
+) -> tuple[str, bool]:
+    from app.forge.llm_continuation import generate_code_output
+
+    return await generate_code_output(ctx, system, user_msg, emit_delta=emit_delta, kind=kind)
+
+
+def _truncation_failure(
+    *,
+    attempt: int,
+    design_doc: dict[str, Any],
+    artifacts: list[Any],
+    art_direction: dict[str, Any] | None,
+    qa_diagnosis: str,
+) -> dict[str, Any]:
+    from app.forge.llm_continuation import OUTPUT_TRUNCATED_ERROR
+
+    return {
+        "attempt": attempt,
+        "candidate_ready": False,
+        "code_ok": False,
+        "qa_ok": False,
+        "failure_kind": "build",
+        "playtest_errors": [OUTPUT_TRUNCATED_ERROR],
+        "qa_diagnosis": qa_diagnosis,
+        "design_doc": design_doc,
+        "artifacts": artifacts,
+        "art_direction": art_direction,
+        "exhausted": False,
+    }
+
+
 def _omit_data_uris(html: str) -> str:
     return re.sub(
         r"data:[^;\"'\s]+;base64,[A-Za-z0-9+/=]+",
@@ -203,13 +241,19 @@ async def execute_code_or_repair(
                     parsed_retry,
                     last_error or qa_diagnosis,
                 )
-                repair_raw = await streamed_llm(
+                repair_raw, truncated = await _code_llm(
                     ctx,
                     build_project_repair_prompt(engine_id, list(design_routing.dependencies)),
                     repair_user,
-                    "code",
-                    emit_delta=False,
                 )
+                if truncated:
+                    return _truncation_failure(
+                        attempt=attempt,
+                        design_doc=design_doc,
+                        artifacts=artifacts,
+                        art_direction=art_direction,
+                        qa_diagnosis=qa_diagnosis,
+                    )
                 parsed_retry = with_design_routing(
                     parse_llm_code_output(repair_raw, engine_id=engine_id),
                     design_routing,
@@ -237,7 +281,15 @@ async def execute_code_or_repair(
                     ctx, s, u, "code", emit_delta=False, kind="skill_select"
                 ),
             )
-            raw_output = await streamed_llm(ctx, system_prompt, user_msg, "code", emit_delta=False)
+            raw_output, truncated = await _code_llm(ctx, system_prompt, user_msg)
+            if truncated:
+                return _truncation_failure(
+                    attempt=attempt,
+                    design_doc=design_doc,
+                    artifacts=artifacts,
+                    art_direction=art_direction,
+                    qa_diagnosis=qa_diagnosis,
+                )
         else:
             user_msg = generation_user_msg
             if last_error:
@@ -254,7 +306,15 @@ async def execute_code_or_repair(
                         ctx, s, u, "code", emit_delta=False, kind="skill_select"
                     ),
                 )
-            raw_output = await streamed_llm(ctx, system_prompt, user_msg, "code", emit_delta=False)
+            raw_output, truncated = await _code_llm(ctx, system_prompt, user_msg)
+            if truncated:
+                return _truncation_failure(
+                    attempt=attempt,
+                    design_doc=design_doc,
+                    artifacts=artifacts,
+                    art_direction=art_direction,
+                    qa_diagnosis=qa_diagnosis,
+                )
 
         for token, data_uri in data_uris.items():
             raw_output = raw_output.replace(token, data_uri)
@@ -270,13 +330,15 @@ async def execute_code_or_repair(
                     current: ParsedCodeOutput, build_error: str
                 ) -> ParsedCodeOutput:
                     repair_user = format_project_repair_input(base_user_msg, current, build_error)
-                    repair_raw = await streamed_llm(
+                    repair_raw, truncated = await _code_llm(
                         ctx,
                         build_project_repair_prompt(engine_id, list(design_routing.dependencies)),
                         repair_user,
-                        "code",
-                        emit_delta=False,
                     )
+                    if truncated:
+                        from app.forge.llm_continuation import OUTPUT_TRUNCATED_ERROR
+
+                        raise RuntimeError(OUTPUT_TRUNCATED_ERROR)
                     return with_design_routing(
                         parse_llm_code_output(repair_raw, engine_id=engine_id),
                         design_routing,

--- a/backend/app/forge/graph.py
+++ b/backend/app/forge/graph.py
@@ -319,7 +319,7 @@ async def _refresh_session_summary(ctx: _Ctx) -> None:
             turns: list[ContextTurn], previous: SessionSummary | None
         ) -> SessionSummary:
             async def complete(system: str, user_msg: str) -> str:
-                content, _usage, _prov = await llm_client.call_llm(
+                result, _prov = await llm_client.call_llm(
                     ctx.s,
                     ctx.r,
                     ctx.run.user_id,
@@ -330,7 +330,7 @@ async def _refresh_session_summary(ctx: _Ctx) -> None:
                     run_id=ctx.run.id,
                     kind="session_summary",
                 )
-                return content
+                return result.content
 
             return await synthesize_summary_via_llm(turns, previous, complete=complete)
 
@@ -482,7 +482,7 @@ async def _llm(ctx: _Ctx, system: str, user_msg: str, *, kind: str | None = None
     # 只记长度不记原文：prompt/响应内容属敏感且冗长，按 docs 约定不落盘
     log.info("llm call start", extra={"stage": stage, "prompt_len": len(user_msg)})
     try:
-        content, usage, prov = await llm_client.call_llm(
+        result, prov = await llm_client.call_llm(
             ctx.s,
             ctx.r,
             ctx.run.user_id,
@@ -493,6 +493,8 @@ async def _llm(ctx: _Ctx, system: str, user_msg: str, *, kind: str | None = None
             run_id=ctx.run.id,
             kind=llm_kind,
         )
+        content = result.content
+        usage = result.usage
     except Exception:
         duration = round(time.monotonic() - started, 3)
         log.exception("llm call failed", extra={"stage": stage, "duration": duration})

--- a/backend/app/forge/guard.py
+++ b/backend/app/forge/guard.py
@@ -283,7 +283,7 @@ class Guard:
                         tags=["forge", "guardrail"],
                     ) as gen,
                 ):
-                    content, usage = await llm_provider.complete(
+                    result = await llm_provider.complete(
                         self._provider,
                         self._apikey,
                         self._model,
@@ -292,6 +292,8 @@ class Guard:
                         base_url=self._base_url,
                         max_tokens=2,
                     )
+                    content = result.content
+                    usage = result.usage
                     if gen is not None:
                         gen.update(
                             output=content.strip() or "(empty)",
@@ -444,18 +446,35 @@ async def run_streamed_llm(
     phase: str,
     emit_delta: bool = True,
     kind: str | None = None,
+    max_tokens: int | None = None,
 ) -> str:
     """用户可见节点的 LLM 调用：流式 + 输入/输出审核 + 微批 LLM_DELTA。
 
-    1. 输入审核（阻塞）：命中 → 发 ATTACKED + raise ContentAttacked。
-    2. 消费 call_llm_stream：攒全文；emit_delta 时按微批窗（字符数/时间）发 LLM_DELTA；
-       审核窗到期把窗口丢给后台 asyncio.Task（不阻塞 token 流），每帧非阻塞检查结果，
-       命中立刻中断。流读完等末窗结果（限时 audit_request_timeout，最后一段不漏审）。
-    3. 输出审核命中 → 发 ATTACKED + raise ContentAttacked。
-    4. 流正常结束 → 发 LLM_CALL（usage），返回完整 content。
-
-    stream_enabled=False 时调用方应走 _llm 而非本函数。
+    返回完整 content 字符串。需 usage/finish_reason 时用 run_streamed_llm_result。
     """
+    result = await run_streamed_llm_result(
+        ctx,
+        system,
+        user_msg,
+        phase=phase,
+        emit_delta=emit_delta,
+        kind=kind,
+        max_tokens=max_tokens,
+    )
+    return result.content
+
+
+async def run_streamed_llm_result(
+    ctx: Any,
+    system: str,
+    user_msg: str,
+    *,
+    phase: str,
+    emit_delta: bool = True,
+    kind: str | None = None,
+    max_tokens: int | None = None,
+) -> llm_provider.LLMCompletion:
+    """同 run_streamed_llm，但返回 LLMCompletion（含 usage / finish_reason）。"""
     guard = await build_guard(ctx)
 
     # 1) 输入侧审核（受 audit_request_timeout 约束，超时视为未命中）
@@ -482,6 +501,7 @@ async def run_streamed_llm(
     pending: list[str] = []  # 自上次输出审核以来的增量
     last_audit_at = started
     usage = llm_provider.Usage()
+    finish_reason: str | None = None
     audit_task: asyncio.Task | None = None  # 后台审核 task：不阻塞 token 流
 
     async def _raise_if_hit(res: AuditResult | None, side: str) -> None:
@@ -505,6 +525,7 @@ async def run_streamed_llm(
         game_id=ctx.game.id,
         run_id=ctx.run.id,
         kind=kind or phase or "chat",
+        max_tokens=max_tokens,
     )
     try:
         async for chunk in gen:
@@ -519,6 +540,8 @@ async def run_streamed_llm(
                     last_flush = await _maybe_flush(ctx, phase, batch_buf, last_flush, force=False)
             if chunk.usage is not None:
                 usage = chunk.usage
+            if chunk.finish_reason:
+                finish_reason = chunk.finish_reason
             # 已启动的后台审核完成 → 立刻检查结果（不阻塞 token 流）
             if audit_task is not None and audit_task.done():
                 done_res = audit_task.result()
@@ -553,6 +576,7 @@ async def run_streamed_llm(
     # 流结束：emit_delta 时 flush 残留微批；再发 LLM_CALL（usage，对齐现有 _llm 事件字段）
     if emit_delta and batch_buf:
         await _maybe_flush(ctx, phase, batch_buf, last_flush, force=True)
+    content = "".join(content_parts)
     await publish_event(
         ctx.run.id,
         WSEventType.LLM_CALL,
@@ -564,7 +588,11 @@ async def run_streamed_llm(
             "output_tokens": usage.output_tokens,
         },
     )
-    return "".join(content_parts)
+    return llm_provider.LLMCompletion(
+        content=content,
+        usage=usage,
+        finish_reason=finish_reason,
+    )
 
 
 async def _maybe_flush(

--- a/backend/app/forge/llm_continuation.py
+++ b/backend/app/forge/llm_continuation.py
@@ -9,6 +9,8 @@ from typing import Any
 from app.core.config import settings
 from app.llm.provider import LLMCompletion
 
+_LENGTH_FINISH_REASONS = frozenset({"length", "max_tokens"})
+
 _CONTINUATION_NOTICE = (
     "【输出截断续写】\n"
     "上一段生成因 token 上限被截断。请从下列已生成内容的末尾无缝继续，"
@@ -23,6 +25,20 @@ _CONTINUATION_NOTICE = (
 OUTPUT_TRUNCATED_ERROR = "OUTPUT_TRUNCATED: LLM output hit token limit after continuation rounds"
 
 
+class OutputTruncatedError(Exception):
+    """Code/Vite 生成在续写轮次耗尽后仍被截断。"""
+
+    def __init__(self, message: str = OUTPUT_TRUNCATED_ERROR) -> None:
+        super().__init__(message)
+
+
+def is_output_truncated_error(errors: list[str] | None) -> bool:
+    if not errors:
+        return False
+    prefix = "OUTPUT_TRUNCATED:"
+    return any(str(e).startswith(prefix) for e in errors)
+
+
 def is_likely_truncated(
     content: str,
     *,
@@ -31,7 +47,7 @@ def is_likely_truncated(
     finish_reason: str | None,
 ) -> bool:
     """判断是否疑似因 max_tokens 截断。"""
-    if finish_reason == "length":
+    if finish_reason in _LENGTH_FINISH_REASONS:
         return True
     if max_tokens > 0 and output_tokens >= int(max_tokens * 0.98):
         return True
@@ -61,11 +77,25 @@ def has_incomplete_structure(content: str) -> bool:
     return False
 
 
+def _looks_like_full_rewrite(suffix: str) -> bool:
+    stripped = suffix.lstrip()
+    if not stripped:
+        return False
+    lower = stripped.lower()
+    return (
+        lower.startswith("<!doctype")
+        or lower.startswith("<html")
+        or (stripped.startswith("{") and '"format"' in stripped[:300])
+    )
+
+
 def merge_continuation(prefix: str, suffix: str, *, max_overlap: int = 500) -> str:
     """拼接续写内容，去除 prefix 尾部与 suffix 头部的重复重叠。"""
     if not suffix:
         return prefix
     if not prefix:
+        return suffix
+    if _looks_like_full_rewrite(suffix):
         return suffix
     head = prefix.strip()[: min(120, len(prefix))]
     if suffix.strip().startswith(head):
@@ -78,16 +108,19 @@ def merge_continuation(prefix: str, suffix: str, *, max_overlap: int = 500) -> s
 
 
 def build_continuation_user_msg(
-    original_user_msg: str,
     partial_content: str,
     *,
+    context_summary: str | None = None,
     tail_chars: int | None = None,
 ) -> str:
+    """续写轮 user message：仅续写指令 + 可选任务摘要 + 已生成尾部（不含首轮完整 prompt）。"""
     tail_limit = tail_chars or settings.llm_continuation_tail_chars
     tail = partial_content[-tail_limit:] if len(partial_content) > tail_limit else partial_content
-    return (
-        f"{original_user_msg}\n\n{_CONTINUATION_NOTICE}\n\n【已生成内容末尾（从此处继续）】\n{tail}"
-    )
+    parts = [_CONTINUATION_NOTICE]
+    if context_summary:
+        parts.append(f"【任务摘要】\n{context_summary.strip()}")
+    parts.append(f"【已生成内容末尾（从此处继续）】\n{tail}")
+    return "\n\n".join(parts)
 
 
 async def generate_with_continuation(
@@ -97,6 +130,7 @@ async def generate_with_continuation(
     user_msg: str,
     max_tokens: int | None = None,
     max_rounds: int | None = None,
+    context_summary: str | None = None,
 ) -> tuple[str, bool]:
     """带截断续写的 LLM 生成。返回 (content, truncated_exhausted)。"""
     limit = max_tokens if max_tokens is not None else settings.llm_code_max_tokens
@@ -118,7 +152,10 @@ async def generate_with_continuation(
             return accumulated, False
         if round_idx >= rounds:
             return accumulated, True
-        current_user = build_continuation_user_msg(user_msg, accumulated)
+        current_user = build_continuation_user_msg(
+            accumulated,
+            context_summary=context_summary,
+        )
 
     assert last_result is not None
     return accumulated, True
@@ -129,6 +166,7 @@ async def generate_code_output(
     system: str,
     user_msg: str,
     *,
+    context_summary: str | None = None,
     emit_delta: bool = False,
     kind: str | None = None,
 ) -> tuple[str, bool]:
@@ -151,7 +189,7 @@ async def generate_code_output(
                 kind=llm_kind,
                 max_tokens=max_tokens,
             )
-        content, usage, _prov = await llm_client.call_llm(
+        result, _prov = await llm_client.call_llm(
             ctx.s,
             ctx.r,
             ctx.run.user_id,
@@ -163,11 +201,12 @@ async def generate_code_output(
             kind=llm_kind,
             max_tokens=max_tokens,
         )
-        return LLMCompletion(content=content, usage=usage)
+        return result
 
     return await generate_with_continuation(
         llm_once,
         system=system,
         user_msg=user_msg,
         max_tokens=max_tokens,
+        context_summary=context_summary,
     )

--- a/backend/app/forge/llm_continuation.py
+++ b/backend/app/forge/llm_continuation.py
@@ -1,0 +1,173 @@
+"""Code 阶段 LLM 输出截断检测与续写。"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.core.config import settings
+from app.llm.provider import LLMCompletion
+
+_CONTINUATION_NOTICE = (
+    "【输出截断续写】\n"
+    "上一段生成因 token 上限被截断。请从下列已生成内容的末尾无缝继续，"
+    "补全至完整可运行产物。\n"
+    "要求：\n"
+    "1. 不要重复已生成部分\n"
+    "2. 只输出需要追加的剩余内容（从截断处继续）\n"
+    "3. 若为 HTML，必须补全至 </html> 并确保 init() 等入口可执行\n"
+    "4. 若为 project JSON，必须补全闭合括号并包含完整 files"
+)
+
+OUTPUT_TRUNCATED_ERROR = "OUTPUT_TRUNCATED: LLM output hit token limit after continuation rounds"
+
+
+def is_likely_truncated(
+    content: str,
+    *,
+    output_tokens: int,
+    max_tokens: int,
+    finish_reason: str | None,
+) -> bool:
+    """判断是否疑似因 max_tokens 截断。"""
+    if finish_reason == "length":
+        return True
+    if max_tokens > 0 and output_tokens >= int(max_tokens * 0.98):
+        return True
+    return has_incomplete_structure(content)
+
+
+def has_incomplete_structure(content: str) -> bool:
+    text = content.strip()
+    if not text:
+        return False
+    lower = text.lower()
+    if text.startswith("{") or '"format"' in text[:300]:
+        try:
+            json.loads(text)
+        except json.JSONDecodeError:
+            if text.count("{") > text.count("}"):
+                return True
+            if text.count("[") > text.count("]"):
+                return True
+            if not text.rstrip().endswith("}"):
+                return True
+    if "<html" in lower or "<!doctype" in lower:
+        if "</html>" not in lower:
+            return True
+        if lower.count("<script") > lower.count("</script"):
+            return True
+    return False
+
+
+def merge_continuation(prefix: str, suffix: str, *, max_overlap: int = 500) -> str:
+    """拼接续写内容，去除 prefix 尾部与 suffix 头部的重复重叠。"""
+    if not suffix:
+        return prefix
+    if not prefix:
+        return suffix
+    head = prefix.strip()[: min(120, len(prefix))]
+    if suffix.strip().startswith(head):
+        return suffix
+    max_check = min(max_overlap, len(prefix), len(suffix))
+    for overlap in range(max_check, 0, -1):
+        if prefix[-overlap:] == suffix[:overlap]:
+            return prefix + suffix[overlap:]
+    return prefix + suffix
+
+
+def build_continuation_user_msg(
+    original_user_msg: str,
+    partial_content: str,
+    *,
+    tail_chars: int | None = None,
+) -> str:
+    tail_limit = tail_chars or settings.llm_continuation_tail_chars
+    tail = partial_content[-tail_limit:] if len(partial_content) > tail_limit else partial_content
+    return (
+        f"{original_user_msg}\n\n{_CONTINUATION_NOTICE}\n\n【已生成内容末尾（从此处继续）】\n{tail}"
+    )
+
+
+async def generate_with_continuation(
+    llm_call: Callable[[str, str], Awaitable[LLMCompletion]],
+    *,
+    system: str,
+    user_msg: str,
+    max_tokens: int | None = None,
+    max_rounds: int | None = None,
+) -> tuple[str, bool]:
+    """带截断续写的 LLM 生成。返回 (content, truncated_exhausted)。"""
+    limit = max_tokens if max_tokens is not None else settings.llm_code_max_tokens
+    rounds = max_rounds if max_rounds is not None else settings.llm_continuation_max_rounds
+    accumulated = ""
+    current_user = user_msg
+    last_result: LLMCompletion | None = None
+
+    for round_idx in range(rounds + 1):
+        last_result = await llm_call(system, current_user)
+        piece = last_result.content
+        accumulated = piece if round_idx == 0 else merge_continuation(accumulated, piece)
+        if not is_likely_truncated(
+            accumulated,
+            output_tokens=last_result.usage.output_tokens,
+            max_tokens=limit,
+            finish_reason=last_result.finish_reason,
+        ):
+            return accumulated, False
+        if round_idx >= rounds:
+            return accumulated, True
+        current_user = build_continuation_user_msg(user_msg, accumulated)
+
+    assert last_result is not None
+    return accumulated, True
+
+
+async def generate_code_output(
+    ctx: Any,
+    system: str,
+    user_msg: str,
+    *,
+    emit_delta: bool = False,
+    kind: str | None = None,
+) -> tuple[str, bool]:
+    """Code 阶段专用：高 max_tokens + 截断续写。返回 (content, truncated_exhausted)。"""
+    from app.forge.guard import run_streamed_llm_result
+    from app.llm import client as llm_client
+
+    max_tokens = settings.llm_code_max_tokens
+    phase = "code"
+    llm_kind = kind or phase
+
+    async def llm_once(sys: str, usr: str) -> LLMCompletion:
+        if settings.stream_enabled:
+            return await run_streamed_llm_result(
+                ctx,
+                sys,
+                usr,
+                phase=phase,
+                emit_delta=emit_delta,
+                kind=llm_kind,
+                max_tokens=max_tokens,
+            )
+        content, usage, _prov = await llm_client.call_llm(
+            ctx.s,
+            ctx.r,
+            ctx.run.user_id,
+            ctx.run.llm_config_id,
+            sys,
+            usr,
+            game_id=ctx.game.id,
+            run_id=ctx.run.id,
+            kind=llm_kind,
+            max_tokens=max_tokens,
+        )
+        return LLMCompletion(content=content, usage=usage)
+
+    return await generate_with_continuation(
+        llm_once,
+        system=system,
+        user_msg=user_msg,
+        max_tokens=max_tokens,
+    )

--- a/backend/app/forge/subgraphs/code_qa_loop.py
+++ b/backend/app/forge/subgraphs/code_qa_loop.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, TypedDict
 from langgraph.graph import END, START, StateGraph
 
 from app.core.config import settings
+from app.forge.llm_continuation import is_output_truncated_error
 from app.sandbox.playtest import is_permanent_infra_error
 
 NodeFn = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
@@ -42,7 +43,7 @@ def _max_attempts() -> int:
 
 def after_code_or_repair(
     state: CodeQaLoopState,
-) -> Literal["playtest", "diagnose", "exhausted", "__end__"]:
+) -> Literal["playtest", "diagnose", "retry", "exhausted", "__end__"]:
     if state.get("paused") or state.get("failed") or state.get("hitl_stop"):
         return "__end__"
     if state.get("candidate_ready"):
@@ -50,6 +51,8 @@ def after_code_or_repair(
     attempt = int(state.get("attempt") or 0)
     if attempt >= _max_attempts():
         return "exhausted"
+    if is_output_truncated_error(list(state.get("playtest_errors") or [])):
+        return "retry"
     # build fail → diagnose（infra 不会从 code_or_repair 产生）
     return "diagnose"
 
@@ -121,6 +124,7 @@ def build_code_qa_loop(
         {
             "playtest": "playtest",
             "diagnose": "diagnose",
+            "retry": "code_or_repair",
             "exhausted": "mark_exhausted",
             END: END,
         },

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -120,7 +120,8 @@ async def _invoke_llm(
     trace_meta: dict[str, str],
     *,
     kind: str = "chat",
-) -> tuple[str, provider.Usage]:
+    max_tokens: int | None = None,
+) -> provider.LLMCompletion:
     """执行 provider.complete 并挂 langfuse generation 观测。
 
     失败时把 generation 标 level=ERROR 后 re-raise（错误计数交回 call_llm 统一处理）。
@@ -134,8 +135,8 @@ async def _invoke_llm(
         metadata=trace_meta,
     ) as gen:
         try:
-            content, usage = await provider.complete(
-                prov, apikey, model, system, user_msg, base_url=base_url
+            result = await provider.complete(
+                prov, apikey, model, system, user_msg, base_url=base_url, max_tokens=max_tokens
             )
         except Exception:
             if gen is not None:
@@ -143,13 +144,13 @@ async def _invoke_llm(
             raise
         if gen is not None:
             gen.update(
-                output=content,
+                output=result.content,
                 usage_details={
-                    "input": usage.input_tokens,
-                    "output": usage.output_tokens,
+                    "input": result.usage.input_tokens,
+                    "output": result.usage.output_tokens,
                 },
             )
-    return content, usage
+    return result
 
 
 async def call_llm(
@@ -163,6 +164,7 @@ async def call_llm(
     game_id: uuid.UUID | None = None,
     run_id: uuid.UUID | None = None,
     kind: str = "chat",
+    max_tokens: int | None = None,
 ) -> tuple[str, provider.Usage, LLMProvider]:
     _, _, rate = await admin_services.get_effective_limits(db)
     await check_rate_limit(r, f"rl:llm:{user_id}", rate, 60)
@@ -178,7 +180,7 @@ async def call_llm(
     if run_id is not None:
         trace_meta["run_id"] = str(run_id)
     try:
-        content, usage = await _invoke_llm(
+        result = await _invoke_llm(
             prov,
             apikey,
             cfg.model,
@@ -187,6 +189,7 @@ async def call_llm(
             cfg.base_url,
             trace_meta,
             kind=kind,
+            max_tokens=max_tokens,
         )
     except Exception:
         LLM_CALLS.labels(prov.value, "error").inc()
@@ -194,13 +197,13 @@ async def call_llm(
         raise
     await circuit.record_success(r, cb_key)
     LLM_CALLS.labels(prov.value, "ok").inc()
-    LLM_TOKENS.labels(prov.value, "input").inc(usage.input_tokens)
-    LLM_TOKENS.labels(prov.value, "output").inc(usage.output_tokens)
+    LLM_TOKENS.labels(prov.value, "input").inc(result.usage.input_tokens)
+    LLM_TOKENS.labels(prov.value, "output").inc(result.usage.output_tokens)
     await record_usage(
         r,
         user_id,
-        input_tokens=usage.input_tokens,
-        output_tokens=usage.output_tokens,
+        input_tokens=result.usage.input_tokens,
+        output_tokens=result.usage.output_tokens,
         game_id=game_id,
         run_id=run_id,
         idempotency_key=_usage_idem_key(
@@ -208,15 +211,15 @@ async def call_llm(
             run_id=run_id,
             system=system,
             user_msg=user_msg,
-            content=content,
-            input_tokens=usage.input_tokens,
-            output_tokens=usage.output_tokens,
+            content=result.content,
+            input_tokens=result.usage.input_tokens,
+            output_tokens=result.usage.output_tokens,
         ),
     )
     await _maybe_quota_alert(db, r, user_id)
     await _maybe_system_alert(db, r)
     # 返回 provider，供调用方在事件/日志里如实记录用户配置的 provider，而非硬编码。
-    return content, usage, prov
+    return result.content, result.usage, prov
 
 
 async def call_llm_stream(
@@ -230,6 +233,7 @@ async def call_llm_stream(
     game_id: uuid.UUID | None = None,
     run_id: uuid.UUID | None = None,
     kind: str = "chat",
+    max_tokens: int | None = None,
 ) -> AsyncIterator[StreamChunk]:
     """流式版 call_llm：逐 token yield StreamChunk（末帧带 usage）。
 
@@ -267,7 +271,13 @@ async def call_llm_stream(
             metadata=trace_meta,
         ) as gen:
             async for chunk in provider.complete_stream(
-                prov, apikey, cfg.model, system, user_msg, cfg.base_url
+                prov,
+                apikey,
+                cfg.model,
+                system,
+                user_msg,
+                cfg.base_url,
+                max_tokens=max_tokens,
             ):
                 if chunk.delta:
                     accumulated.append(chunk.delta)

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -165,7 +165,7 @@ async def call_llm(
     run_id: uuid.UUID | None = None,
     kind: str = "chat",
     max_tokens: int | None = None,
-) -> tuple[str, provider.Usage, LLMProvider]:
+) -> tuple[provider.LLMCompletion, LLMProvider]:
     _, _, rate = await admin_services.get_effective_limits(db)
     await check_rate_limit(r, f"rl:llm:{user_id}", rate, 60)
 
@@ -218,8 +218,8 @@ async def call_llm(
     )
     await _maybe_quota_alert(db, r, user_id)
     await _maybe_system_alert(db, r)
-    # 返回 provider，供调用方在事件/日志里如实记录用户配置的 provider，而非硬编码。
-    return result.content, result.usage, prov
+    # 返回 LLMCompletion（含 finish_reason）与 provider，供事件/日志使用。
+    return result, prov
 
 
 async def call_llm_stream(

--- a/backend/app/llm/platform_complete.py
+++ b/backend/app/llm/platform_complete.py
@@ -42,7 +42,7 @@ async def platform_complete(
         ) as gen,
     ):
         try:
-            content, usage = await provider.complete(
+            result = await provider.complete(
                 prov,
                 apikey,
                 model,
@@ -57,10 +57,10 @@ async def platform_complete(
             raise
         if gen is not None:
             gen.update(
-                output=content,
+                output=result.content,
                 usage_details={
-                    "input": usage.input_tokens,
-                    "output": usage.output_tokens,
+                    "input": result.usage.input_tokens,
+                    "output": result.usage.output_tokens,
                 },
             )
-    return content, usage
+    return result.content, result.usage

--- a/backend/app/llm/provider.py
+++ b/backend/app/llm/provider.py
@@ -51,10 +51,19 @@ class Usage:
 class StreamChunk:
     """complete_stream 的单帧：delta 为增量文本（可能为 ""，如纯 usage 帧），
     usage 仅在流末尾/usage 帧非 None。调用方累加 usage 即得最终用量。
+    finish_reason 仅在流末帧非 None（如 length / stop）。
     """
 
     delta: str
     usage: Usage | None = None
+    finish_reason: str | None = None
+
+
+@dataclass
+class LLMCompletion:
+    content: str
+    usage: Usage
+    finish_reason: str | None = None
 
 
 def _host_from_base_url(base_url: str | None) -> str | None:
@@ -196,9 +205,7 @@ async def test_connectivity(
         return False, str(e)[:200]
 
 
-async def list_models(
-    provider: LLMProvider, apikey: str, base_url: str | None = None
-) -> list[str]:
+async def list_models(provider: LLMProvider, apikey: str, base_url: str | None = None) -> list[str]:
     """按 provider 拉 /models；失败回退白名单（docs/05 §模型列表来源）。"""
     try:
         if provider == LLMProvider.OPENAI_COMPAT and not base_url:
@@ -208,14 +215,14 @@ async def list_models(
         async with _build_llm_client(url, httpx.Timeout(10)) as client:
             resp = await client.get(url, headers=headers)
         if resp.status_code == 200:
-            ids = [
-                m.get("id")
+            ids: list[str] = [
+                str(m["id"])
                 for m in resp.json().get("data", [])
                 if isinstance(m, dict) and m.get("id")
             ]
             if ids:
                 return ids
-    except Exception:  # noqa: BLE001 拉取失败走白名单
+    except Exception:  # noqa: BLE001  # nosec B110 拉取失败走白名单
         pass
     return list(_MODEL_WHITELIST[provider])
 
@@ -281,7 +288,7 @@ def _llm_timeout() -> httpx.Timeout:
 def _retry_delay_s(attempt: int) -> float:
     """指数退避 + 少量 jitter：attempt 从 0 起（第 1 次失败后的等待）。"""
     base = settings.llm_http_retry_base_delay_s
-    return base * (2**attempt) + random.uniform(0, base)
+    return base * (2**attempt) + random.uniform(0, base)  # nosec B311
 
 
 def _http_error_hint(url: str, status_code: int) -> str:
@@ -294,9 +301,7 @@ def _http_error_hint(url: str, status_code: int) -> str:
     )
 
 
-async def _sleep_before_retry(
-    *, attempt: int, model: str, reason: str
-) -> None:
+async def _sleep_before_retry(*, attempt: int, model: str, reason: str) -> None:
     delay = _retry_delay_s(attempt)
     log.warning(
         "llm http retry",
@@ -320,7 +325,7 @@ async def complete(
     base_url: str | None = None,
     *,
     max_tokens: int | None = None,
-) -> tuple[str, Usage]:
+) -> LLMCompletion:
     """调一次补全，返回 (content, usage)。usage 取响应真实字段（docs/05 不估算）。
 
     传输层对网络错误与 429/502-504 做有限指数退避重试，不消耗业务自修复预算。
@@ -352,15 +357,10 @@ async def complete(
                     extra={"stage": "http", "model": model, "duration": duration},
                 )
                 raise
-            await _sleep_before_retry(
-                attempt=attempt, model=model, reason=type(exc).__name__
-            )
+            await _sleep_before_retry(attempt=attempt, model=model, reason=type(exc).__name__)
             continue
 
-        if (
-            resp.status_code in _RETRYABLE_HTTP_STATUS
-            and attempt < max_retries
-        ):
+        if resp.status_code in _RETRYABLE_HTTP_STATUS and attempt < max_retries:
             await _sleep_before_retry(
                 attempt=attempt,
                 model=model,
@@ -390,20 +390,24 @@ async def complete(
             f"{resp.text[:120]}{_http_error_hint(url, resp.status_code)}",
         )
     data = resp.json()
+    finish_reason: str | None = None
     if _uses_anthropic_native_api(provider, base_url):
         content = "".join(b.get("text", "") for b in data.get("content", []))
         usage = Usage(
             input_tokens=data.get("usage", {}).get("input_tokens", 0),
             output_tokens=data.get("usage", {}).get("output_tokens", 0),
         )
+        finish_reason = data.get("stop_reason")
     else:
-        raw = data["choices"][0]["message"].get("content")
+        choice = data["choices"][0]
+        raw = choice.get("message", {}).get("content")
         content = raw if isinstance(raw, str) else (raw or "")
         usage = Usage(
             input_tokens=data.get("usage", {}).get("prompt_tokens", 0),
             output_tokens=data.get("usage", {}).get("completion_tokens", 0),
         )
-    return content or "", usage
+        finish_reason = choice.get("finish_reason")
+    return LLMCompletion(content=content or "", usage=usage, finish_reason=finish_reason)
 
 
 async def _iter_sse(resp: httpx.Response) -> AsyncIterator[tuple[str | None, str]]:
@@ -479,7 +483,11 @@ async def _parse_anthropic_stream(
             if "output_tokens" in usage:
                 output_tokens = usage["output_tokens"]
         elif etype == "message_stop":
-            yield StreamChunk(delta="", usage=Usage(input_tokens, output_tokens))
+            yield StreamChunk(
+                delta="",
+                usage=Usage(input_tokens, output_tokens),
+                finish_reason=obj.get("stop_reason"),
+            )
             return
 
 
@@ -496,6 +504,7 @@ async def _parse_openai_stream(
     """
     char_count = 0
     final_usage: Usage | None = None
+    finish_reason: str | None = None
     async for _event_name, data in _iter_sse(resp):
         if data == "[DONE]":
             break
@@ -513,20 +522,23 @@ async def _parse_openai_stream(
         choices = obj.get("choices") or []
         if not choices:
             continue
-        delta = choices[0].get("delta") or {}
+        choice = choices[0]
+        if choice.get("finish_reason"):
+            finish_reason = choice.get("finish_reason")
+        delta = choice.get("delta") or {}
         # content 才是正文；reasoning_content（思考链）丢弃
         text = delta.get("content")
         if text:
             char_count += len(text)
             yield StreamChunk(delta=text)
     if final_usage is not None:
-        yield StreamChunk(delta="", usage=final_usage)
+        yield StreamChunk(delta="", usage=final_usage, finish_reason=finish_reason)
     elif char_count:
         # 兜底：provider 没给 usage，按字符数估 output（中英混合代码 ~4 chars/token），
         # input 记 0（解析器拿不到 prompt）。与 docs「不估算」原则的已知例外
         # （compat 流式 usage 缺失），比此前按 chunk 计数更接近真实值。
         est = Usage(input_tokens=0, output_tokens=max(1, char_count // 4))
-        yield StreamChunk(delta="", usage=est)
+        yield StreamChunk(delta="", usage=est, finish_reason=finish_reason)
         log.warning(
             "llm stream usage missing, estimated by char count",
             extra={"stage": "http", "chars": char_count},
@@ -601,9 +613,7 @@ async def complete_stream(
                     extra={"stage": "http", "model": model, "duration": duration},
                 )
                 raise
-            await _sleep_before_retry(
-                attempt=attempt, model=model, reason="HTTPError"
-            )
+            await _sleep_before_retry(attempt=attempt, model=model, reason="HTTPError")
     duration = round(time.monotonic() - started, 3)
     log.info(
         "llm stream response done",

--- a/backend/app/sandbox/builder.py
+++ b/backend/app/sandbox/builder.py
@@ -229,15 +229,14 @@ class DockerBuilder:
             )
             await container.start()
             try:
-                await asyncio.wait_for(container.wait(), timeout=timeout)
+                wait_result = await asyncio.wait_for(container.wait(), timeout=timeout)
             except TimeoutError:
                 await container.kill()
                 SANDBOX_RUNS.labels("builder", "timeout").inc()
                 return BuilderRunResult(ok=False, error="构建超时")
             logs = await container.log(stdout=True, stderr=True, tail=settings.sandbox_log_tail)
             log_text = "".join(logs) if isinstance(logs, list) else str(logs)
-            info = await container.show()
-            code = (info.get("State") or {}).get("ExitCode", 1)
+            code = wait_result.get("StatusCode", 1) if isinstance(wait_result, dict) else 1
             if code != 0:
                 SANDBOX_RUNS.labels("builder", "fail").inc()
                 return BuilderRunResult(ok=False, logs=log_text, error=f"构建退出码 {code}")

--- a/backend/app/sandbox/docker.py
+++ b/backend/app/sandbox/docker.py
@@ -149,15 +149,14 @@ class DockerSandbox:
             )
             await container.start()
             try:
-                await asyncio.wait_for(container.wait(), timeout=limits["timeout_s"])
+                wait_result = await asyncio.wait_for(container.wait(), timeout=limits["timeout_s"])
             except TimeoutError:
                 with contextlib.suppress(DockerError):
                     await container.kill()
                 return BuildResult(ok=False, error="构建超时", failure_kind="timeout")
             logs = await container.log(stdout=True, stderr=True, tail=settings.sandbox_log_tail)
             log_text = "".join(logs) if isinstance(logs, list) else str(logs)
-            info = await container.show()
-            code = (info.get("State") or {}).get("ExitCode", 1)
+            code = wait_result.get("StatusCode", 1) if isinstance(wait_result, dict) else 1
             if code != 0:
                 kind: Literal["oom", "build"] = "oom" if _looks_like_oom(log_text) else "build"
                 return BuildResult(

--- a/backend/app/sandbox/resources.py
+++ b/backend/app/sandbox/resources.py
@@ -34,9 +34,12 @@ def docker_user_spec() -> str:
 
 
 def docker_log_host_config() -> dict[str, Any]:
-    """AutoRemove + json-file 轮转（ADR-11）。"""
+    """json-file 轮转（ADR-11）。
+
+    不用 AutoRemove：容器退出后仍须读 log，AutoRemove 会竞态 404。
+    """
     return {
-        "AutoRemove": True,
+        "AutoRemove": False,
         "LogConfig": {
             "Type": "json-file",
             "Config": {"max-size": "2m", "max-file": "2"},

--- a/backend/tests/build/test_build_failure_kind.py
+++ b/backend/tests/build/test_build_failure_kind.py
@@ -19,9 +19,9 @@ def test_tier_limits_single_source() -> None:
     assert tier_limits("unknown")["timeout_s"] == tier_limits("standard")["timeout_s"]
 
 
-def test_docker_log_host_config_has_autoremove() -> None:
+def test_docker_log_host_config_log_rotation() -> None:
     cfg = docker_log_host_config()
-    assert cfg["AutoRemove"] is True
+    assert cfg["AutoRemove"] is False
     assert cfg["LogConfig"]["Type"] == "json-file"
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -247,32 +247,36 @@ def _fake_llm(monkeypatch: pytest.MonkeyPatch):
     call_llm_stream 是流式门面，把 _fake 的完整内容切成 10 字一块 yield，末帧带 usage。
     """
     from app.enums import LLMProvider
-    from app.llm.provider import StreamChunk, Usage
+    from app.llm.provider import LLMCompletion, StreamChunk, Usage
 
     def _decide(system: str):
         """按 system prompt 决定返回内容 + usage。流式/非流式共用。"""
         if "Skill 路由器" in system or "skill_ids" in system:
-            return '{"skill_ids":[]}', Usage(5, 2)
+            return LLMCompletion(content='{"skill_ids":[]}', usage=Usage(5, 2))
         if "方向提案" in system or "上一轮两个视觉方向" in system:
-            return _valid_art_options_json(), Usage(10, 5)
+            return LLMCompletion(content=_valid_art_options_json(), usage=Usage(10, 5))
         if "前端动效负责人" in system:
-            return _valid_art_detail_json(), Usage(20, 10)
+            return LLMCompletion(content=_valid_art_detail_json(), usage=Usage(20, 10))
         if "只生成一个自包含的 index.html" in system or "故障修复工程师" in system:
-            return (
-                "<html><body><canvas id='c'></canvas>"
-                "<button>play</button><script></script></body></html>",
-                Usage(20, 10),
+            return LLMCompletion(
+                content=(
+                    "<html><body><canvas id='c'></canvas>"
+                    "<button>play</button><script></script></body></html>"
+                ),
+                usage=Usage(20, 10),
             )
         if "JSON" in system or "策划" in system:
-            return _valid_design_doc_json(), Usage(10, 5)
-        return "stub design doc", Usage(10, 5)
+            return LLMCompletion(content=_valid_design_doc_json(), usage=Usage(10, 5))
+        return LLMCompletion(content="stub design doc", usage=Usage(10, 5))
 
     async def _fake(db, r, user_id, config_id, system, user_msg, **kwargs):
-        content, usage = _decide(system)
-        return content, usage, LLMProvider.ANTHROPIC
+        result = _decide(system)
+        return result, LLMProvider.ANTHROPIC
 
     async def _fake_stream(db, r, user_id, config_id, system, user_msg, **kwargs):
-        content, usage = _decide(system)
+        result = _decide(system)
+        content = result.content
+        usage = result.usage
         # 切成 10 字一块逐块 yield，末帧带 usage（对齐 provider.complete_stream 协议）
         for i in range(0, max(len(content), 1), 10):
             yield StreamChunk(delta=content[i : i + 10], usage=None)

--- a/backend/tests/forge/cache/test_llm_summary_and_semantic.py
+++ b/backend/tests/forge/cache/test_llm_summary_and_semantic.py
@@ -156,8 +156,13 @@ async def test_semantic_soft_hit_uses_confirm_llm(
     monkeypatch.setattr(settings, "semantic_confirm_base_url", "http://localhost:9")
     monkeypatch.setattr(settings, "semantic_confirm_provider", "openai_compat")
 
+    from app.llm.provider import LLMCompletion, Usage
+
     async def fake_complete(*_a, **_k):
-        return ('{"ok":true,"result":"greenfield"}', None)
+        return LLMCompletion(
+            content='{"ok":true,"result":"greenfield"}',
+            usage=Usage(1, 1),
+        )
 
     monkeypatch.setattr("app.llm.provider.complete", fake_complete)
 

--- a/backend/tests/forge/guard/test_guard.py
+++ b/backend/tests/forge/guard/test_guard.py
@@ -139,7 +139,7 @@ def _audit_llm_stub(content: str):
     """构造一个返回固定 content 的 provider.complete 替身。"""
 
     async def _fake(*_args, **_kwargs):
-        return content, provider.Usage(1, 1)
+        return provider.LLMCompletion(content=content, usage=provider.Usage(1, 1))
 
     return _fake
 
@@ -151,7 +151,7 @@ async def test_guard_audit_quick_filter_hit_short_circuits_llm(monkeypatch) -> N
 
     async def _should_not_call(*_a, **_k):
         called["n"] += 1
-        return "x", provider.Usage()
+        return provider.LLMCompletion(content="x", usage=provider.Usage())
 
     monkeypatch.setattr(provider, "complete", _should_not_call)
     g = guard.Guard(provider=LLMProvider.OPENAI, model="gpt-4o-mini", apikey="k", base_url=None)
@@ -218,7 +218,7 @@ async def test_guard_audit_invalid_verdict_retries_then_allows(monkeypatch) -> N
 
     async def _bad_then_clean(*args, **_kwargs):
         calls.append(args[4] if len(args) > 4 else "")
-        return "maybe harmful", provider.Usage(1, 1)
+        return provider.LLMCompletion(content="maybe harmful", usage=provider.Usage(1, 1))
 
     monkeypatch.setattr(provider, "complete", _bad_then_clean)
     g = guard.Guard(provider=LLMProvider.OPENAI, model="gpt-4o-mini", apikey="k", base_url=None)
@@ -233,7 +233,7 @@ async def test_guard_audit_invalid_verdict_recovers_on_retry(monkeypatch) -> Non
     responses = iter(["invalid", "0"])
 
     async def _flaky(*_a, **_k):
-        return next(responses), provider.Usage(1, 1)
+        return provider.LLMCompletion(content=next(responses), usage=provider.Usage(1, 1))
 
     monkeypatch.setattr(provider, "complete", _flaky)
     g = guard.Guard(provider=LLMProvider.OPENAI, model="gpt-4o-mini", apikey="k", base_url=None)

--- a/backend/tests/forge/guard/test_lexicon.py
+++ b/backend/tests/forge/guard/test_lexicon.py
@@ -169,7 +169,7 @@ async def test_guard_suspect_llm_zero_allows(
     reset_lexicon_cache()
 
     async def _zero(*_a, **_k):
-        return "0", provider.Usage(1, 1)
+        return provider.LLMCompletion(content="0", usage=provider.Usage(1, 1))
 
     monkeypatch.setattr(provider, "complete", _zero)
     g = guard.Guard(provider=LLMProvider.OPENAI, model="gpt-4o-mini", apikey="k", base_url=None)
@@ -187,7 +187,7 @@ async def test_guard_suspect_llm_one_blocks_with_category(
     reset_lexicon_cache()
 
     async def _one(*_a, **_k):
-        return "1", provider.Usage(1, 1)
+        return provider.LLMCompletion(content="1", usage=provider.Usage(1, 1))
 
     monkeypatch.setattr(provider, "complete", _one)
     g = guard.Guard(provider=LLMProvider.OPENAI, model="gpt-4o-mini", apikey="k", base_url=None)

--- a/backend/tests/forge/memory/test_inferred_preferences.py
+++ b/backend/tests/forge/memory/test_inferred_preferences.py
@@ -109,11 +109,15 @@ async def test_llm_extract_parser_unit(monkeypatch) -> None:
     monkeypatch.setattr(settings, "preference_extract_provider", "openai_compat")
     monkeypatch.setattr(settings, "preference_extract_base_url", "http://localhost:9")
 
+    from app.llm.provider import LLMCompletion, Usage
+
     async def fake_complete(*_a, **_k):
-        return (
-            '{"preferences":[{"category":"visual","key":"style",'
-            '"value_json":{"style":"pixel"},"source":"explicit","confidence":0.9}]}',
-            None,
+        return LLMCompletion(
+            content=(
+                '{"preferences":[{"category":"visual","key":"style",'
+                '"value_json":{"style":"pixel"},"source":"explicit","confidence":0.9}]}'
+            ),
+            usage=Usage(1, 1),
         )
 
     monkeypatch.setattr("app.llm.provider.complete", fake_complete)

--- a/backend/tests/forge/run/test_runs.py
+++ b/backend/tests/forge/run/test_runs.py
@@ -275,9 +275,9 @@ async def test_art_options_retry_exhaustion_falls_back_and_finishes(
         if "方向提案" in system:
             calls["art"] += 1
             from app.enums import LLMProvider
-            from app.llm.provider import Usage
+            from app.llm.provider import LLMCompletion, Usage
 
-            return "not-json", Usage(1, 1), LLMProvider.ANTHROPIC
+            return LLMCompletion(content="not-json", usage=Usage(1, 1)), LLMProvider.ANTHROPIC
         return await _fake_llm(*args, **kwargs)
 
     async def fail_art_options_stream(*args, **kwargs):
@@ -291,9 +291,10 @@ async def test_art_options_retry_exhaustion_falls_back_and_finishes(
             yield StreamChunk(delta="", usage=Usage(1, 1))
             return
         # 非 art 方向提案节点：用原非流式 mock 拿内容，切块 yield，保证 run 正常完成
-        content, _usage, _prov = await _fake_llm(*args, **kwargs)
+        result, _prov = await _fake_llm(*args, **kwargs)
         from app.llm.provider import StreamChunk, Usage
 
+        content = result.content
         for i in range(0, len(content), 10):
             yield StreamChunk(delta=content[i : i + 10], usage=None)
         yield StreamChunk(delta="", usage=Usage(10, 5))

--- a/backend/tests/forge/test_code_qa_truncation.py
+++ b/backend/tests/forge/test_code_qa_truncation.py
@@ -1,0 +1,179 @@
+"""CodeQa / Vite 截断路径集成测试（mock LLM）。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from app.forge.build.code_output import ParsedCodeOutput
+from app.forge.build.integration import run_project_build_loop
+from app.forge.build.routing import BuildRouting
+from app.forge.llm_continuation import OUTPUT_TRUNCATED_ERROR, OutputTruncatedError
+from app.forge.subgraphs.code_qa_loop import after_code_or_repair, build_code_qa_loop
+
+
+@pytest.mark.asyncio
+async def test_run_project_build_loop_handles_output_truncated() -> None:
+    routing = BuildRouting(build="vite", renderer="canvas", ui="vanilla", dependencies=[])
+    initial = ParsedCodeOutput(
+        format="project",
+        files={"src/main.ts": "broken"},
+        routing=routing,
+    )
+
+    async def repair_fn(_current: ParsedCodeOutput, _err: str) -> ParsedCodeOutput:
+        raise OutputTruncatedError()
+
+    result = await run_project_build_loop(initial, repair_fn=repair_fn, max_retries=2)
+    assert result.ok is False
+    assert result.output_truncated is True
+
+
+@pytest.mark.asyncio
+async def test_code_qa_loop_skips_diagnose_on_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "code_qa_max_attempts", 3)
+    steps: list[str] = []
+
+    async def code_or_repair(state: dict[str, Any]) -> dict[str, Any]:
+        steps.append("code")
+        attempt = int(state.get("attempt") or 0) + 1
+        if attempt == 1:
+            return {
+                "attempt": attempt,
+                "candidate_ready": False,
+                "playtest_errors": [OUTPUT_TRUNCATED_ERROR],
+            }
+        return {
+            "attempt": attempt,
+            "candidate_ready": True,
+            "candidate_version": attempt,
+            "qa_ok": False,
+            "playtest_errors": [],
+        }
+
+    async def playtest(state: dict[str, Any]) -> dict[str, Any]:
+        steps.append("playtest")
+        return {
+            "qa_ok": True,
+            "attempt": state.get("attempt"),
+            "candidate_version": state.get("candidate_version"),
+            "candidate_ready": True,
+        }
+
+    async def diagnose(state: dict[str, Any]) -> dict[str, Any]:
+        steps.append("diagnose")
+        return {"attempt": state.get("attempt")}
+
+    graph = build_code_qa_loop(
+        code_or_repair=code_or_repair,
+        playtest=playtest,
+        diagnose=diagnose,
+    )
+    result = await graph.ainvoke({"attempt": 0})
+    assert result.get("qa_ok") is True
+    assert "diagnose" not in steps
+    assert steps == ["code", "code", "playtest"]
+
+
+def test_after_code_or_repair_routes_truncation_to_retry() -> None:
+    assert (
+        after_code_or_repair(
+            {
+                "candidate_ready": False,
+                "attempt": 1,
+                "playtest_errors": [OUTPUT_TRUNCATED_ERROR],
+            }
+        )
+        == "retry"
+    )
+
+
+def test_after_code_or_repair_truncation_exhausted() -> None:
+    assert (
+        after_code_or_repair(
+            {
+                "candidate_ready": False,
+                "attempt": 3,
+                "playtest_errors": [OUTPUT_TRUNCATED_ERROR],
+            }
+        )
+        == "exhausted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_code_or_repair_returns_truncation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from app.forge import code_qa_exec as cqe
+    from app.forge.memory.context_builder import BuiltContext
+
+    async def fake_code_llm(*_a, **_k) -> tuple[str, bool]:
+        return "<html>", True
+
+    async def fake_build_node_context(*_a, **_k) -> BuiltContext:
+        return BuiltContext(
+            user_message="请实现游戏",
+            sections={},
+            token_estimate=10,
+            node="code",
+        )
+
+    monkeypatch.setattr(cqe, "_code_llm", fake_code_llm)
+    monkeypatch.setattr(
+        "app.forge.memory.loader.build_node_context",
+        fake_build_node_context,
+    )
+    monkeypatch.setattr(settings, "memory_session_summary", False)
+    monkeypatch.setattr(settings, "build_pipeline_enabled", False)
+
+    ctx = SimpleNamespace(
+        s=None,
+        r=None,
+        game=SimpleNamespace(id="g1", title="Test", owner_id="u1", current_version=0),
+        run=SimpleNamespace(
+            id="r1",
+            user_id="u1",
+            llm_config_id=None,
+            status="running",
+            ended_at=None,
+            phase="code",
+        ),
+    )
+
+    design_doc = {
+        "title": "Test",
+        "engine": {"id": "canvas"},
+        "format_version": "2.0",
+        "core_loop": "test",
+        "controls": [],
+        "entities": [],
+        "levels": [],
+        "acceptance_criteria": [],
+    }
+
+    async def noop(*_a, **_k):
+        return "ok"
+
+    async def check_ctrl_ok(*_a, **_k):
+        return "ok"
+
+    result = await cqe.execute_code_or_repair(
+        ctx,
+        {"attempt": 0, "design_doc": design_doc, "artifacts": [], "art_direction": {}},
+        streamed_llm=noop,
+        set_phase=noop,
+        check_ctrl=check_ctrl_ok,
+        normalize_html=lambda x: x,
+        commit_project_build=noop,
+        run_finalized_exc=RuntimeError,
+    )
+    assert result.get("candidate_ready") is False
+    assert OUTPUT_TRUNCATED_ERROR in (result.get("playtest_errors") or [])
+    assert result.get("failure_kind") == "truncated"

--- a/backend/tests/forge/test_llm_continuation.py
+++ b/backend/tests/forge/test_llm_continuation.py
@@ -1,0 +1,110 @@
+"""LLM 截断检测与续写单测。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.forge.llm_continuation import (
+    generate_with_continuation,
+    has_incomplete_structure,
+    is_likely_truncated,
+    merge_continuation,
+)
+from app.llm.provider import LLMCompletion, Usage
+
+
+def test_has_incomplete_html_without_closing_tag() -> None:
+    html = "<!DOCTYPE html><html><body><script>function init(){}"
+    assert has_incomplete_structure(html) is True
+
+
+def test_complete_html_not_incomplete() -> None:
+    html = "<!DOCTYPE html><html><body></body></html>"
+    assert has_incomplete_structure(html) is False
+
+
+def test_is_likely_truncated_by_finish_reason() -> None:
+    assert (
+        is_likely_truncated(
+            "ok",
+            output_tokens=100,
+            max_tokens=8192,
+            finish_reason="length",
+        )
+        is True
+    )
+
+
+def test_is_likely_truncated_by_output_token_ceiling() -> None:
+    assert (
+        is_likely_truncated(
+            "<html></html>",
+            output_tokens=8190,
+            max_tokens=8192,
+            finish_reason="stop",
+        )
+        is True
+    )
+
+
+def test_merge_continuation_deduplicates_overlap() -> None:
+    prefix = "abcdef"
+    suffix = "defghi"
+    assert merge_continuation(prefix, suffix) == "abcdefghi"
+
+
+@pytest.mark.asyncio
+async def test_generate_with_continuation_stops_when_complete() -> None:
+    calls = {"n": 0}
+
+    async def llm_call(_system: str, _user: str) -> LLMCompletion:
+        calls["n"] += 1
+        return LLMCompletion(
+            content="<!DOCTYPE html><html></html>",
+            usage=Usage(output_tokens=100),
+            finish_reason="stop",
+        )
+
+    content, exhausted = await generate_with_continuation(
+        llm_call,
+        system="sys",
+        user_msg="make game",
+        max_tokens=8192,
+        max_rounds=3,
+    )
+    assert exhausted is False
+    assert calls["n"] == 1
+    assert "</html>" in content
+
+
+@pytest.mark.asyncio
+async def test_generate_with_continuation_retries_on_truncation() -> None:
+    calls = {"n": 0}
+    user_prompts: list[str] = []
+
+    async def llm_call(_system: str, user: str) -> LLMCompletion:
+        calls["n"] += 1
+        user_prompts.append(user)
+        if calls["n"] == 1:
+            return LLMCompletion(
+                content="<!DOCTYPE html><html><body><script>",
+                usage=Usage(output_tokens=8192),
+                finish_reason="length",
+            )
+        return LLMCompletion(
+            content="</script></body></html>",
+            usage=Usage(output_tokens=50),
+            finish_reason="stop",
+        )
+
+    content, exhausted = await generate_with_continuation(
+        llm_call,
+        system="sys",
+        user_msg="make game",
+        max_tokens=8192,
+        max_rounds=3,
+    )
+    assert exhausted is False
+    assert calls["n"] == 2
+    assert content.endswith("</html>")
+    assert "截断续写" in user_prompts[1]

--- a/backend/tests/forge/test_llm_continuation.py
+++ b/backend/tests/forge/test_llm_continuation.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import pytest
 
 from app.forge.llm_continuation import (
+    OUTPUT_TRUNCATED_ERROR,
+    build_continuation_user_msg,
     generate_with_continuation,
     has_incomplete_structure,
     is_likely_truncated,
+    is_output_truncated_error,
     merge_continuation,
 )
 from app.llm.provider import LLMCompletion, Usage
@@ -35,6 +38,18 @@ def test_is_likely_truncated_by_finish_reason() -> None:
     )
 
 
+def test_is_likely_truncated_by_max_tokens_finish_reason() -> None:
+    assert (
+        is_likely_truncated(
+            "ok",
+            output_tokens=100,
+            max_tokens=8192,
+            finish_reason="max_tokens",
+        )
+        is True
+    )
+
+
 def test_is_likely_truncated_by_output_token_ceiling() -> None:
     assert (
         is_likely_truncated(
@@ -47,10 +62,33 @@ def test_is_likely_truncated_by_output_token_ceiling() -> None:
     )
 
 
+def test_is_output_truncated_error() -> None:
+    assert is_output_truncated_error([OUTPUT_TRUNCATED_ERROR]) is True
+    assert is_output_truncated_error(["NO_RUNTIME_SIGNAL"]) is False
+
+
 def test_merge_continuation_deduplicates_overlap() -> None:
     prefix = "abcdef"
     suffix = "defghi"
     assert merge_continuation(prefix, suffix) == "abcdefghi"
+
+
+def test_merge_continuation_replaces_full_html_rewrite() -> None:
+    prefix = "<!DOCTYPE html><html><body><p>partial"
+    suffix = "<!DOCTYPE html><html><body><p>complete</p></body></html>"
+    assert merge_continuation(prefix, suffix) == suffix
+
+
+def test_build_continuation_user_msg_omits_full_original_prompt() -> None:
+    huge = "X" * 50000
+    msg = build_continuation_user_msg(
+        "<html><body>partial",
+        context_summary="游戏：Test；引擎：canvas",
+    )
+    assert huge not in msg
+    assert "截断续写" in msg
+    assert "任务摘要" in msg
+    assert "partial" in msg
 
 
 @pytest.mark.asyncio
@@ -78,9 +116,10 @@ async def test_generate_with_continuation_stops_when_complete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_with_continuation_retries_on_truncation() -> None:
+async def test_generate_with_continuation_retries_with_compact_prompt() -> None:
     calls = {"n": 0}
     user_prompts: list[str] = []
+    original = "make game" + ("Y" * 40000)
 
     async def llm_call(_system: str, user: str) -> LLMCompletion:
         calls["n"] += 1
@@ -100,11 +139,14 @@ async def test_generate_with_continuation_retries_on_truncation() -> None:
     content, exhausted = await generate_with_continuation(
         llm_call,
         system="sys",
-        user_msg="make game",
+        user_msg=original,
         max_tokens=8192,
         max_rounds=3,
+        context_summary="游戏：Test；引擎：canvas",
     )
     assert exhausted is False
     assert calls["n"] == 2
     assert content.endswith("</html>")
+    assert original not in user_prompts[1]
+    assert len(user_prompts[1]) < len(original)
     assert "截断续写" in user_prompts[1]

--- a/backend/tests/infra/test_logging_and_llm_null.py
+++ b/backend/tests/infra/test_logging_and_llm_null.py
@@ -66,15 +66,15 @@ async def test_complete_coerces_null_openai_content(monkeypatch: pytest.MonkeyPa
             return _Resp()
 
     monkeypatch.setattr("app.llm.provider.httpx.AsyncClient", lambda **_k: _Client())
-    content, usage = await complete(
+    result = await complete(
         LLMProvider.OPENAI,
         "key",
         "gpt-4o",
         "sys",
         "user",
     )
-    assert content == ""
-    assert usage == Usage(input_tokens=1, output_tokens=0)
+    assert result.content == ""
+    assert result.usage == Usage(input_tokens=1, output_tokens=0)
 
 
 class _OkResp:

--- a/backend/tests/llm/test_langfuse_integration.py
+++ b/backend/tests/llm/test_langfuse_integration.py
@@ -12,7 +12,7 @@ from app.core.config import settings
 from app.enums import LLMProvider
 from app.llm import client as llm_client
 from app.llm import provider as llm_provider
-from app.llm.provider import Usage
+from app.llm.provider import LLMCompletion, Usage
 
 
 def test_client_none_when_unconfigured() -> None:
@@ -31,16 +31,24 @@ async def test_invoke_llm_transparent_when_unconfigured(monkeypatch) -> None:
     """langfuse 禁用时 _invoke_llm 仅透传 provider.complete 的 content 与 usage。"""
 
     async def _fake_complete(
-        prov: Any, apikey: Any, model: Any, system: Any, user_msg: Any, *, base_url: Any
-    ) -> tuple[str, Usage]:
-        return "hello", Usage(7, 11)
+        prov: Any,
+        apikey: Any,
+        model: Any,
+        system: Any,
+        user_msg: Any,
+        *,
+        base_url: Any,
+        max_tokens: Any = None,
+    ) -> LLMCompletion:
+        _ = (prov, apikey, model, system, user_msg, base_url, max_tokens)
+        return LLMCompletion(content="hello", usage=Usage(7, 11))
 
     monkeypatch.setattr(llm_provider, "complete", _fake_complete)
-    content, usage = await llm_client._invoke_llm(
+    result = await llm_client._invoke_llm(
         LLMProvider.ANTHROPIC, "k", "model-x", "sys", "hi", None, {"user_id": "u"}
     )
-    assert content == "hello"
-    assert usage == Usage(7, 11)
+    assert result.content == "hello"
+    assert result.usage == Usage(7, 11)
 
 
 class _FakeGen:
@@ -96,15 +104,23 @@ async def test_invoke_llm_writes_generation_when_enabled(monkeypatch) -> None:
     """注入 fake client：_invoke_llm 成功后写 output 与 usage_details（int 字典）。"""
 
     async def _fake_complete(
-        prov: Any, apikey: Any, model: Any, system: Any, user_msg: Any, *, base_url: Any
-    ) -> tuple[str, Usage]:
-        return "<html></html>", Usage(13, 9)
+        prov: Any,
+        apikey: Any,
+        model: Any,
+        system: Any,
+        user_msg: Any,
+        *,
+        base_url: Any,
+        max_tokens: Any = None,
+    ) -> LLMCompletion:
+        _ = (prov, apikey, model, system, user_msg, base_url, max_tokens)
+        return LLMCompletion(content="<html></html>", usage=Usage(13, 9))
 
     monkeypatch.setattr(llm_provider, "complete", _fake_complete)
     fake = _FakeClient()
     monkeypatch.setattr(lf, "_client", lambda: fake)
 
-    content, usage = await llm_client._invoke_llm(
+    result = await llm_client._invoke_llm(
         LLMProvider.OPENAI_COMPAT,
         "k",
         "gpt-x",
@@ -114,8 +130,8 @@ async def test_invoke_llm_writes_generation_when_enabled(monkeypatch) -> None:
         {},
         kind="plan",
     )
-    assert content == "<html></html>"
-    assert usage == Usage(13, 9)
+    assert result.content == "<html></html>"
+    assert result.usage == Usage(13, 9)
     # 关键：usage_details 必须是 int 字典（v4 SDK 入参），output 为 LLM 文本
     assert fake.gen.updated["output"] == "<html></html>"
     assert fake.gen.updated["usage_details"] == {"input": 13, "output": 9}

--- a/backend/tests/llm/test_platform_complete.py
+++ b/backend/tests/llm/test_platform_complete.py
@@ -9,7 +9,7 @@ import pytest
 from app.core import langfuse as lf
 from app.enums import LLMProvider
 from app.llm import provider as llm_provider
-from app.llm.provider import Usage
+from app.llm.provider import LLMCompletion, Usage
 
 
 @pytest.mark.asyncio
@@ -25,9 +25,9 @@ async def test_platform_complete_writes_generation(monkeypatch) -> None:
         base_url: Any = None,
         *,
         max_tokens: int | None = None,
-    ) -> tuple[str, Usage]:
+    ) -> LLMCompletion:
         _ = (prov, apikey, model, system, user_msg, base_url, max_tokens)
-        return '{"ok":true}', Usage(3, 5)
+        return LLMCompletion(content='{"ok":true}', usage=Usage(3, 5))
 
     class _FakeGen:
         def __init__(self) -> None:

--- a/backend/tests/llm/test_provider_retry.py
+++ b/backend/tests/llm/test_provider_retry.py
@@ -39,7 +39,7 @@ async def test_complete_retries_on_429_then_succeeds(monkeypatch) -> None:
             transport=httpx.MockTransport(handler), timeout=timeout
         ),
     )
-    content, usage = await provider.complete(
+    result = await provider.complete(
         LLMProvider.OPENAI_COMPAT,
         "k",
         "m",
@@ -47,8 +47,8 @@ async def test_complete_retries_on_429_then_succeeds(monkeypatch) -> None:
         "hi",
         base_url="https://x.example.com/v1",
     )
-    assert content == "ok"
-    assert usage.input_tokens == 1
+    assert result.content == "ok"
+    assert result.usage.input_tokens == 1
     assert calls["n"] == 3
 
 
@@ -71,7 +71,7 @@ async def test_complete_retries_transport_error(monkeypatch) -> None:
             transport=httpx.MockTransport(handler), timeout=timeout
         ),
     )
-    content, _ = await provider.complete(
+    result = await provider.complete(
         LLMProvider.OPENAI_COMPAT,
         "k",
         "m",
@@ -79,7 +79,7 @@ async def test_complete_retries_transport_error(monkeypatch) -> None:
         "hi",
         base_url="https://x.example.com/v1",
     )
-    assert content == "ok"
+    assert result.content == "ok"
     assert calls["n"] == 2
 
 


### PR DESCRIPTION
## Summary
- Raise Code-stage output budget via \LLM_CODE_MAX_TOKENS\ (default 32768) with auto-continuation when output is truncated.
- Compact continuation prompts: only task summary + tail context (no full first-round user_msg replay).
- Surface \OUTPUT_TRUNCATED\ explicitly; skip diagnose and retry generate directly in CodeQaLoop.
- Vite inner build loop catches \OutputTruncatedError\ instead of crashing the run.

## Background
Large single-file HTML games hit the 8192 output cap, producing truncated artifacts that failed QA with misleading \NO_RUNTIME_SIGNAL\.

## Changes
- \llm_continuation.py\: truncation detection (\length\/\max_tokens\), merge with full-HTML rewrite detection, continuation loop.
- \call_llm\ returns \LLMCompletion\ (includes \inish_reason\).
- \code_qa_exec.py\: all generate/repair LLM calls use continuation; structured truncation failure.
- \code_qa_loop.py\: truncation routes to \
etry\ (skip diagnose).
- \uild/integration.py\: \ProjectBuildLoopResult.output_truncated\.

## Test plan
- [x] \pytest tests/forge/test_llm_continuation.py\
- [x] \pytest tests/forge/test_code_qa_truncation.py\
- [x] \pytest tests/forge/reliability/test_code_qa_loop.py tests/llm/\
- [x] Re-run a previously failing large HTML game after merge