### PR TITLE
docs: revise plan revision rollback design

### DIFF
--- a/docs/2026-08-17-plan-revision-rollback-design.md
+++ b/docs/2026-08-17-plan-revision-rollback-design.md
@@ -1,360 +1,522 @@
-# 策划稿跨阶段修订与失败恢复（Replan & Recovery）生产级技术方案
+# GameForge 跨阶段策划修订与失败恢复生产级技术方案
 
-* **Status:** Proposed（待评审）
-* **Date:** 2026-08-17
+* **Status:** Proposed
+* **Date:** 2026-08-18
 * **Owners:** TBD
-* **Related:**
-
-  * `backend/app/forge/graph.py`：主图 / `route_start` / HITL 路由
-  * `backend/app/forge/hitl.py`：HITL 决策与合法命令
-  * `backend/app/forge/subgraphs/code_qa_loop.py`：CodeQaLoop 子图
-  * `backend/app/forge/state.py`：Run checkpoint / state persistence
-  * `backend/app/forge/queue.py`：RabbitMQ enqueue / resume
-  * `docs/adr/ADR-10-checkpoint-hitl-idempotency.md`
-* **拟新增 / 修订 ADR：**
-
-  * ADR-10：补充 HITL resume 不再假设单一恢复目标
-  * 新增 ADR：`Workflow Versioning & Artifact Lineage`
-  * 新增 ADR：`Run Command / Decision Request / Outbox Reliability`
+* **Scope:** Workflow Recovery / Replan / Artifact Lineage
+* **核心目标:** 在不重写现有 LangGraph + PostgreSQL + RabbitMQ 工作流骨架的前提下，使后置开发/QA 阶段能够基于真实失败证据安全地修订上游策划，并保证恢复流程具备生产级的一致性、幂等性、可审计性和版本兼容能力。
 
 ---
 
-## 0. 执行摘要
+## 目录
 
-GameForge 当前工作流已经具备完整的策划、美术、开发、自动 QA 与 HITL 暂停恢复能力，但整个系统仍隐含一个单向假设：
-
-> 上游策划一旦确认，后续阶段只能继续向前；如果开发阶段发现策划本身不可实现，只能继续修代码或放弃整个 run。
-
-这一假设在真实生产环境下不成立。
-
-开发和 QA 不只是“验证代码是否正确”，同时也是对策划可实现性的后置验证。某些需求只有进入真实构建、浏览器执行、性能测试或试玩阶段后，才能确认其超出当前运行时能力、预算或验收能力。
-
-因此，本方案不再把问题定义成简单的 **Plan Rollback**，而是建立一套正式的：
-
-> **Cross-stage Replan & Recovery Model**
-
-核心原则是：
-
-**历史永远向前，不做破坏性回滚。**
-
-发生 QA 或能力失败后，不修改或删除旧策划，而是创建新的 `PlanRevision`；旧的 Art、Candidate 等产物继续保留，但根据依赖关系被标记为 `STALE` / `SUPERSEDED`，不得继续 Promote。
-
-本方案保留现有：
-
-* FastAPI
-* LangGraph
-* PostgreSQL checkpoint
-* Redis cache
-* RabbitMQ
-* 云沙箱
-* WebSocket
-* 外部 HITL 暂停 / 恢复
-
-等核心技术选型，不重写工作流框架。
-
-本次架构升级的核心不是“给 `qa_failed` 多加一个按钮”，而是正式建立 GameForge 的 Workflow Domain Model：
-
-1. `RunCommand`
-2. `DecisionRequest`
-3. `FailureReport`
-4. Immutable Artifact Revision
-5. Artifact Dependency / Lineage
-6. Workflow Versioning
-7. Capability Validation
-8. Reliable Command Delivery
-9. Promotion Invariants
-10. Failure Recovery Policy
+1. 背景与现状
+2. 问题定义
+3. 已确认的现有基础设施
+4. 架构目标与设计原则
+5. 核心领域模型
+6. RunCommand
+7. HITL 控制版本与陈旧请求防护
+8. FailureReport
+9. FailureClass 判定机制
+10. RecoveryPolicy
+11. PlanRevision 与 Artifact Lineage
+12. Art 失效与复用策略
+13. Promotion Guard
+14. Capability Validation
+15. Acceptance Contract
+16. REVISE_PLAN 执行流程
+17. 消息可靠性与 Command 幂等
+18. Cancel / Pause / Resume 收敛
+19. Workflow Versioning
+20. Prompt 与失败证据安全
+21. Budget 与成本控制
+22. API / WebSocket / Frontend Contract
+23. 可观测性与审计
+24. 数据模型
+25. 分阶段实施计划
+26. 测试与验收
+27. Rollout 与回滚
+28. Non-Goals
+29. 最终架构不变量
+30. 最终决策
 
 ---
 
-# 1. 项目背景
+# 1. 背景与现状
 
-GameForge 是一个 AI 辅助浏览器游戏创作平台。
+GameForge 当前工作流大致为：
 
-用户通过自然语言描述玩法创意，系统自动完成：
+```text
+User Idea
+   │
+   ▼
+Plan
+   │
+   ▼
+Plan Confirm
+   │
+   ▼
+Art
+   │
+   ▼
+Art Confirm
+   │
+   ▼
+Code
+   │
+   ▼
+Sandbox / Playtest / QA
+   │
+   ▼
+Done
+```
 
-1. AI 策划
-2. 用户确认策划
-3. 美术方案生成
-4. 用户确认美术
-5. 游戏代码生成
-6. 云沙箱构建
-7. 浏览器自动试玩
-8. 自动 QA / 修复
-9. 最终版本交付、下载与发布
-
-主要技术栈：
+主要技术组件：
 
 ```text
 FastAPI
-    │
-    ▼
-LangGraph Workflow
-    │
-    ├── Plan
-    ├── Art
-    ├── Code
-    └── QA
-    │
-    ▼
-PostgreSQL RunCheckpoint
-Redis Cache
+LangGraph
+PostgreSQL
+Redis
 RabbitMQ
 Cloud Sandbox
 Playwright
 WebSocket
 ```
 
-当前系统采用：
+当前采用：
 
-> **单步执行器 + 外部暂停恢复 + 集中式路由**
+> **单步 Workflow 执行 + PostgreSQL 状态持久化 + 外部 HITL 暂停恢复 + RabbitMQ 异步调度 + 集中式 route_start**
 
-模式。
+模型。
 
-主图中的节点执行完成后，如果需要 HITL：
+典型 HITL：
 
 ```text
 Node
  ↓
 _pause_hitl()
  ↓
-Run = PAUSED
+Run PAUSED
  ↓
 Graph END
  ↓
-User resolves decision
+User Decision
  ↓
-Resume job enqueue
+enqueue_resume
  ↓
-Worker starts again
+RabbitMQ
+ ↓
+Worker
  ↓
 route_start()
  ↓
-Next node
+Next Node
 ```
 
-因此本方案不需要把 LangGraph 改造成 Fully Connected Graph，也不需要通过图内边实现复杂回环。
+本方案不改变这一核心执行模型。
 
 ---
 
 # 2. 问题定义
 
-## 2.1 当前用户问题
+当前系统隐含一个不成立的业务假设：
 
-标准生成链路：
+> Plan 一旦确认，后面的 Code / QA 只能修改实现，不能重新审视 Plan。
 
-```text
-Plan
- ↓
-Plan Confirm
- ↓
-Art
- ↓
-Art Confirm
- ↓
-Code + QA
- ↓
-Done
-```
+现实中，开发和 QA 同时承担：
 
-CodeQaLoop 当前能够处理：
+1. Implementation Verification
+2. Developability Verification
 
-* build error
-* runtime error
-* Playwright failure
-* quality failure
-* implementation repair
-* infra replay
+某些策划只有真正进入：
 
-但当达到最大修复次数后：
+* Build
+* Runtime
+* Browser Playtest
+* Resource Measurement
+* Automated QA
+
+之后，才能确认其不可实现或不经济。
+
+例如：
 
 ```text
-attempt >= max_attempts
- ↓
-qa_failed
- ↓
-HITL
-```
-
-用户当前只能：
-
-```text
-approve
-modify
-```
-
-两者最终仍回：
-
-```text
-code_qa_loop
-```
-
-于是存在三个生产级缺口。
-
----
-
-## 2.2 缺口一：开发失败无法修改上游策划
-
-例如用户要求：
-
-> 制作一个 3D 开放世界多人联机生存游戏。
-
-策划阶段可能生成了一个逻辑合理但当前 GameForge Runtime 无法实现的 Design Doc。
-
-用户确认策划后：
-
-```text
-Plan
- ↓
-Art
- ↓
-Code Attempt 1
- ↓
-Fail
- ↓
-Code Attempt 2
- ↓
-Fail
- ↓
-Code Attempt 3
- ↓
-Fail
-```
-
-此时继续修 Code 没有意义。
-
-真正合理的恢复动作可能是：
-
-```text
-3D → 2D
-开放世界 → 小型地图
-多人同步 → 单人玩法
-复杂物理 → 简化碰撞规则
-20 分钟 Session → 5 分钟 Session
-```
-
-当前系统没有这条路径。
-
----
-
-## 2.3 缺口二：失败证据没有形成稳定的数据资产
-
-当前 `revise_plan` 主要依赖：
-
-```text
-原 design_doc
+3D 开放世界
 +
-用户 modify_text
+实时多人同步
++
+复杂物理
++
+大量动态资产
 ```
 
-但是 QA 已经产生了大量高价值证据：
+策划本身可能语义合理，但超出当前 Runtime 能力。
+
+如果继续：
 
 ```text
-build errors
-runtime errors
-playtest failures
-qa diagnosis
-failure kind
-attempt history
-resource usage
+Code Retry 1
+ ↓
+Code Retry 2
+ ↓
+Code Retry 3
 ```
 
-如果这些信息没有冻结成稳定结构，而是在 `revise_plan` 执行时临时从当前 checkpoint 中读取，会出现：
+并不能解决问题。
 
-* failure context 被后续 attempt 覆盖
-* 恢复时读到不同版本的数据
-* 无法审计“当时为什么建议用户修改策划”
-* 无法稳定复现
-* prompt 输入与 UI 展示信息不一致
+真正需要的是：
+
+```text
+Plan P1
+ ↓
+失败证据 F1
+ ↓
+用户确认修改
+ ↓
+Plan P2
+```
+
+因此本方案正式把问题定义为：
+
+> **Cross-stage Replan & Recovery**
+
+而不是简单的：
+
+> Plan Rollback
 
 ---
 
-## 2.4 缺口三：产物缺乏正式血缘关系
+# 3. 已确认的现有基础设施
 
-当前逻辑上存在：
+本方案必须基于当前代码事实，而不是重新设计已经存在的基础设施。
+
+## 3.1 Transactional Outbox 已存在
+
+现有代码已经具备 Task Outbox：
 
 ```text
-Design Doc
- ↓
-Art Direction
- ↓
-Candidate
+app/messaging/outbox.py
 ```
 
-但系统无法稳定回答：
+其中 `add_task` 在业务数据库事务内写入 `TaskOutbox`。
 
-> Candidate C7 是基于哪一版策划生成？
+当前：
 
-> Art A3 是否仍然兼容新的 Plan P4？
+```text
+app/forge/queue.py
+```
 
-> Plan 修改后是否需要重新生成美术？
+中的 `enqueue_resume` 已经保证：
 
-> 某个旧 Candidate 为什么不能 Promote？
+```text
+resume_grant write
++
+add_task()
++
+DB COMMIT
+```
 
-缺乏正式 Artifact Lineage 后，系统只能：
+位于同一 PostgreSQL Transaction 内。
 
-* 全量重新生成，浪费成本；
-* 或复用旧产物，产生一致性风险。
+因此以下经典故障：
+
+```text
+DB commit success
+RabbitMQ publish failure
+```
+
+不会导致 Resume 永久丢失。
+
+Publish 失败后 TaskOutbox 记录仍然存在。
 
 ---
 
-## 2.5 缺口四：失败类型与恢复策略耦合在 phase 上
+## 3.2 Outbox Publisher 已存在
 
-当前存在类似：
+现有：
 
 ```text
-sandbox_failed
-qa_failed
+dispatch_pending
 ```
 
-这样的 phase。
-
-但：
+已经负责：
 
 ```text
-sandbox_failed
+TaskOutbox
+ ↓
+RabbitMQ Publish
+ ↓
+Retry
 ```
 
-可能代表：
+并具有：
 
-* 云 Sandbox 服务临时不可用；
-* Build Timeout；
-* 内存不足；
-* 用户策划要求的能力不支持；
-* 代码实现 bug；
-* 第三方资源失败。
+* retry
+* exponential backoff
+* `skip_locked`
+* 并发 publisher 防重
+* 最终失败处理
 
-这些失败的正确恢复行为完全不同。
+因此：
 
-因此生产系统不应该使用：
+> **本方案不新建 `outbox_events`。**
+
+统一复用现有：
 
 ```text
-phase → recovery action
+task_outbox
 ```
 
-作为核心模型。
+---
 
-应改为：
+## 3.3 Worker 租约恢复已存在
+
+现有 Scheduler 已有：
 
 ```text
-FailureClass
+RUNNING lease lost recovery
+```
+
+因此 Worker 死亡后的基础任务回收机制已经存在。
+
+本方案不重复实现。
+
+---
+
+## 3.4 当前消息层真正缺少的能力
+
+现有消息可靠性主要解决：
+
+```text
+Task 不丢
+```
+
+但还没有正式解决：
+
+```text
+同一个业务 Command 被重复消费时，
+是否只产生一次业务效果
+```
+
+因此本方案消息层真实增量只有：
+
+```text
+RunCommand identity
++
+command_id
++
+command execution status
++
+worker-side command idempotency
+```
+
+而不是重建 Outbox。
+
+---
+
+# 4. 架构目标与设计原则
+
+## 4.1 历史只能向前
+
+禁止：
+
+```text
+P1 → overwrite → P2
+```
+
+应使用：
+
+```text
+P1
+ ↓
+P2
+```
+
+其中 P1 永远保留。
+
+同理：
+
+```text
+Art A1
+Candidate C1
+Failure F1
+```
+
+不能因为新版本产生而删除。
+
+---
+
+## 4.2 Replan 不是 Rollback
+
+业务含义：
+
+```text
+PlanRevision P1
+   │
+   ▼
+ArtRevision A1
+   │
+   ▼
+CandidateRevision C1
+   │
+   ▼
+FailureReport F1
+   │
+   ▼
+REVISE_PLAN
+   │
+   ▼
+PlanRevision P2
+```
+
+系统并没有回到 P1。
+
+而是基于 P1 + F1 创建 P2。
+
+---
+
+## 4.3 失败类别与 Workflow Phase 解耦
+
+禁止长期使用：
+
+```text
+qa_failed → 某恢复动作
+sandbox_failed → 某恢复动作
+```
+
+作为核心恢复模型。
+
+改为：
+
+```text
+Observed Failure
+ ↓
+Failure Classification
  ↓
 RecoveryPolicy
  ↓
-AllowedCommands
+Allowed Commands
 ```
 
 ---
 
-# 3. 根因分析
+## 4.4 用户语义变化需要 HITL
 
-本问题不是 LangGraph 缺乏回环能力。
+以下操作改变产品语义：
 
-真正根因有六个。
+```text
+3D → 2D
+多人 → 单人
+开放地图 → 有限地图
+删除机制
+缩减关卡
+修改核心验收标准
+```
 
-## 3.1 HITL decision 使用上下文依赖型弱语义词汇
+必须用户确认。
 
-当前：
+基础设施恢复：
+
+```text
+503
+RabbitMQ redelivery
+Sandbox startup timeout
+临时网络失败
+```
+
+不需要用户做产品决策。
+
+---
+
+## 4.5 消息允许重复，业务效果不能重复
+
+系统目标明确为：
+
+```text
+At-Least-Once Delivery
++
+Exactly-Once Business Effect
+```
+
+不追求依赖 Broker 实现虚假的：
+
+```text
+Exactly-Once Delivery
+```
+
+---
+
+## 4.6 在昂贵阶段之前尽早失败
+
+优先：
+
+```text
+Plan
+ ↓
+Developability Validation
+ ↓
+Plan Confirm
+```
+
+而不是：
+
+```text
+Plan
+ ↓
+Art
+ ↓
+Code × N
+ ↓
+最终才知道根本做不了
+```
+
+---
+
+# 5. 核心领域模型
+
+本次架构正式引入四个核心概念：
+
+```text
+RunCommand
+FailureReport
+Artifact Revision
+Artifact Lineage
+```
+
+另外增加两个控制能力：
+
+```text
+control_revision
+workflow_version
+```
+
+最终逻辑模型：
+
+```text
+Run
+ │
+ ├── RunCommand
+ │
+ ├── FailureReport
+ │
+ └── ArtifactRevision
+        │
+        ├── PlanRevision
+        ├── ArtRevision
+        └── CandidateRevision
+```
+
+本期 **不独立创建 QAContractRevision**，Acceptance Contract 作为 PlanRevision 的结构化组成部分，后文详述。
+
+---
+
+# 6. RunCommand
+
+## 6.1 为什么引入 Command
+
+当前 HITL vocabulary 存在：
 
 ```text
 approve
@@ -369,373 +531,27 @@ select_b
 qa_failed + approve
 ```
 
-实际上表达的是：
-
-> 再进行一次实现尝试。
-
-而：
+实际表示：
 
 ```text
-qa_failed + modify
+重新尝试实现
 ```
 
-表达的是：
+离开 `phase` 后：
 
-> 带用户反馈重新尝试实现。
-
-离开 `phase` 后，`approve` / `modify` 本身没有业务含义。
-
-随着工作流增长，会最终演变为：
-
-```python
-if phase == ...
-    if decision == ...
-        ...
+```text
+approve
 ```
 
-形成隐式状态机。
+无法表达任何完整业务语义。
+
+因此内部领域模型统一改为具有明确语义的 Command。
 
 ---
 
-## 3.2 Failure Evidence 没有不可变快照
+## 6.2 Command 类型
 
-Failure 是工作流状态的一部分，而不是独立领域对象。
-
-这导致恢复动作与“当前 checkpoint”过度耦合。
-
----
-
-## 3.3 Artifact 是值，不是 Revision
-
-当前系统更接近：
-
-```text
-design_doc = {...}
-art_direction = {...}
-candidate = {...}
-```
-
-生产级模型应该是：
-
-```text
-PlanRevision P1
-PlanRevision P2
-
-ArtRevision A1
-
-CandidateRevision C1
-CandidateRevision C2
-```
-
-每个版本不可变。
-
----
-
-## 3.4 没有正式依赖关系
-
-系统缺少：
-
-```text
-A1 depends_on P1
-C1 depends_on P1 + A1
-```
-
-因此无法可靠执行 invalidation。
-
----
-
-## 3.5 可开发性检查发生得太晚
-
-明显的 capability mismatch 应尽可能在：
-
-```text
-Plan
- ↓
-Capability Validation
- ↓
-Plan Confirm
-```
-
-期间发现，而不是消耗三次代码生成后才发现。
-
----
-
-## 3.6 消息投递与数据库状态缺乏统一可靠性模型
-
-HITL Resolve 涉及：
-
-```text
-DB update
-+
-RabbitMQ publish
-```
-
-如果缺少 Transactional Outbox，会出现经典不一致：
-
-### Case A
-
-```text
-DB commit success
-RabbitMQ publish failed
-```
-
-Run 看似已恢复，但永远没有 Worker 继续执行。
-
-### Case B
-
-```text
-RabbitMQ publish success
-HTTP response timeout
-```
-
-用户重试 Resolve，产生重复命令。
-
-因此生产模型必须接受：
-
-> 消息可能重复投递。
-
-系统目标不是“Exactly Once Delivery”，而是：
-
-> **At-Least-Once Delivery + Exactly-Once Effect**
-
----
-
-# 4. 目标架构
-
-整体业务模型：
-
-```text
-                         CapabilityProfile
-                                │
-                                ▼
-User Idea ────────→ Plan Revision P1
-                         │
-                         ├── Capability Validate
-                         │
-                         ▼
-                   QA Contract Q1
-                         │
-                         ▼
-                    Plan Confirm
-                         │
-                         ▼
-                  Art Revision A1
-                         │
-                         ▼
-                    Art Confirm
-                         │
-                         ▼
-                Candidate Revision C1
-                         │
-                         ▼
-                    Code / QA
-                         │
-              ┌──────────┴────────────┐
-              │                       │
-             PASS                    FAIL
-              │                       │
-              ▼                       ▼
-       Promotion Guard          FailureReport F1
-              │                       │
-              ▼            ┌──────────┼──────────────┐
-            DONE            │          │              │
-                         Infra       Impl.        Capability
-                       Transient     Defect       Mismatch
-                           │           │              │
-                           ▼           ▼              ▼
-                       Auto Retry   Code Retry   DecisionRequest
-                                                      │
-                                                 REVISE_PLAN
-                                                      │
-                                                      ▼
-                                               Plan Revision P2
-                                                      │
-                                              Dependency Check
-                                                ┌─────┴─────┐
-                                                │           │
-                                             reuse A1   generate A2
-                                                │           │
-                                                └─────┬─────┘
-                                                      ▼
-                                               Candidate C2
-```
-
-底层可靠执行模型：
-
-```text
-Client
-  │
-  ▼
-FastAPI
-  │
-  ▼
-PostgreSQL Transaction
- ├── Resolve DecisionRequest
- ├── Insert RunCommand
- ├── CAS Run Revision
- └── Insert Outbox Event
-  │
- COMMIT
-  │
-  ▼
-Outbox Publisher
-  │
-  ▼
-RabbitMQ
-  │
-  ▼
-Worker
-  │
-  ▼
-Idempotent Command Execution
-```
-
----
-
-# 5. 核心设计原则
-
-## 5.1 历史只追加，不做破坏性回滚
-
-所谓 `revise_plan` 实际不是 rollback。
-
-禁止：
-
-```text
-P1 → overwrite → P2
-```
-
-应使用：
-
-```text
-P1
- ↓ superseded_by
-P2
-```
-
-任何已经产生的：
-
-* Plan
-* Art
-* Candidate
-* Failure Report
-* QA Result
-
-默认都不物理删除。
-
----
-
-## 5.2 旧产物可以失效，但不能消失
-
-Plan P2 创建以后：
-
-```text
-active_plan = P2
-```
-
-如果旧 Candidate C1 不兼容：
-
-```text
-C1.status = STALE
-C1.stale_reason = PLAN_SUPERSEDED
-```
-
-而不是：
-
-```text
-candidate = null
-DELETE candidate
-```
-
-Run 当前活跃 Candidate 可以置空：
-
-```text
-active_candidate_revision_id = NULL
-```
-
-但历史 Candidate 必须保留。
-
----
-
-## 5.3 语义变化必须 HITL，机械恢复自动执行
-
-需要 HITL：
-
-```text
-3D → 2D
-多人 → 单人
-5 关 → 3 关
-删除某玩法机制
-修改核心验收标准
-重新生成美术
-```
-
-不需要 HITL：
-
-```text
-RabbitMQ redelivery
-Sandbox 503
-短暂网络故障
-Browser startup timeout
-临时镜像拉取失败
-```
-
-原则：
-
-> **改变用户产品意图的操作需要 HITL。恢复基础设施状态的操作应该自动完成。**
-
----
-
-## 5.4 Workflow 恢复必须幂等
-
-所有外部恢复请求都必须具有稳定：
-
-```text
-command_id
-```
-
-重复投递：
-
-```text
-Command X
-Command X
-Command X
-```
-
-只能产生一次业务效果。
-
----
-
-## 5.5 在进入昂贵阶段前尽早验证
-
-优先：
-
-```text
-Plan
- ↓
-Validate
- ↓
-Reject / Replan
-```
-
-而不是：
-
-```text
-Plan
- ↓
-Art
- ↓
-Code × 3
- ↓
-发现 Plan 根本无法实现
-```
-
----
-
-# 6. RunCommand：正式替代上下文型 decision
-
-## 6.1 新命令模型
-
-新增：
+建议：
 
 ```python
 class RunCommandType(StrEnum):
@@ -752,7 +568,7 @@ class RunCommandType(StrEnum):
     CANCEL_RUN = "cancel_run"
 ```
 
-后续可扩展：
+未来如有需要可以扩展：
 
 ```text
 CHANGE_RUNTIME
@@ -760,234 +576,260 @@ ACCEPT_DEGRADED_RESULT
 RESTART_FROM_ART
 ```
 
-但本期不实现。
+本期不实现。
 
 ---
 
-## 6.2 不再使用 `approve` 表示 QA Retry
+## 6.3 Legacy Decision Adapter
 
-旧语义：
+迁移期外部 API 可以暂时接受旧 vocabulary。
 
-```text
-qa_failed + approve
-```
-
-新语义：
-
-```text
-RETRY_IMPLEMENTATION
-```
-
-旧：
-
-```text
-qa_failed + modify
-```
-
-新：
-
-```text
-RETRY_IMPLEMENTATION
-feedback = "..."
-```
-
-优点：
-
-* API 自解释；
-* Event Log 自解释；
-* 不依赖 phase 才能理解；
-* 降低 `route_start()` 复杂度；
-* 未来新增流程不需要继续扩散语义不明的 `approve/modify`。
-
----
-
-## 6.3 向后兼容
-
-迁移期间 API 可以暂时接受旧 decision：
-
-```text
-approve
-modify
-```
-
-在 API Boundary 转成新命令。
-
-例如：
-
-```python
-legacy_map = {
-    ("qa_failed", "approve"): RETRY_IMPLEMENTATION,
-    ("qa_failed", "modify"): RETRY_IMPLEMENTATION,
-    ("plan_confirm", "approve"): APPROVE_PLAN,
-    ("plan_confirm", "modify"): REVISE_PLAN,
-}
-```
-
-内部 Worker 与新数据表只处理正式 `RunCommandType`。
-
-旧 vocabulary 在兼容窗口后删除。
-
----
-
-# 7. DecisionRequest：正式 HITL 对象
-
-当前 HITL 不应只表现为：
-
-```text
-run.phase = qa_failed
-```
-
-新增正式领域对象：
-
-```text
-DecisionRequest
-```
-
-建议字段：
-
-```text
-id
-run_id
-run_revision
-
-request_type
-phase_snapshot
-
-failure_report_id nullable
-
-allowed_commands
-
-status:
-    OPEN
-    RESOLVED
-    EXPIRED
-    CANCELLED
-
-created_at
-resolved_at
-
-resolved_command_id nullable
-```
+但必须在统一边界转换。
 
 示例：
 
+```python
+LEGACY_DECISION_MAP = {
+    ("plan_confirm", "approve"):
+        RunCommandType.APPROVE_PLAN,
+
+    ("plan_confirm", "modify"):
+        RunCommandType.REVISE_PLAN,
+
+    ("qa_failed", "approve"):
+        RunCommandType.RETRY_IMPLEMENTATION,
+
+    ("qa_failed", "modify"):
+        RunCommandType.RETRY_IMPLEMENTATION,
+
+    ("sandbox_failed", "approve"):
+        RunCommandType.RETRY_IMPLEMENTATION,
+
+    ("sandbox_failed", "modify"):
+        RunCommandType.RETRY_IMPLEMENTATION,
+}
+```
+
+对于：
+
+```text
+modify
+```
+
+原始 `modify_text` 转入：
+
+```text
+command.payload.feedback
+```
+
+---
+
+## 6.4 Adapter 必须覆盖所有 Resume 入口
+
+当前 Resume 不只来自：
+
+```text
+resolve_hitl
+```
+
+还包括：
+
+```text
+resolve_hitl
+resume_run_control
+retry_run
+dev_requeue
+```
+
+因此禁止在各入口分别手写 legacy mapping。
+
+应增加统一函数，例如：
+
+```python
+normalize_resume_command(...)
+```
+
+所有进入：
+
+```text
+enqueue_resume
+```
+
+之前的路径统一调用。
+
+原则：
+
+> **Command Normalization 必须发生在公共 Resume Boundary，而不是某一个 API Endpoint。**
+
+否则会出现部分路径：
+
+```text
+有 command_id
+```
+
+部分路径：
+
+```text
+只有 legacy resume_grant
+```
+
+的问题。
+
+---
+
+# 7. HITL 控制版本与陈旧请求防护
+
+## 7.1 不复用 RunCheckpoint revision
+
+当前 RunCheckpoint 上已有 revision / version 类概念。
+
+但它解决的是：
+
+> Workflow State 是否被其他写操作修改。
+
+用户 HITL 需要解决的是：
+
+> 用户当前看到的决策页面是否仍然有效。
+
+这两个概念语义不同。
+
+因此不复用 Checkpoint Revision。
+
+---
+
+## 7.2 新增 runs.control_revision
+
+在 `runs` 表增加：
+
+```text
+control_revision BIGINT NOT NULL DEFAULT 0
+```
+
+它只表达：
+
+> 对外可操作控制状态的版本。
+
+例如以下行为会递增：
+
+```text
+进入新的 HITL
+Resolve HITL
+Cancel
+Resume
+会导致旧用户操作失效的控制状态变更
+```
+
+普通内部：
+
+```text
+token usage update
+metric update
+worker heartbeat
+```
+
+不递增。
+
+---
+
+## 7.3 HITL Payload
+
+向客户端发送：
+
 ```json
 {
-  "id": "dr_123",
-  "run_id": "run_456",
-  "run_revision": 37,
-  "request_type": "QA_RECOVERY",
-  "phase_snapshot": "qa_failed",
-  "failure_report_id": "failure_789",
+  "decision_id": "decision_xxx",
+  "control_revision": 42,
   "allowed_commands": [
     "retry_implementation",
     "revise_plan",
     "cancel_run"
-  ],
-  "status": "OPEN"
+  ]
 }
 ```
 
 ---
 
-# 8. HITL Resolve API
+## 7.4 Resolve CAS
 
-建议请求：
-
-```http
-POST /runs/{run_id}/decision-requests/{decision_request_id}/resolve
-```
-
-Request：
+客户端提交：
 
 ```json
 {
+  "decision_id": "decision_xxx",
+  "expected_control_revision": 42,
   "command": "revise_plan",
-  "feedback": "改为 2D 俯视角，取消多人同步",
-  "idempotency_key": "client-generated-key"
+  "feedback": "改成 2D"
 }
 ```
 
-服务端事务必须校验：
-
-```text
-DecisionRequest.status == OPEN
-
-DecisionRequest.run_id == Run.id
-
-DecisionRequest.run_revision == Run.revision
-
-command ∈ DecisionRequest.allowed_commands
-```
-
----
-
-## 8.1 CAS 防陈旧请求
-
-Resolve 时：
+服务器：
 
 ```sql
 UPDATE runs
-SET revision = revision + 1
+SET control_revision = control_revision + 1
 WHERE id = :run_id
-  AND revision = :expected_revision;
+  AND control_revision = :expected_control_revision;
 ```
 
-若：
+如果：
 
 ```text
-affected_rows != 1
+affected rows != 1
 ```
 
 返回：
 
-```http
-409 Conflict
-```
-
-业务错误：
-
 ```text
-STALE_DECISION
+409 STALE_DECISION
 ```
-
-这样自然处理：
-
-* 用户双击；
-* 两个浏览器 Tab；
-* 旧页面操作；
-* 请求重试；
-* WebSocket 延迟。
 
 ---
 
-# 9. FailureReport：冻结失败证据
+## 7.5 解决的问题
 
-## 9.1 FailureReport 必须在失败发生时创建
+这一机制直接解决：
 
-禁止 `revise_plan` 执行时再动态：
-
-```python
-checkpoint.load_current_failure()
+```text
+双击按钮
+两个浏览器 Tab
+旧 WebSocket UI
+重复 HTTP 请求
+用户在 Run 已恢复后再次点击旧决策
 ```
+
+---
+
+# 8. FailureReport
+
+## 8.1 Failure 必须在暂停前冻结
+
+禁止：
+
+```text
+进入 REVISE_PLAN
+ ↓
+临时读取“当前 checkpoint 的错误”
+```
+
+因为错误上下文可能已经发生变化。
 
 正确流程：
 
 ```text
-QA Attempt Exhausted
+Failure occurs
  ↓
-Create immutable FailureReport F1
+Create FailureReport
  ↓
-Create DecisionRequest referring F1
+Persist
+ ↓
+Create HITL
  ↓
 PAUSE
 ```
 
 ---
 
-## 9.2 FailureReport 数据模型
-
-建议：
+## 8.2 FailureReport 建议结构
 
 ```json
 {
@@ -999,6 +841,9 @@ PAUSE
   "candidate_revision_id": "candidate_8",
 
   "failure_class": "CAPABILITY_MISMATCH",
+  "classification_source": "CAPABILITY_VALIDATOR",
+  "classification_confidence": 1.0,
+
   "failure_stage": "PLAYTEST",
 
   "attempt_count": 3,
@@ -1012,52 +857,63 @@ PAUSE
     },
     {
       "attempt": 2,
-      "stage": "playtest",
-      "error_code": "PLAYTEST_TIMEOUT",
+      "stage": "runtime",
+      "error_code": "RUNTIME_ERROR",
       "summary": "..."
     }
   ],
 
   "diagnosis": {
     "summary": "...",
-    "confidence": 0.87,
     "suggested_recovery": "REVISE_PLAN"
   },
 
   "resource_usage": {
-    "sandbox_seconds": 84,
-    "llm_tokens": 12345
+    "sandbox_seconds": 83,
+    "llm_tokens": 12000
   },
 
   "created_at": "..."
 }
 ```
 
-FailureReport 创建后不可修改。
+---
 
-如需重新诊断，创建：
+## 8.3 FailureReport 不可变
+
+创建后不覆盖：
 
 ```text
-FailureDiagnosisRevision
+F1
 ```
 
-或新的报告。
+如之后产生新错误：
 
-P0 可暂不拆 Diagnosis Revision。
+```text
+F2
+```
+
+不能更新 F1。
+
+这样能够稳定回答：
+
+> 用户当时为什么看到“建议修改策划”？
 
 ---
 
-# 10. Failure Classification
+# 9. FailureClass 判定机制
 
-停止使用简单：
+FailureClass 不能单纯交给 LLM 自由判断。
 
-```text
-product / infra
-```
+这是 Recovery 模型中最关键的安全边界之一。
 
-二分类。
+采用：
 
-建议最少：
+> **Deterministic First + Validator Second + LLM Assisted Fallback + UNKNOWN Conservative Path**
+
+---
+
+## 9.1 FailureClass
 
 ```python
 class FailureClass(StrEnum):
@@ -1072,100 +928,304 @@ class FailureClass(StrEnum):
 
 ---
 
-## 10.1 Recovery Policy
+## 9.2 第一层：确定性规则
 
-| FailureClass            | 默认动作              | HITL              |
-| ----------------------- | ----------------- | ----------------- |
-| `INFRA_TRANSIENT`       | 自动 infra retry    | 否                 |
-| `IMPLEMENTATION_DEFECT` | CodeQaLoop repair | retry budget 耗尽后是 |
-| `CAPABILITY_MISMATCH`   | 推荐 `REVISE_PLAN`  | 是                 |
-| `ACCEPTANCE_MISMATCH`   | 推荐 `REVISE_PLAN`  | 是                 |
-| `RESOURCE_EXCEEDED`     | 自动降级建议 / 用户选择     | 是                 |
-| `POLICY_SECURITY`       | 禁止继续原方案，要求调整      | 是                 |
-| `UNKNOWN`               | 默认保守进入人工恢复        | 是                 |
-
----
-
-## 10.2 `sandbox_failed` 不再等价于需要用户决策
+结构化基础设施信号优先。
 
 例如：
 
 ```text
-Sandbox API 503
+HTTP 502 / 503 from sandbox control plane
+sandbox allocation timeout
+browser launch infrastructure error
+RabbitMQ transport failure
 ```
 
-应：
+直接：
 
 ```text
 INFRA_TRANSIENT
- ↓
-automatic retry
 ```
 
-而不是：
+例如：
 
 ```text
-sandbox_failed
- ↓
-让用户选择 revise_plan
+TypeScript compiler error
+ReferenceError
+module resolution caused by generated source
 ```
 
-只有 Sandbox 暴露出的真实原因属于：
+优先：
 
 ```text
-CAPABILITY_MISMATCH
+IMPLEMENTATION_DEFECT
+```
+
+例如：
+
+```text
+memory hard limit
+bundle size hard limit
+sandbox execution quota
+```
+
+直接：
+
+```text
 RESOURCE_EXCEEDED
+```
+
+Policy Engine 明确拒绝：
+
+```text
 POLICY_SECURITY
 ```
 
-时才进入语义恢复。
+这些硬规则不能被 LLM 覆盖。
 
 ---
 
-# 11. Artifact Revision：不可变产物模型
+## 9.3 第二层：Capability Validator
 
-## 11.1 Artifact 类型
-
-正式引入 Artifact Revision 概念。
-
-至少包含：
+若当前 Plan 声明：
 
 ```text
-PLAN
-QA_CONTRACT
-ART_DIRECTION
-CANDIDATE
-QA_REPORT
+realtime_multiplayer = true
 ```
 
-每次生成新版本创建新 ID。
+但 Runtime CapabilityProfile：
+
+```text
+realtime_multiplayer = false
+```
+
+则确定性得到：
+
+```text
+CAPABILITY_MISMATCH
+```
+
+这类结果：
+
+```text
+classification_source = CAPABILITY_VALIDATOR
+classification_confidence = 1.0
+```
+
+---
+
+## 9.4 第三层：LLM Assisted Diagnosis
+
+只有无法通过结构化规则确定时，才允许 LLM 对以下问题做辅助诊断：
+
+```text
+IMPLEMENTATION_DEFECT
+vs
+ACCEPTANCE_MISMATCH
+vs
+suspected CAPABILITY_MISMATCH
+vs
+UNKNOWN
+```
+
+LLM 输入必须是结构化、清洗后的 Failure Evidence。
+
+LLM 输出必须是 Schema：
+
+```json
+{
+  "candidate_class": "ACCEPTANCE_MISMATCH",
+  "evidence": [],
+  "reason": "..."
+}
+```
+
+---
+
+## 9.5 不信任 LLM 自报 confidence
+
+禁止直接采用：
+
+```json
+{
+  "confidence": 0.93
+}
+```
+
+作为安全决策依据。
+
+`classification_confidence` 必须由系统依据：
+
+```text
+rule strength
+validator result
+evidence coverage
+signal consistency
+```
+
+计算。
+
+---
+
+## 9.6 UNKNOWN 保守策略
+
+证据不足或者冲突时：
+
+```text
+UNKNOWN
+```
+
+禁止为了“必须分到某一类”而强行分类。
+
+UNKNOWN 默认：
+
+```text
+不自动修改任何用户语义
+```
+
+进入通用恢复 UI：
+
+```text
+再次尝试
+修改策划
+取消
+```
+
+但 UI 不显示：
+
+> 系统确认策划不可实现
+
+这类强结论。
+
+---
+
+## 9.7 分类监控
+
+新增：
+
+```text
+forge_failure_class_total
+forge_failure_class_unknown_total
+forge_failure_class_override_total
+forge_failure_recovery_mismatch_total
+```
+
+如果未来允许用户：
+
+```text
+“这不是策划问题”
+```
+
+显式纠正诊断，则记录：
+
+```text
+forge_failure_class_user_corrected_total
+```
+
+这将成为后续优化分类器的重要数据。
+
+---
+
+# 10. RecoveryPolicy
+
+FailureClass 与恢复策略单独建模。
+
+| FailureClass            | 默认恢复                    | 是否 HITL     |
+| ----------------------- | ----------------------- | ----------- |
+| `INFRA_TRANSIENT`       | `RETRY_INFRA`           | 否           |
+| `IMPLEMENTATION_DEFECT` | 自动 Code Repair          | Budget 耗尽后是 |
+| `CAPABILITY_MISMATCH`   | 推荐 `REVISE_PLAN`        | 是           |
+| `ACCEPTANCE_MISMATCH`   | 推荐 `REVISE_PLAN`        | 是           |
+| `RESOURCE_EXCEEDED`     | Replan / Retry / Cancel | 是           |
+| `POLICY_SECURITY`       | 必须调整 Plan 或 Cancel      | 是           |
+| `UNKNOWN`               | Retry / Replan / Cancel | 是           |
+
+核心逻辑从：
+
+```text
+phase → action
+```
+
+改为：
+
+```text
+failure_class
++
+retry_budget
++
+runtime_context
+ ↓
+RecoveryPolicy
+ ↓
+allowed_commands
+```
+
+### RETRY_INFRA 与图内 infra_replay 的边界
+
+CodeQaLoop 现有图内 `infra_replay` 环（attempt +1、同 Candidate 重放）**保留不动**，
+它负责执行过程中的自动 infra 重试。
+
+`RETRY_INFRA` 命令只用于一个场景：
+
+```text
+Run 已经因 infra 原因暂停（如 infra retry budget 耗尽进入 HITL）
+ ↓
+用户 / 系统恢复执行
+```
+
+即：图内环管执行中，命令管恢复时。二者不是替代关系，禁止在引入命令式恢复时删除图内 `infra_replay`。
+
+---
+
+# 11. PlanRevision 与 Artifact Lineage
+
+## 11.1 不可变 Revision
+
+生产模型：
+
+```text
+PlanRevision P1
+PlanRevision P2
+
+ArtRevision A1
+ArtRevision A2
+
+CandidateRevision C1
+CandidateRevision C2
+```
+
+禁止：
+
+```text
+design_doc = new_value
+```
+
+覆盖全部历史语义。
 
 ---
 
 ## 11.2 PlanRevision
 
-示例：
+建议：
 
 ```json
 {
   "id": "plan_4",
   "run_id": "run_1",
-  "artifact_type": "PLAN",
-
   "revision": 4,
 
   "supersedes": "plan_3",
 
+  "schema_version": 2,
+
   "payload_uri": "...",
   "payload_hash": "...",
 
-  "created_by_command_id": "cmd_9",
+  "created_by_command_id": "cmd_123",
 
   "created_at": "..."
 }
 ```
-
-禁止直接覆盖 P3。
 
 ---
 
@@ -1174,12 +1234,9 @@ QA_REPORT
 ```json
 {
   "id": "art_5",
+  "run_id": "run_1",
 
-  "artifact_type": "ART_DIRECTION",
-
-  "dependencies": {
-    "plan_revision_id": "plan_4"
-  },
+  "plan_revision_id": "plan_4",
 
   "dependency_fingerprint": "...",
 
@@ -1195,233 +1252,223 @@ QA_REPORT
 {
   "id": "candidate_12",
 
-  "artifact_type": "CANDIDATE",
+  "run_id": "run_1",
 
-  "dependencies": {
-    "plan_revision_id": "plan_4",
-    "art_revision_id": "art_5",
-    "qa_contract_revision_id": "qa_4"
-  },
+  "plan_revision_id": "plan_4",
+  "art_revision_id": "art_5",
 
-  "status": "ACTIVE"
+  "status": "ACTIVE",
+  "qa_status": "PASSED"
 }
 ```
 
 ---
 
-# 12. Artifact 状态
+# 12. Art 失效与复用策略
 
-建议：
+只在本节定义一次，其他章节不重复定义。
+
+## 12.1 P0 默认策略
+
+Plan Revision 改变后：
 
 ```text
-ACTIVE
-STALE
-SUPERSEDED
-FAILED
-PROMOTED
-ARCHIVED
+P1 → P2
+```
+
+默认：
+
+```text
+A1 → STALE
+C1 → STALE
+```
+
+重新生成 Art。
+
+原因：
+
+> 正确性优先于成本优化。
+
+---
+
+## 12.2 P1 优化：Dependency Fingerprint
+
+后续允许判断：
+
+```text
+Plan 改动是否实际影响 Art
+```
+
+例如 Art 依赖：
+
+```text
+visual_style
+color_palette
+entity_visual_description
+ui_visual_structure
+environment_style
+animation_requirements
+asset_needs
+```
+
+生成：
+
+```text
+art dependency projection
+ ↓
+canonical serialization
+ ↓
+SHA-256
 ```
 
 ---
 
-## 12.1 Replan 后禁止删除旧 Candidate
+## 12.3 Canonicalization 必须钉死
 
-旧行为计划：
+Fingerprint 协议必须有版本，例如：
 
 ```text
-candidate_version = null
+art-dependency-fingerprint-v1
 ```
 
-调整为：
+Canonicalization 规则：
+
+```text
+Unicode normalization = NFC
+
+JSON object keys = lexical sorted
+
+encoding = UTF-8
+
+whitespace = none
+
+JSON separators = fixed
+
+null representation = fixed
+
+number serialization = fixed
+```
+
+数组：
+
+> 默认保留顺序。
+
+只有字段 Schema 明确声明：
+
+```text
+semantic set
+```
+
+时，才允许排序后 Hash。
+
+禁止通用地对所有数组排序。
+
+否则：
+
+```text
+关卡 1, 2, 3
+```
+
+和：
+
+```text
+关卡 3, 2, 1
+```
+
+可能被错误认为相同。
+
+---
+
+## 12.4 Fingerprint 协议升级
+
+如果 Dependency Projection Schema 变化：
+
+```text
+v1 → v2
+```
+
+禁止直接比较不同版本 Hash。
+
+必须：
+
+```text
+fingerprint_version == same
+```
+
+才能复用。
+
+---
+
+# 13. Promotion Guard
+
+旧 Candidate 不删除。
+
+Plan 改动后：
 
 ```text
 active_candidate_revision_id = null
 ```
 
-历史 Candidate 保留：
+同时：
 
 ```text
-candidate_8.status = STALE
-candidate_8.stale_reason = PLAN_SUPERSEDED
+C1.status = STALE
+C1.stale_reason = PLAN_SUPERSEDED
 ```
 
-这样保留：
-
-* Debug 证据；
-* 成本审计；
-* 用户历史；
-* 失败复现；
-* 模型评估数据；
-* 版本比较能力。
-
----
-
-# 13. Artifact Dependency 与失效传播
-
-基本依赖：
-
-```text
-Plan P1
- │
- ├── QAContract Q1
- │
- └── Art A1
-      │
-      └── Candidate C1
-```
-
-Plan P2 创建以后不能简单认为所有下游一定失效。
-
-需要：
-
-```text
-dependency compatibility check
-```
-
----
-
-# 14. Dependency Fingerprint
-
-仅依赖：
-
-```text
-plan_rev
-```
-
-过于粗粒度。
-
-例如：
-
-```text
-P1：敌人血量 = 100
-P2：敌人血量 = 120
-```
-
-可能不影响 Art。
-
-因此 Art 生成时计算：
-
-```text
-art_dependency_fingerprint
-```
-
-输入可包括：
-
-```text
-visual_style
-color_palette
-asset_needs
-entity_visual_descriptions
-ui_structure
-environment_visual_requirements
-animation_requirements
-```
-
-执行：
-
-```text
-canonical JSON
- ↓
-SHA-256
-```
-
-得到：
-
-```text
-art_dependency_fingerprint
-```
-
-新 Plan P2：
-
-```text
-fingerprint(P1) == fingerprint(P2)
-```
-
-则 A1 可以继续兼容。
-
----
-
-## 14.1 默认策略
-
-P0：
-
-> Replan 后默认重新生成 Art。
-
-P1：
-
-> 增加 Dependency Fingerprint，在确定 Art 依赖未变化时允许复用。
-
-这样保证 P0 正确性优先，P1 再优化成本。
-
----
-
-# 15. Promotion Guard
-
-任何 Candidate Promote 前必须执行最终 invariant。
-
-至少：
+任何 Promote 前执行最终 invariant：
 
 ```python
 candidate.plan_revision_id == run.active_plan_revision_id
 
 candidate.art_revision_id == run.active_art_revision_id
 
-candidate.qa_contract_revision_id == run.active_qa_contract_revision_id
-
 candidate.status == ACTIVE
 
 candidate.qa_status == PASSED
 ```
 
-并再次确认：
+P1 Art Fingerprint 上线以后再增加：
 
 ```text
-dependency fingerprints compatible
+candidate dependency compatibility == true
 ```
 
-任何条件失败：
+任一失败：
 
 ```text
 PROMOTION_REJECTED_STALE_ARTIFACT
 ```
 
-不能依赖前面路由“应该已经正确”。
+Promotion Guard 是最后一道安全边界。
 
-Promotion Guard 是最后安全边界。
+不能假设：
 
----
-
-# 16. CapabilityProfile：替代关键词黑名单
-
-删除以下设计：
-
-> technical_constraints / acceptance_criteria 不允许出现“3D”“物理引擎”“网络同步”等关键词。
-
-关键词 lint 无法正确表达真正的平台能力。
-
-例如：
-
-```text
-“不要使用 3D”
-```
-
-并不要求 3D。
-
-```text
-“模拟 3D 视觉效果”
-```
-
-也未必需要真正 WebGL 3D。
+> 前面的 route 应该已经做对了。
 
 ---
 
-## 16.1 Runtime Capability Profile
+# 14. Capability Validation
 
-平台维护结构化：
+禁止使用：
+
+```text
+"3D"
+"物理引擎"
+"网络同步"
+```
+
+关键词黑名单判断 Plan 是否可实现。
+
+---
+
+## 14.1 CapabilityProfile
+
+平台维护：
 
 ```json
 {
-  "profile_version": "2026-08-17.1",
+  "profile_version": "2026-08-18.1",
 
   "renderers": [
     "dom",
@@ -1431,14 +1478,9 @@ Promotion Guard 是最后安全边界。
   ],
 
   "webgl_3d": false,
-
   "physics_2d": true,
-
   "realtime_multiplayer": false,
-
   "backend_server": false,
-
-  "persistent_database": false,
 
   "limits": {
     "max_build_seconds": 120,
@@ -1450,112 +1492,128 @@ Promotion Guard 是最后安全边界。
 
 ---
 
-## 16.2 Plan RequiredCapabilities
+## 14.2 RequiredCapabilities 直接进入 Design Doc Schema
 
-Plan 生成后结构化抽取：
+不增加单独一次：
+
+```text
+LLM capability extraction
+```
+
+调用。
+
+Plan Agent 一次性输出：
 
 ```json
 {
-  "renderer": "canvas2d",
-  "physics": "2d_optional",
-  "multiplayer": false,
-  "backend": false,
-  "estimated_asset_count": 24
+  "title": "...",
+
+  "required_capabilities": {
+    "renderer": "canvas2d",
+    "physics_2d": true,
+    "realtime_multiplayer": false,
+    "backend_server": false
+  },
+
+  "acceptance_contract": [],
+
+  "..."
 }
 ```
 
-然后执行确定性：
+优点：
 
 ```text
-RequiredCapabilities
-        ×
+少一次模型调用
+减少信息重复
+降低漂移
+Schema 单一来源
+```
+
+---
+
+## 14.3 Deterministic Capability Validator
+
+执行：
+
+```text
+design_doc.required_capabilities
+       ×
 CapabilityProfile
-        ↓
+       ↓
 CapabilityValidator
 ```
 
-失败：
+明确不支持：
 
 ```text
 CAPABILITY_MISMATCH
 ```
 
-在 Plan Confirm 之前处理。
+---
+
+## 14.4 Developability Precheck
+
+推荐：
+
+```text
+Plan Generation
+ ↓
+Schema Validation
+ ↓
+Capability Validation
+ ↓
+Budget Validation
+ ↓
+Acceptance Validation
+ ↓
+Plan Confirm
+```
+
+明显不可实现的问题尽量不进入 Art / Code。
 
 ---
 
-# 17. Developability Precheck
+# 15. Acceptance Contract
 
-新流程：
-
-```text
-PLAN NODE
- ↓
-schema validation
- ↓
-requirement extraction
- ↓
-capability validation
- ↓
-budget estimation
- ↓
-acceptance criteria validation
- ↓
-PLAN_CONFIRM
-```
-
-如果明显不可开发：
-
-```text
-PLAN
- ↓
-PRECHECK FAILED
- ↓
-自动要求 Plan Agent 重新约束一次
- ↓
-仍失败
- ↓
-向用户展示能力冲突
-```
-
-避免进入 Art 和 Code 后再失败。
-
----
-
-# 18. QA Contract
-
-当前：
-
-```text
-design_doc.acceptance_criteria
-```
-
-已经承担机器验收规格职责。
-
-正式拆出：
+本方案取消独立：
 
 ```text
 QAContractRevision
 ```
 
-示例：
+Artifact。
+
+原因：
+
+1. 当前 Acceptance Criteria 本质属于 Plan；
+2. Plan Revision 改变后 QA Contract 必然一起改变；
+3. 独立 Artifact 会制造新的双版本一致性问题；
+4. 当前没有独立生命周期需求。
+
+因此结构化为：
+
+```text
+PlanRevision.acceptance_contract
+```
+
+---
+
+## 15.1 示例
 
 ```json
 {
-  "id": "qa_7",
-
-  "criteria": [
+  "acceptance_contract": [
     {
       "id": "AC-01",
-      "description": "玩家可以使用方向键移动",
+      "description": "玩家可以通过方向键移动",
       "severity": "BLOCKER",
       "testability": "AUTOMATED",
-      "strategy": "PLAYWRIGHT",
-      "timeout_seconds": 5
+      "strategy": "PLAYWRIGHT"
     },
     {
       "id": "AC-02",
-      "description": "整体视觉风格应具有轻松氛围",
+      "description": "整体视觉保持轻松风格",
       "severity": "NON_BLOCKER",
       "testability": "LLM_REVIEW"
     }
@@ -1563,44 +1621,52 @@ QAContractRevision
 }
 ```
 
-这样能够区分：
+---
+
+## 15.2 未来拆分条件
+
+只有当未来出现以下需求时再单独 ADR：
 
 ```text
-Implementation Failure
+同一 Plan 多套 QA Profile
+QA Contract 独立人工编辑
+不同 Runtime 使用不同验收契约
+QA Contract 有独立审批生命周期
 ```
 
-与：
-
-```text
-Specification / Acceptance Failure
-```
+当前明确不拆。
 
 ---
 
-# 19. REVISE_PLAN 工作流
+# 16. REVISE_PLAN 执行流程
 
-## 19.1 触发来源
+## 16.1 支持入口
 
-本期支持：
+最终支持：
 
 ```text
 PLAN_CONFIRM
 ART_CONFIRM
 QA_RECOVERY
-CAPABILITY_PRECHECK
 ```
 
-其中：
+Capability Precheck 在用户首次确认前可以触发 Plan Agent 自动自修复，不一定产生 HITL。
 
-### Plan Confirm
+---
+
+## 16.2 PLAN_CONFIRM
+
+允许：
 
 ```text
+APPROVE_PLAN
 REVISE_PLAN
+CANCEL_RUN
 ```
 
-属于正常策划编辑。
+---
 
-### Art Confirm
+## 16.3 ART_CONFIRM
 
 允许：
 
@@ -1609,13 +1675,22 @@ SELECT_ART_A
 SELECT_ART_B
 REVISE_ART
 REVISE_PLAN
+CANCEL_RUN
 ```
 
-用户如果在看美术时发现上游策划范围不合理，不要求 Cancel 整个 Run。
+例如用户看到美术后发现：
 
-### QA Recovery
+> 其实我不要十个角色，只需要三个。
 
-允许：
+这是 Plan Scope 问题。
+
+不要求用户取消整个 Run。
+
+---
+
+## 16.4 QA_RECOVERY
+
+根据 RecoveryPolicy 动态产生，例如：
 
 ```text
 RETRY_IMPLEMENTATION
@@ -1623,66 +1698,34 @@ REVISE_PLAN
 CANCEL_RUN
 ```
 
-具体 Allowed Commands 由 Recovery Policy 决定。
+或者：
+
+```text
+REVISE_PLAN
+CANCEL_RUN
+```
 
 ---
 
-# 20. REVISE_PLAN 输入
-
-模型输入不是直接拼原始 checkpoint。
-
-输入为稳定对象：
+## 16.5 REVISE_PLAN 输入
 
 ```text
 Current PlanRevision
 +
 User Feedback
 +
-FailureReport（如存在）
+FailureReport（如果有）
 +
 CapabilityProfile
 +
-Budget Context
+Remaining Budget
 ```
 
-例如：
-
-```text
-当前策划版本：P3
-
-用户修改意见：
-改为 2D 俯视视角，不需要多人同步。
-
-上一轮失败摘要：
-FailureClass: CAPABILITY_MISMATCH
-
-Attempt 1:
-BUILD_ERROR ...
-
-Attempt 2:
-PLAYTEST_TIMEOUT ...
-
-Attempt 3:
-RESOURCE_EXCEEDED ...
-
-诊断：
-当前策划同时要求 3D 场景、大地图以及实时多人同步，
-超出当前运行时能力。
-
-当前平台能力：
-- Canvas2D: supported
-- Phaser2D: supported
-- WebGL 3D: unsupported
-- Realtime Multiplayer: unsupported
-```
+禁止直接把整个 checkpoint 无选择注入模型。
 
 ---
 
-# 21. REVISE_PLAN 结构化输出
-
-禁止只让模型输出自然语言“保留项 / 削减项 / 替代项”。
-
-建议 schema：
+## 16.6 结构化输出
 
 ```json
 {
@@ -1692,19 +1735,19 @@ RESOURCE_EXCEEDED ...
     {
       "requirement_id": "REQ-12",
       "action": "REPLACE",
-      "from": "3D third-person open world",
-      "to": "2D top-down bounded map",
-      "reason": "current runtime does not support required 3D stack"
+      "from": "3D open world",
+      "to": "2D top-down bounded world",
+      "reason": "runtime capability mismatch"
     }
   ],
 
   "retained_requirements": [],
-
   "removed_requirements": [],
-
   "replaced_requirements": [],
 
   "required_capabilities": {},
+
+  "acceptance_contract": [],
 
   "design_doc": {}
 }
@@ -1712,192 +1755,75 @@ RESOURCE_EXCEEDED ...
 
 ---
 
-# 22. Plan Revision Validation
-
-模型输出后必须经过 deterministic validation：
+## 16.7 Validation Pipeline
 
 ```text
-JSON Schema
+LLM Output
  ↓
-Design Doc Validator
+JSON Schema Validation
  ↓
-Capability Validator
+Design Consistency Validation
  ↓
-QA Contract Validator
+Capability Validation
  ↓
-Budget Validator
+Acceptance Contract Validation
  ↓
-Consistency Validator
+Budget Validation
 ```
 
-任何一层失败：
-
-```text
-LLM repair
-```
-
-达到 validator retry budget 后：
-
-```text
-进入人工错误处理
-```
-
-而不是把非法 Plan 写进 active state。
+非法输出不能写入 Active Plan。
 
 ---
 
-# 23. Failure Context Prompt Safety
+## 16.8 新 Plan 必须再次 HITL
 
-以下内容全部视为 **Untrusted Input**：
-
-* Console Log
-* Browser DOM Text
-* Generated Code
-* Dependency Error
-* Playtest Error
-* External Asset Content
-* Model-generated diagnostics
-
-进入 Replan Prompt 前：
+Replan 产生：
 
 ```text
-truncate
- ↓
-redact secrets
- ↓
-normalize
- ↓
-structure
- ↓
-delimiter wrap
+P2
+```
+
+之后必须：
+
+```text
+PLAN_CONFIRM
 ```
 
 禁止：
 
-```python
-prompt += raw_console_logs
-```
-
-FailureReport 中优先存：
-
 ```text
-structured error
-+
-sanitized excerpt
-```
-
-而不是无上限保存并注入全部原始日志。
-
----
-
-# 24. Retry Budget 与成本控制
-
-不采用：
-
-> revise_plan 默认无限，只依赖 run 总 token / 总时长。
-
-生产环境需要分层预算：
-
-```text
-run_cost_budget
-
-llm_token_budget
-
-sandbox_runtime_budget
-
-implementation_retry_budget
-
-infra_retry_budget
-
-plan_revision_budget
-```
-
-默认值示例：
-
-```text
-implementation retry = 3
-infra transient retry = 5
-replan = 2
-```
-
-实际配置化，不硬编码。
-
----
-
-## 24.1 Retry 行为
-
-### Infra Retry
-
-推荐：
-
-```text
-exponential backoff
-+
-jitter
-```
-
-不进入用户 HITL。
-
-### Implementation Retry
-
-CodeQaLoop 内执行，耗尽后生成 FailureReport。
-
-### Replan Budget
-
-达到阈值后：
-
-```text
-不再自动建议无限回炉
-```
-
-向用户展示：
-
-> 当前 Run 已进行了多次策划调整。继续将产生额外生成和测试成本。
-
-用户显式确认后才允许继续。
-
----
-
-# 25. RabbitMQ + PostgreSQL 可靠性
-
-## 25.1 Transactional Outbox
-
-HITL Resolve 不直接：
-
-```text
-DB commit
-then RabbitMQ publish
-```
-
-改成一个 PostgreSQL Transaction：
-
-```text
-BEGIN
-
-CAS Run Revision
-
-Resolve DecisionRequest
-
-Insert RunCommand
-
-Insert OutboxEvent
-
-COMMIT
-```
-
-独立 Publisher：
-
-```text
-SELECT pending outbox
+Failure
  ↓
-RabbitMQ publish
+LLM Replan
  ↓
-mark published
+直接 Code
 ```
+
+因为 P2 已经改变用户产品定义。
 
 ---
 
-## 25.2 RunCommand
+# 17. 消息可靠性与 Command 幂等
+
+## 17.1 复用现有 task_outbox
+
+不增加新的：
+
+```text
+outbox_events
+```
+
+所有 Resume Command 仍使用：
+
+```text
+task_outbox
+```
+
+完成可靠发布。
+
+---
+
+## 17.2 新增 run_commands
 
 建议：
 
@@ -1906,12 +1832,18 @@ id
 run_id
 command_type
 payload
-decision_request_id
+
+source
+decision_id nullable
+
 idempotency_key
+
 status
+
 created_at
 started_at
 completed_at
+failed_at
 ```
 
 Status：
@@ -1926,727 +1858,542 @@ CANCELLED
 
 ---
 
-## 25.3 Worker 幂等
+## 17.3 Resume Transaction
 
-Worker 收到：
+统一：
+
+```text
+BEGIN
+
+Validate expected control_revision
+
+Normalize legacy decision → RunCommand
+
+Insert RunCommand
+
+Write/update resume_grant
+
+Insert task_outbox
+
+Increment control_revision
+
+COMMIT
+```
+
+注意：
+
+> 当前 `resume_grant + task_outbox` 原子性已经存在。
+
+本阶段真实增量是：
+
+```text
+RunCommand insert
++
+control_revision CAS
+```
+
+加入同一事务。
+
+---
+
+## 17.4 Worker 幂等
+
+收到：
 
 ```text
 command_id = CMD123
 ```
 
-执行前：
+执行前检查：
 
 ```text
-检查 CMD123 是否已经 SUCCEEDED
+CMD123.status
 ```
 
-如果已执行：
+如果：
+
+```text
+SUCCEEDED
+```
+
+则：
 
 ```text
 ACK
 return
 ```
 
-如果 Worker：
+如果：
+
+```text
+RUNNING
+```
+
+需要结合现有 execution lease 判断：
+
+```text
+仍有有效 owner → 不重复执行
+lease 已失效 → 接管恢复
+```
+
+---
+
+## 17.5 Worker Crash 场景
+
+```text
+Command 执行业务写入成功
+ ↓
+DB COMMIT
+ ↓
+Worker 在 RabbitMQ ACK 前 Crash
+ ↓
+RabbitMQ Redelivery
+```
+
+第二次消费：
+
+```text
+发现 Command 已 SUCCEEDED
+ ↓
+ACK
+```
+
+不能再次生成：
+
+```text
+Plan P3
+```
+
+---
+
+# 18. Cancel / Pause / Resume 收敛
+
+## 18.1 CANCEL_RUN 只有一个业务语义
+
+当前已有：
+
+```text
+/cancel
+```
+
+以及 Redis `_check_ctrl` 控制位。
+
+引入：
+
+```text
+CANCEL_RUN
+```
+
+后不能同时存在两套取消语义。
+
+---
+
+## 18.2 对外 Endpoint 可以保留
+
+保留现有：
+
+```text
+POST /cancel
+```
+
+作为 Public API。
+
+但内部统一转换为：
+
+```text
+RunCommandType.CANCEL_RUN
+```
+
+---
+
+## 18.3 PostgreSQL 是取消 SoT
+
+Cancel 请求事务内：
+
+```text
+insert CANCEL_RUN command
+set durable cancel_requested state
+increment control_revision
+invalidate current HITL if needed
+```
+
+事务成功后再 best-effort：
+
+```text
+set Redis cancel control bit
+```
+
+---
+
+## 18.4 Redis 只是快速中断通道
+
+Redis `_check_ctrl` 的定位调整为：
+
+> Low-latency Interrupt Signal
+
+而不是：
+
+> Cancellation Source of Truth
+
+即使：
 
 ```text
 DB commit success
-RabbitMQ ACK 前 crash
+Redis write failure
 ```
 
-RabbitMQ redelivery 后不会产生第二次业务效果。
+系统仍然知道该 Run 已请求 Cancel。
+
+Worker 在安全点除检查 Redis 外，也必须能够通过持久化状态最终观察到 Cancel。
 
 ---
 
-# 26. Run Execution Lock
+## 18.5 Pause
 
-现有 execution lock 保留。
+`/pause` 本期不强制改造成 Workflow Recovery Command。
 
-建议锁粒度：
+Pause 属于执行控制，不属于产品语义恢复。
 
-```text
-run_id
-```
-
-保证同一个 Run 同时只有一个 active workflow mutation。
-
-但锁不是幂等替代品。
-
-生产正确性需要：
+但它同样必须影响：
 
 ```text
-Run Lock
-+
-Run Revision CAS
-+
-Command Idempotency
+control_revision
 ```
 
-三者同时存在。
+避免旧 HITL 决策在控制状态变化后继续提交。
 
 ---
 
-# 27. Workflow Versioning
+# 19. Workflow Versioning
 
-本方案明确要求增加：
+Run 创建时冻结：
 
 ```text
 workflow_version
 ```
 
-Run 创建时冻结。
-
 例如：
 
 ```json
 {
-  "run_id": "...",
   "workflow_version": 13
 }
 ```
 
 ---
 
-## 27.1 为什么必须版本化
+## 19.1 为什么需要
 
-滚动发布过程中可能出现：
+滚动发布期间：
 
 ```text
-API = New Version
-
-Worker A = Old Version
-Worker B = New Version
+API = New
+Worker A = Old
+Worker B = New
 ```
 
-如果新 API 产生：
+新 API 可能产生：
 
 ```text
 REVISE_PLAN
 ```
 
-旧 Worker 不认识该命令，则存在生产事故风险。
+旧 Worker 不允许：
 
-因此 Worker 执行前验证：
+```text
+“不认识但继续按旧逻辑猜”
+```
+
+---
+
+## 19.2 Worker Capability
+
+Worker 明确声明：
 
 ```text
 supported_workflow_versions
 ```
 
-不支持：
+收到不支持版本：
 
 ```text
-NACK / move to compatibility worker / fail-safe
+不得执行
 ```
 
-禁止默默使用新逻辑解释旧 Run。
+进入：
+
+```text
+compatibility routing
+或 fail-safe retry
+```
 
 ---
 
-## 27.2 三类版本分离
+## 19.3 版本概念分离
 
-至少区分：
+必须区分：
 
 ```text
 workflow_version
 checkpoint_schema_version
 artifact_schema_version
+fingerprint_version
 ```
 
-含义：
-
-### workflow_version
-
-业务状态机语义。
-
-### checkpoint_schema_version
-
-Run state 序列化格式。
-
-### artifact_schema_version
-
-Plan / Art / QA Contract 等数据格式。
-
-禁止用一个 `version` 字段同时表达三个概念。
+四者语义不同。
 
 ---
 
-# 28. Feature / Rollout Gate
+# 20. Prompt 与失败证据安全
 
-原方案“无需 Feature Flag”调整为：
-
-本功能必须具备最小发布门控。
-
-例如：
+以下全部视为不可信输入：
 
 ```text
-replan_recovery_enabled
+generated source code
+browser console
+DOM text
+dependency error
+asset metadata
+playtest output
+external page content
+LLM diagnosis
 ```
 
-作用不是长期业务逻辑，而是发布安全。
-
-推荐：
+进入 Replan Agent 前：
 
 ```text
-Internal
+truncate
  ↓
-5%
+secret redaction
  ↓
-25%
+normalization
  ↓
-100%
+structured extraction
+ ↓
+explicit untrusted delimiter
 ```
 
-发生问题时：
-
-```text
-关闭新 DecisionRequest 中的 REVISE_PLAN
-```
-
-已有旧 Run 仍按照冻结的：
-
-```text
-workflow_version
-```
-
-恢复。
-
----
-
-# 29. LangGraph 使用边界
-
-本期：
-
-> **不迁移 LangGraph 原生 persistence / interrupt。**
-
-原因不是原生能力不足，而是当前系统已经拥有稳定：
-
-```text
-PG checkpoint
-RabbitMQ
-HITL API
-resume
-execution lock
-WebSocket lifecycle
-```
-
-迁移会同时影响大量生产语义。
-
-本次只增强现有 Domain Layer。
-
----
-
-## 29.1 后续重新评估条件
-
-当以下情况持续出现时单独 ADR：
-
-* 自研 checkpoint 恢复 bug 明显增多；
-* HITL plumbing 维护成本过高；
-* Workflow State migration 复杂；
-* 大量逻辑重复 LangGraph durable execution；
-* 调试和 replay 成本过高。
-
-原则：
-
-> 同一 Run 只能有一个真正的 Workflow SoT。
-
-禁止长期同时维护两套持久化状态机。
-
----
-
-# 30. route_start 重构
-
-短期仍保留集中路由。
-
-但避免：
+禁止：
 
 ```python
-if phase == ...
-    if decision == ...
-```
-
-不断增长。
-
-推荐：
-
-```python
-TRANSITIONS = {
-    RunCommandType.APPROVE_PLAN: "art_options",
-    RunCommandType.REVISE_PLAN: "revise_plan",
-    RunCommandType.REVISE_ART: "revise_art_options",
-    RunCommandType.RETRY_IMPLEMENTATION: "code_qa_loop",
-}
-```
-
-复杂 recovery 使用函数：
-
-```python
-next_node = recovery_policy.resolve(
-    run=run,
-    command=command,
-    failure_report=failure_report,
-)
-```
-
-`route_start()` 只承担：
-
-```text
-load active command
-validate workflow version
-validate command freshness
-resolve transition
-```
-
-不承担全部业务策略。
-
----
-
-# 31. 新恢复流
-
-## 31.1 QA Implementation Failure
-
-```text
-Code Attempt
- ↓
-IMPLEMENTATION_DEFECT
- ↓
-attempt < budget
- ↓
-automatic Code Repair
-```
-
-预算耗尽：
-
-```text
-FailureReport
- ↓
-DecisionRequest
- ↓
-RETRY_IMPLEMENTATION
-REVISE_PLAN
-CANCEL_RUN
+prompt += raw_logs
 ```
 
 ---
 
-## 31.2 Capability Mismatch
+# 21. Budget 与成本控制
 
-```text
-QA
- ↓
-CAPABILITY_MISMATCH
- ↓
-FailureReport
- ↓
-DecisionRequest
-```
+必须显式区分两个完全不同的概念。
 
-默认 UI 强推荐：
-
-```text
-REVISE_PLAN
-```
-
-仍可根据产品策略允许：
-
-```text
-RETRY_IMPLEMENTATION
-```
-
-但 UI 应提示成功概率低。
-
----
-
-## 31.3 Infra Failure
-
-```text
-Sandbox 503
- ↓
-INFRA_TRANSIENT
- ↓
-Retry Policy
- ↓
-same Candidate replay
-```
-
-不修改：
-
-```text
-Plan
-Art
-Candidate lineage
-```
-
-只有 infra retry budget 耗尽后才通知用户：
-
-```text
-系统暂时无法完成运行环境执行
-```
-
-而不是建议修改策划。
-
----
-
-# 32. Art Confirm 支持回到 Plan
-
-调整原 Non-Goal。
-
-新 `ART_CONFIRM`：
-
-```text
-SELECT_ART_A
-SELECT_ART_B
-REVISE_ART
-REVISE_PLAN
-CANCEL_RUN
-```
-
-典型场景：
-
-用户看到 Art 以后发现：
-
-> 角色太多，我其实只要 3 个。
-
-这是 Scope / Plan 问题，而不是 Art Prompt 问题。
-
-不应要求 Cancel Run。
-
----
-
-# 33. 新的 HITL UI
-
-QA Recovery 卡片建议展示：
-
-```text
-开发未通过
-```
-
-下面分成：
-
-### 失败分类
-
-```text
-当前判断：策划能力与运行环境不匹配
-```
-
-### 关键证据
-
-```text
-- 多次构建失败
-- 当前运行环境不支持实时多人同步
-- 当前方案资源需求超出单局预算
-```
-
-### 系统建议
-
-```text
-建议将：
-3D → 2D
-实时多人 → 单人
-开放世界 → 小型地图
-```
-
-用户可编辑建议。
-
-操作：
-
-```text
-[按建议调整策划]
-[再次尝试实现]
-[取消生成]
-```
-
-内部对应：
-
-```text
-REVISE_PLAN
-RETRY_IMPLEMENTATION
-CANCEL_RUN
-```
-
----
-
-# 34. Replan 后用户确认
-
-任何新的：
-
-```text
-PlanRevision
-```
-
-即使由 FailureReport 自动生成，也必须重新：
-
-```text
-PLAN_CONFIRM
-```
-
-禁止系统自动：
-
-```text
-P1
- ↓ failure
-P2
- ↓ automatically code
-```
-
-因为 P2 很可能修改：
-
-* 核心玩法；
-* Scope；
-* 视觉；
-* Session Length；
-* 验收标准。
-
-这是用户语义变更。
-
----
-
-# 35. Replan 后下游处理
-
-P0 默认：
-
-```text
-P2 created
- ↓
-old Art = STALE
-old Candidate = STALE
- ↓
-PLAN_CONFIRM
- ↓
-regenerate Art
- ↓
-ART_CONFIRM
- ↓
-new Candidate
-```
-
-P1 增加：
-
-```text
-Art dependency fingerprint
-```
-
-如果：
-
-```text
-A1 compatible with P2
-```
-
-可以：
-
-```text
-reuse A1
-```
-
-但必须由系统判定，不让用户通过非结构化选择破坏 invariant。
-
----
-
-# 36. 数据持久化建议
+## 21.1 现有 PLAN_MAX_ATTEMPTS
 
 当前：
 
 ```text
-RunCheckpoint = PostgreSQL SoT
-Redis = Cache
+PLAN_MAX_ATTEMPTS = 3
 ```
 
-继续保留。
+含义是：
 
-但 Checkpoint 不再承担全部历史职责。
+> 单次 Plan 生成过程中的 Schema / Validator Repair Attempts。
 
-最小建议新增：
+它不是用户跨阶段回炉次数。
+
+为避免误用，文档统一称：
 
 ```text
-runs
-
-run_commands
-
-decision_requests
-
-artifacts
-
-failure_reports
-
-outbox_events
+PLAN_GENERATION_REPAIR_MAX_ATTEMPTS
 ```
+
+代码是否立即 rename 可以单独处理。
 
 ---
 
-## 36.1 大 Payload
+## 21.2 新增 REPLAN_MAX_REVISIONS
 
-大对象：
-
-* Design Doc
-* Art spec
-* generated code bundle
-* browser traces
-* screenshots
-* full logs
-
-不建议全部塞 PostgreSQL JSON。
-
-推荐：
+跨阶段策划修订预算使用：
 
 ```text
-Object Storage
+REPLAN_MAX_REVISIONS
 ```
-
-PG 保存：
-
-```text
-URI
-hash
-size
-schema_version
-metadata
-```
-
-小型结构化对象可以继续 JSONB。
-
----
-
-# 37. RunCheckpoint 的定位
-
-RunCheckpoint 只回答：
-
-> 当前工作流执行到哪里？
 
 例如：
 
-```json
-{
-  "active_plan_revision_id": "plan_4",
-  "active_art_revision_id": "art_5",
-  "active_candidate_revision_id": null,
-
-  "phase": "plan_confirm",
-
-  "workflow_version": 13,
-
-  "revision": 42
-}
-```
-
-而：
-
-> 为什么来到这里？
-
-由：
-
 ```text
-RunCommand
-RunEvent
-FailureReport
+2
 ```
 
-解释。
+含义：
+
+> 一个 Run 因后置失败产生的新 PlanRevision 次数上限。
 
 ---
 
-# 38. 可观测性
+## 21.3 其他预算
 
-所有关键事件统一包含：
+建议：
+
+```text
+IMPLEMENTATION_RETRY_MAX_ATTEMPTS
+INFRA_RETRY_MAX_ATTEMPTS
+REPLAN_MAX_REVISIONS
+
+RUN_TOKEN_BUDGET
+RUN_SANDBOX_BUDGET
+RUN_COST_BUDGET
+```
+
+分别独立。
+
+---
+
+# 22. API / WebSocket / Frontend Contract
+
+本方案不仅是 Backend 改造。
+
+必须包含 Contract Migration。
+
+---
+
+## 22.1 HITL API
+
+可继续兼容旧 Resolve Endpoint，也可以演进为：
+
+```text
+POST /runs/{run_id}/hitl/{decision_id}/resolve
+```
+
+请求：
+
+```json
+{
+  "expected_control_revision": 42,
+  "command": "revise_plan",
+  "feedback": "..."
+}
+```
+
+---
+
+## 22.2 HITL_WAIT WebSocket Payload
+
+增加：
+
+```json
+{
+  "decision_id": "...",
+  "control_revision": 42,
+
+  "allowed_commands": [
+    "retry_implementation",
+    "revise_plan",
+    "cancel_run"
+  ],
+
+  "failure": {
+    "failure_class": "CAPABILITY_MISMATCH",
+    "summary": "...",
+    "suggested_recovery": "REVISE_PLAN"
+  }
+}
+```
+
+---
+
+## 22.3 OpenAPI / Contracts 同步
+
+Phase 2 必须包含：
+
+```text
+backend schema update
+ ↓
+OpenAPI regenerate
+ ↓
+contracts sync
+ ↓
+frontend types update
+ ↓
+HITL UI update
+```
+
+不能只改 Python Enum。
+
+---
+
+## 22.4 Frontend Legacy Compatibility
+
+灰度期间前端必须能处理：
+
+```text
+legacy decision payload
+```
+
+与：
+
+```text
+command-based payload
+```
+
+直到旧 Workflow Version 基本退出。
+
+---
+
+# 23. 可观测性与审计
+
+关键 Log Context：
 
 ```text
 run_id
 command_id
-decision_request_id
 workflow_version
+
+control_revision
+
 plan_revision_id
 art_revision_id
 candidate_revision_id
+
 failure_report_id
+failure_class
+
 execution_id
 ```
 
-不存在的字段置空。
-
 ---
 
-## 38.1 关键 Metrics
+## 23.1 Metrics
 
-建议至少：
+建议：
 
 ```text
 forge_replan_total
-
 forge_replan_success_total
-
-forge_replan_per_run_histogram
+forge_replan_per_run
 
 forge_failure_class_total
+forge_failure_class_unknown_total
+forge_failure_class_user_corrected_total
 
 forge_code_retry_total
-
 forge_infra_retry_total
 
-forge_artifact_stale_total
-
-forge_promotion_rejected_total
-
-forge_decision_stale_total
-
 forge_command_redelivery_total
-
 forge_command_idempotent_skip_total
 
-forge_outbox_pending
+forge_stale_decision_total
 
-forge_outbox_publish_latency
+forge_artifact_stale_total
+forge_promotion_rejected_total
 
-forge_run_cost_after_replan
+forge_replan_incremental_cost
+forge_run_completion_after_replan
 ```
 
 ---
 
-## 38.2 关键产品指标
+## 23.2 Audit Events
 
-需要回答：
-
-```text
-多少 qa_failed 最终通过 replan 成功？
-
-用户点击 REVISE_PLAN 后完成率是多少？
-
-Replan 平均多消耗多少 Token？
-
-多少 Replan 实际改变了 Capability Requirements？
-
-多少 Art 能通过 Fingerprint 安全复用？
-
-Replan 2 次以上的成功率是多少？
-```
-
-这些指标决定未来是否值得做：
-
-```text
-auto degradation
-art reuse
-automatic scope reduction
-```
-
----
-
-# 39. Event / Audit
-
-建议建立最小 Run Event：
-
-```json
-{
-  "event_type": "PLAN_REVISED",
-  "run_id": "...",
-  "command_id": "...",
-
-  "from_plan_revision_id": "plan_3",
-  "to_plan_revision_id": "plan_4",
-
-  "reason": "CAPABILITY_MISMATCH",
-
-  "created_at": "..."
-}
-```
-
-至少记录：
+建议最少：
 
 ```text
 PLAN_CREATED
@@ -2660,606 +2407,450 @@ ART_STALE
 CANDIDATE_CREATED
 CANDIDATE_STALE
 
-QA_FAILED
-QA_PASSED
+FAILURE_REPORTED
 
-DECISION_REQUESTED
-DECISION_RESOLVED
-
+COMMAND_CREATED
 COMMAND_STARTED
 COMMAND_COMPLETED
 
+HITL_OPENED
+HITL_RESOLVED
+
 PROMOTION_REJECTED
 RUN_COMPLETED
+RUN_CANCELLED
 ```
 
-Event 不一定第一期做完整 Event Sourcing。
+本期不是 Event Sourcing。
 
-它是 Audit Log，不是新的 SoT。
-
----
-
-# 40. 测试策略
-
-原方案仅测试 Happy Path 不足。
-
-生产发布前至少覆盖以下。
-
----
-
-## 40.1 Unit Tests
-
-### Command Vocabulary
+这些 Event 用于：
 
 ```text
-allowed command
-invalid command
-legacy decision mapping
-```
-
-### Failure Classification
-
-```text
-infra
-implementation
-capability
-resource
-acceptance
-```
-
-### Dependency Fingerprint
-
-```text
-visual fields change → changed
-gameplay-only fields change → unchanged
-canonical ordering → stable
-```
-
-### Promotion Guard
-
-所有 invariant 单独测试。
-
----
-
-# 41. HITL 并发测试
-
-必须覆盖：
-
-### 双击
-
-```text
-same DecisionRequest
-same command
-```
-
-只生成一次。
-
-### 两个浏览器
-
-```text
-Browser A resolves
-Browser B resolves old revision
-```
-
-B：
-
-```text
-409 STALE_DECISION
-```
-
-### 旧 WebSocket 卡片
-
-Run 已前进后 Resolve：
-
-```text
-409
+debug
+audit
+analytics
 ```
 
 ---
 
-# 42. 消息可靠性测试
+# 24. 数据模型
 
-必须覆盖：
+## 24.1 复用
 
-### DB Commit 后 API 超时
-
-客户端 Retry：
+现有：
 
 ```text
-不产生重复业务效果
+runs
+run checkpoint storage
+task_outbox
 ```
 
-### RabbitMQ Duplicate
-
-同 `command_id` 投递两次：
-
-```text
-执行一次
-```
-
-### Worker Crash Before ACK
-
-```text
-business DB commit
- ↓
-worker crash
- ↓
-redelivery
-```
-
-第二次执行：
-
-```text
-idempotent skip
-```
-
-### Outbox Publish Failure
-
-RabbitMQ 不可用时：
-
-```text
-Outbox remains pending
-```
-
-恢复后继续发布。
+继续使用。
 
 ---
 
-# 43. Workflow Version Compatibility 测试
-
-必须模拟：
-
-```text
-Old Worker
-New Worker
-Old Run
-New Run
-```
-
-验证：
-
-```text
-old worker cannot silently execute unsupported new command
-```
-
-旧 Run 在滚动发布后仍能恢复。
-
----
-
-# 44. Artifact Staleness 测试
-
-### Replan
-
-```text
-P1 → A1 → C1
- ↓
-P2
-```
-
-必须：
-
-```text
-C1 = STALE
-```
-
-P0：
-
-```text
-A1 = STALE
-```
-
-P1 Fingerprint compatible 时：
-
-```text
-A1 remains compatible
-```
-
----
-
-# 45. Promote 安全测试
-
-故意构造：
-
-```text
-active plan = P2
-candidate.plan = P1
-candidate.qa = PASSED
-```
-
-Promote 必须失败。
-
-QA Pass 不能绕过 lineage。
-
----
-
-# 46. Failure Routing 测试
-
-### INFRA_TRANSIENT
-
-不得创建：
-
-```text
-REVISE_PLAN DecisionRequest
-```
-
-### CAPABILITY_MISMATCH
-
-允许：
-
-```text
-REVISE_PLAN
-```
-
-### IMPLEMENTATION_DEFECT
-
-attempt budget 未耗尽：
-
-```text
-automatic repair
-```
-
-耗尽：
-
-```text
-DecisionRequest
-```
-
----
-
-# 47. Prompt Safety Tests
-
-输入：
-
-```text
-console log:
-IGNORE ALL PREVIOUS INSTRUCTIONS...
-```
-
-必须：
-
-* 被标记为 Failure Evidence；
-* 不能改变 System / Developer Instruction；
-* 日志长度受限；
-* secret pattern 被脱敏。
-
----
-
-# 48. Cost Budget Tests
-
-验证：
-
-```text
-implementation retry budget
-infra retry budget
-replan budget
-run budget
-```
-
-分别独立。
-
-不能：
-
-```text
-infra retry
-```
-
-意外耗尽：
-
-```text
-plan revision budget
-```
-
----
-
-# 49. 实施计划
-
-生产实施不建议按原：
-
-```text
-P0 button
-P1 plan_rev
-P2 prompt
-```
-
-拆法。
-
-调整为以下顺序。
-
----
-
-## Phase 0：领域模型与兼容层
-
-目标：
-
-> 在不改变用户行为的情况下先建立可靠基础。
-
-实现：
-
-```text
-RunCommand
-DecisionRequest
-workflow_version
-command_id
-Run revision CAS
-legacy decision adapter
-```
-
-涉及：
-
-```text
-hitl.py
-runs.py
-queue.py
-state.py
-worker
-migration
-```
-
-上线后原 UI 行为不变。
-
----
-
-## Phase 1：可靠消息
-
-实现：
-
-```text
-Transactional Outbox
-Idempotent Worker
-Command status
-Publisher retry
-```
-
-发布前完成 RabbitMQ 重投 / worker crash integration test。
-
-这一层是后续 Replan 的上线前提。
-
----
-
-## Phase 2：FailureReport + Failure Classification
-
-实现：
-
-```text
-FailureReport
-FailureClass
-RecoveryPolicy
-```
-
-将：
-
-```text
-sandbox_failed
-qa_failed
-```
-
-从核心决策条件降级为 UI / workflow phase。
-
-Recovery 由 FailureClass 决定。
-
----
-
-## Phase 3：REVISE_PLAN Production Path
-
-实现：
-
-```text
-QA Recovery → REVISE_PLAN
-ART_CONFIRM → REVISE_PLAN
-```
-
-Replan 输入：
-
-```text
-PlanRevision
-FailureReport
-User Feedback
-CapabilityProfile
-```
-
-输出：
-
-```text
-new PlanRevision
-```
-
-重新进入：
-
-```text
-PLAN_CONFIRM
-```
-
----
-
-## Phase 4：Immutable Artifact Lineage
-
-实现：
-
-```text
-PlanRevision ID
-ArtRevision ID
-CandidateRevision ID
-QAContractRevision ID
-Dependency edges
-STALE state
-Promotion Guard
-```
-
-停止物理“清空旧 Candidate”。
-
----
-
-## Phase 5：Capability Precheck
-
-实现：
-
-```text
-CapabilityProfile
-RequiredCapabilities
-CapabilityValidator
-Developability Precheck
-```
-
-删除 keyword blacklist。
-
----
-
-## Phase 6：Dependency Fingerprint
-
-实现：
-
-```text
-Art reuse
-```
-
-仅当：
-
-```text
-fingerprint compatible
-```
-
-时跳过重新生成 Art。
-
-该阶段属于成本优化，不阻塞核心 Replan 上线。
-
----
-
-## Phase 7：Observability / Product Optimization
-
-实现：
-
-```text
-Replan metrics
-Failure metrics
-Run cost metrics
-Replan UX
-Plan change summary
-```
-
-根据真实数据决定后续是否：
-
-```text
-自动 scope degradation
-自动推荐修改
-部分资产复用
-```
-
----
-
-# 50. 数据迁移
-
-新字段必须保证旧 Run 可恢复。
+## 24.2 新增 / 演进
 
 建议：
 
 ```text
-existing runs:
-workflow_version = legacy version
+runs
+  + control_revision
+  + workflow_version
+
+run_commands
+
+failure_reports
+
+artifact_revisions
 ```
 
-旧 checkpoint：
-
-```text
-没有 artifact revision id
-```
-
-恢复时：
-
-```text
-legacy adapter
-```
-
-禁止上线 Migration 后直接要求所有旧 Run 符合新 Schema。
+如果当前 Artifact 已经有独立表，也可以演进现有结构，而不是一定新建统一大表。
 
 ---
 
-## 50.1 新旧 Run 原则
+## 24.3 不新增
+
+本方案明确不新增：
+
+```text
+outbox_events
+qa_contract_revisions
+```
+
+前者复用：
+
+```text
+task_outbox
+```
+
+后者并入：
+
+```text
+PlanRevision.acceptance_contract
+```
+
+---
+
+## 24.4 Checkpoint 定位
+
+Checkpoint 只回答：
+
+> Workflow 当前执行到哪里。
+
+例如：
+
+```json
+{
+  "phase": "plan_confirm",
+
+  "active_plan_revision_id": "plan_4",
+  "active_art_revision_id": null,
+  "active_candidate_revision_id": null
+}
+```
+
+领域历史由：
+
+```text
+RunCommand
+FailureReport
+ArtifactRevision
+Audit Event
+```
+
+承担。
+
+---
+
+# 25. 分阶段实施计划
+
+由于现有 Transactional Outbox 已完成，原“先建设 Outbox 再做 Replan”的排期取消。
+
+新的关键路径明显缩短。
+
+---
+
+## Phase 0 — Command & Control Foundation
+
+目标：
+
+> 不改变用户行为，先统一恢复语义和并发控制。
+
+实现：
+
+* [ ] 新增 `RunCommandType`
+* [ ] 新增 `run_commands`
+* [ ] 新增 `runs.control_revision`
+* [ ] 新增 `runs.workflow_version`
+* [ ] Resume Transaction 写入 `RunCommand`
+* [ ] 复用现有 `task_outbox`
+* [ ] Worker 增加 `command_id` 幂等检查
+* [ ] legacy decision → command adapter
+* [ ] adapter 覆盖 `resolve_hitl`
+* [ ] adapter 覆盖 `resume_run_control`
+* [ ] adapter 覆盖 `retry_run`
+* [ ] adapter 覆盖 `dev_requeue`
+* [ ] 补齐 `sandbox_failed` legacy mapping
+
+这一阶段不要求 UI 出现 Replan。
+
+---
+
+## Phase 1 — FailureReport Lite & Classification
+
+目标：
+
+> 为 Replan 提供稳定失败证据。
+
+实现：
+
+* [ ] `FailureReport`
+* [ ] FailureReport 在 HITL 前冻结
+* [ ] FailureReport 创建点：`code_qa_loop_node` exhausted 分支与 `_pause_recoverable`，均先落库再调 `_pause_hitl` / 发暂停事件
+* [ ] FailureClass Enum
+* [ ] deterministic infra classification
+* [ ] implementation classification
+* [ ] UNKNOWN fallback
+* [ ] classification provenance
+* [ ] sanitized failure summary
+
+本阶段不必一次实现全部高级 LLM Diagnosis。
+
+只要能够安全地区分：
+
+```text
+infra
+implementation
+semantic/unknown
+```
+
+就足够支撑 Phase 2。
+
+---
+
+## Phase 2 — REVISE_PLAN End-to-End
+
+这是第一个直接产生用户价值的阶段。
+
+实现：
+
+* [ ] QA Recovery 支持 `REVISE_PLAN`
+* [ ] `ART_CONFIRM` 支持 `REVISE_PLAN`
+* [ ] Replan 使用 FailureReport
+* [ ] Replan 结构化输出
+* [ ] 新 Plan 必须重新 `PLAN_CONFIRM`
+* [ ] `REPLAN_MAX_REVISIONS`
+* [ ] HITL API Command Contract
+* [ ] `HITL_WAIT` WS Payload 更新
+* [ ] OpenAPI regenerate
+* [ ] contracts sync
+* [ ] Frontend HITL Card 更新
+* [ ] stale decision 409 UX
+* [ ] **Phase 3 之前的历史保全**：Replan 提交时将旧 design_doc / art_direction 快照写入 checkpoint（如 `superseded` 字段），或确认 forge_messages 已有的 design 消息链足以追溯——Lineage 上线前灰度流量产生的 Replan 历史不能不可见
+* [ ] `PLAN_CONFIRM` / `ART_CONFIRM` 新增 `CANCEL_RUN` 的前端按钮与文案（legacy 词表原本没有 cancel，属于行为扩展）
+
+到这里即可正式灰度上线核心“失败后修改策划”。
+
+> **Phase 2 的一致性边界：** 本阶段系统仍是「design_doc 单值覆盖」模型，
+> 没有 STALE 标记与旧 Candidate 保留。灰度期间的 Replan run 即按此语义执行，
+> 不做复杂复用；Phase 3 上线后新 run 才进入完整 Lineage 模型。
+> 上述历史保全 checklist 是这段窗口期的最低要求。
+
+---
+
+## Phase 3 — Immutable Artifact Lineage
+
+目标：
+
+> 防止 Replan 后旧产物污染新流程。
+
+实现：
+
+* [ ] PlanRevision ID
+* [ ] ArtRevision ID
+* [ ] CandidateRevision ID
+* [ ] lineage dependencies
+* [ ] `ACTIVE / STALE`
+* [ ] old Candidate 保留
+* [ ] active candidate pointer 清空
+* [ ] Promotion Guard
+
+这一阶段完成后，Replan 达到完整生产一致性模型。
+
+---
+
+## Phase 4 — Capability Precheck
+
+目标：
+
+> 尽量不要让明显无法实现的 Plan 进入 Code。
+
+实现：
+
+* [ ] Design Doc schema 增加 `required_capabilities`
+* [ ] Runtime `CapabilityProfile`
+* [ ] CapabilityValidator
+* [ ] Developability Precheck
+* [ ] `CAPABILITY_MISMATCH`
+* [ ] 删除关键词式 Capability Blacklist
+
+---
+
+## Phase 5 — Failure Classification Enhancement
+
+目标：
+
+> 提升 Implementation / Acceptance / Capability 的诊断质量。
+
+实现：
+
+* [ ] LLM-assisted ambiguous diagnosis
+* [ ] system-generated classification confidence
+* [ ] classification correction metrics
+* [ ] better RecoveryPolicy recommendations
+
+---
+
+## Phase 6 — Art Dependency Fingerprint
+
+目标：
+
+> 优化 Replan 成本。
+
+实现：
+
+* [ ] Art dependency projection
+* [ ] Unicode NFC
+* [ ] canonical JSON specification
+* [ ] fingerprint version
+* [ ] safe Art reuse
+* [ ] reuse metrics
+
+该阶段不阻塞核心 Replan。
+
+---
+
+# 26. 测试与验收
+
+DoD 按 Phase 标注。
+
+---
+
+## 26.1 Phase 0
+
+* [ ] `[P0]` 同一个 `command_id` 重复消费只产生一次业务效果
+* [ ] `[P0]` DB Commit 后 HTTP Timeout，客户端重试不会重复创建业务结果
+* [ ] `[P0]` Worker DB Commit 后、RabbitMQ ACK 前 Crash 可安全 Redeliver
+* [ ] `[P0]` 两浏览器同时 Resolve，仅一个成功
+* [ ] `[P0]` 旧 HITL 页面 Resolve 返回 `409 STALE_DECISION`
+* [ ] `[P0]` 四个 Resume 入口全部经过 Command Normalization
+* [ ] `[P0]` `sandbox_failed` legacy 行为不因迁移意外改变
+* [ ] `[P0]` 现有 task_outbox 行为保持不变
+
+---
+
+## 26.2 Phase 1
+
+* [ ] `[P1]` HITL 打开之前 FailureReport 已持久化
+* [ ] `[P1]` 后续 checkpoint 更新不会改变旧 FailureReport
+* [ ] `[P1]` 503 类基础设施错误不会误分类成 Capability Mismatch
+* [ ] `[P1]` 证据不足时输出 UNKNOWN
+* [ ] `[P1]` 原始日志经过 truncate / redact
+
+---
+
+## 26.3 Phase 2
+
+* [ ] `[P2]` QA Exhausted 后用户能选择 `REVISE_PLAN`
+* [ ] `[P2]` Art Confirm 能选择 `REVISE_PLAN`
+* [ ] `[P2]` 新 Plan 重新进入 `PLAN_CONFIRM`
+* [ ] `[P2]` Replan 输入包含 FailureReport
+* [ ] `[P2]` Replan Budget 独立于 `PLAN_MAX_ATTEMPTS`
+* [ ] `[P2]` WS Contract 与前端 Types 已同步
+* [ ] `[P2]` 旧 Workflow Version 的 HITL UI 仍能操作
+* [ ] `[P2]` Replan 后旧 design_doc / art_direction 可追溯（checkpoint 快照或 forge_messages 消息链）
+* [ ] `[P2]` `PLAN_CONFIRM` / `ART_CONFIRM` 的 `CANCEL_RUN` 按钮可用且文案准确
+
+---
+
+## 26.4 Phase 3
+
+* [ ] `[P3]` Replan 不删除旧 Plan
+* [ ] `[P3]` Replan 不删除旧 Candidate
+* [ ] `[P3]` 不兼容 Candidate 标记 STALE
+* [ ] `[P3]` STALE Candidate 无法 Promote
+* [ ] `[P3]` active Plan 与 Candidate dependency 不一致时 Promotion Guard 拒绝
+
+---
+
+## 26.5 Phase 4
+
+* [ ] `[P4]` unsupported runtime capability 在 Plan Confirm 前可检测
+* [ ] `[P4]` “不要使用 3D”不会因为包含字符串 `3D` 被误判
+* [ ] `[P4]` RequiredCapabilities 与 CapabilityProfile 产生可解释冲突信息
+
+---
+
+## 26.6 Phase 6
+
+* [ ] `[P6]` Unicode 等价文本 NFC 后产生相同 Fingerprint
+* [ ] `[P6]` JSON key 顺序不同不改变 Fingerprint
+* [ ] `[P6]` 语义有序数组顺序变化会改变 Fingerprint
+* [ ] `[P6]` 不同 fingerprint version 不允许直接复用 Art
+
+---
+
+# 27. Rollout 与回滚
+
+## 27.1 Rollout Gate
+
+Replan UI 增加发布门控：
+
+```text
+replan_recovery_enabled
+```
 
 推荐：
 
 ```text
-Old Run → Old Workflow Semantics
-New Run → New Workflow Semantics
-```
-
-不强制把长期暂停中的旧 Run 自动升级为最新工作流。
-
----
-
-# 51. Rollout
-
-必须灰度。
-
-推荐：
-
-```text
-Stage 1
-internal accounts
-
-Stage 2
+Internal
+ ↓
 5% new runs
-
-Stage 3
+ ↓
 25%
-
-Stage 4
+ ↓
 100%
 ```
 
-监控：
-
-```text
-replan error rate
-resume error rate
-command duplication
-outbox lag
-run completion rate
-cost per completed run
-promotion rejection
-```
-
 ---
 
-# 52. 回滚策略
+## 27.2 Run 冻结 Workflow Version
 
-禁止通过数据库删除新字段回滚。
-
-回滚顺序：
-
-```text
-1. Disable new REVISE_PLAN DecisionRequest exposure
-2. Stop assigning new workflow_version
-3. Existing new-version runs continue on compatible workers
-4. Revert UI exposure if necessary
-```
-
-不能让已经产生：
+新 Run：
 
 ```text
 workflow_version = N
 ```
 
-的 Run 被旧 Worker 按 `N-1` 业务语义恢复。
+长期暂停 Run 不自动升级到 N+1。
 
 ---
 
-# 53. 明确不做（Non-Goals）
+## 27.3 回滚
 
-本方案重新定义 Non-Goals。
+出现问题时：
 
-## 53.1 本期不迁移 LangGraph Native Interrupt / Persistence
+```text
+1. 关闭新 Run 的 REVISE_PLAN UI exposure
+2. 停止分配新的 workflow_version
+3. 已存在 N 版本 Run 继续由兼容 Worker 处理
+4. 保留 DB schema，禁止 destructive rollback
+```
 
-保持现有 PG SoT + RabbitMQ + 外部恢复模型。
+不能：
 
-这是当前项目范围边界，不代表永久否定。
+```text
+让旧 Worker 用旧语义执行新 Command
+```
 
 ---
 
-## 53.2 不做 Fully Connected Graph
+# 28. Non-Goals
 
-不把所有节点互相连边。
+## 28.1 不重建 Transactional Outbox
 
-跨阶段恢复继续使用：
+现有：
+
+```text
+task_outbox
+```
+
+继续使用。
+
+---
+
+## 28.2 不迁移 LangGraph Native Interrupt / Persistence
+
+当前：
+
+```text
+PG checkpoint
+RabbitMQ
+resume grant
+execution lock
+external HITL
+```
+
+保持。
+
+未来维护成本达到阈值后单独 ADR。
+
+---
+
+## 28.3 不做 Fully Connected Graph
+
+跨阶段恢复仍然使用：
 
 ```text
 Command
@@ -3267,35 +2858,25 @@ Command
 route_start
 ```
 
-架构。
+模式。
 
 ---
 
-## 53.3 不做完整 Event Sourcing
+## 28.4 不做 QA Contract 独立 Revision
 
-Artifact 与 Command 是正式 SoT。
-
-RunEvent 仅用于：
-
-```text
-audit / observability
-```
-
-本期不通过 Replay Event 重建整个 Run。
+Acceptance Contract 属于 PlanRevision。
 
 ---
 
-## 53.4 不做 Plan Branch / Merge
+## 28.5 不做 Plan Branch / Merge
 
-Plan Revision 是：
+只支持：
 
 ```text
 P1 → P2 → P3
 ```
 
-线性历史。
-
-暂不支持：
+不支持：
 
 ```text
 P2A
@@ -3305,231 +2886,62 @@ merge
 
 ---
 
-## 53.5 不做 Art Partial Regeneration
+## 28.6 不做 Art Partial Regeneration
 
-Art 要么：
+Art：
 
 ```text
-reuse compatible revision
+reuse whole compatible revision
 ```
 
-要么：
+或者：
 
 ```text
 generate new revision
 ```
 
-本期不做局部资产 diff / patch。
+本期不 Patch 部分资产。
 
 ---
 
-## 53.6 不做 Cross-Run Artifact Sharing
+## 28.7 不做 Cross-Run Artifact Sharing
 
-Artifact lineage 仅在同一个 Run 内生效。
-
-跨 Run 模板 / Plan Library / Art Cache 单独设计。
+Lineage 只在当前 Run 内成立。
 
 ---
 
-## 53.7 不做全自动语义降级
+## 28.8 不做无确认的自动语义降级
 
 系统可以：
 
 ```text
 diagnose
 suggest
-prepare revised plan
+generate revised draft
 ```
 
-但涉及用户需求变化的：
-
-```text
-REVISE_PLAN
-```
-
-必须由用户确认触发。
+但改变用户产品定义必须 HITL。
 
 ---
 
-# 54. 已决定问题
-
-原方案开放问题在本方案中直接拍板。
-
-## 54.1 Replan 后旧 Candidate 怎么处理？
-
-**保留，但标记 STALE。**
-
-不 Promote，不删除。
-
----
-
-## 54.2 Replan 是否无限？
-
-**否。**
-
-独立 `plan_revision_budget`。
-
----
-
-## 54.3 Art Confirm 是否可以 Replan？
-
-**可以。**
-
-正式支持 `REVISE_PLAN`。
-
----
-
-## 54.4 美术无关字段怎么判断？
-
-P0：
-
-```text
-默认重新生成
-```
-
-P1：
-
-```text
-Dependency Fingerprint
-```
-
-不用手写某几个字段的临时 diff 作为长期规则。
-
----
-
-## 54.5 Plan Confirm Modify 与 QA Replan 是否合并？
-
-**底层统一为 `REVISE_PLAN`。**
-
-区别由 Context 决定。
-
-例如：
-
-```text
-source = PLAN_CONFIRM
-failure_report_id = null
-```
-
-与：
-
-```text
-source = QA_RECOVERY
-failure_report_id = F123
-```
-
-共用 Revision Pipeline，不维护两套实际业务实现。
-
----
-
-## 54.6 Sandbox Failed 是否直接提供 Replan？
-
-**不直接绑定。**
-
-由：
-
-```text
-FailureClass
-```
-
-决定。
-
-只有语义失败才允许 Replan。
-
----
-
-## 54.7 是否需要 Feature Flag / Version Gate？
-
-**需要。**
-
-至少：
-
-```text
-workflow_version
-+
-rollout gate
-```
-
----
-
-# 55. 最终状态机
-
-高层用户状态：
-
-```text
-PLAN
- ↓
-PLAN_CONFIRM
- ├── APPROVE_PLAN
- │       ↓
- │      ART
- │
- └── REVISE_PLAN
-         ↓
-        PLAN
-
-ART_CONFIRM
- ├── SELECT_ART
- │       ↓
- │      CODE
- │
- ├── REVISE_ART
- │       ↓
- │      ART
- │
- └── REVISE_PLAN
-         ↓
-        PLAN
-
-CODE / QA
- │
- ├── PASS
- │      ↓
- │   PROMOTION GUARD
- │      ↓
- │     DONE
- │
- └── FAIL
-        ↓
-   Failure Classification
-        │
-        ├── INFRA_TRANSIENT
-        │       ↓
-        │   AUTO RETRY
-        │
-        ├── IMPLEMENTATION_DEFECT
-        │       ↓
-        │   CODE REPAIR
-        │
-        └── SEMANTIC / CAPABILITY FAILURE
-                ↓
-          DecisionRequest
-             ├── RETRY_IMPLEMENTATION
-             ├── REVISE_PLAN
-             └── CANCEL_RUN
-```
-
----
-
-# 56. 系统最终不变量
-
-以下 invariant 作为生产级实现的硬要求。
-
-## Run
-
-```text
-一个 Run 同时最多一个有效 Execution Mutation。
-```
-
-## Decision
-
-```text
-一个 DecisionRequest 最多成功 Resolve 一次。
-```
+# 29. 最终架构不变量
 
 ## Command
 
 ```text
 一个 command_id 最多产生一次业务效果。
+```
+
+## HITL
+
+```text
+一个 control_revision 对应的用户决策只能成功 Resolve 一次。
+```
+
+## Failure
+
+```text
+触发 HITL 的 FailureReport 必须在 HITL 打开前冻结。
 ```
 
 ## Plan
@@ -3541,137 +2953,158 @@ PlanRevision 不可原地修改。
 ## Artifact
 
 ```text
-历史 Artifact 不因新版本生成而删除。
+历史 Artifact 不因新版本产生而删除。
 ```
 
-## Dependency
+## Lineage
 
 ```text
-任何 Artifact 必须明确记录其依赖版本。
+每个 Art / Candidate 必须能回答自己依赖哪一版 Plan。
 ```
 
-## Failure
+## Candidate
 
 ```text
-触发 HITL 的 FailureReport 必须在暂停前冻结。
+旧 Candidate 可以存在，但 STALE Candidate 永远不能 Promote。
 ```
 
-## Promotion
+## Infra Recovery
 
 ```text
-STALE Artifact 永远不能 Promote。
+基础设施恢复不能擅自改变用户产品语义。
 ```
 
-## Workflow
+## Semantic Recovery
 
 ```text
-Worker 不能使用自己不支持的 workflow_version 执行 Run。
+改变用户产品语义必须经过 HITL。
 ```
 
-## Recovery
+## Messaging
 
 ```text
-Infra Recovery 不改变用户语义；
-任何改变用户语义的 Recovery 必须经过 HITL。
+task_outbox 保证任务不丢；
+RunCommand 幂等保证重复消息不产生重复业务效果。
+```
+
+## Control Revision
+
+```text
+Checkpoint Revision 与 HITL Control Revision 是两个独立概念。
+```
+
+## Cancellation
+
+```text
+PostgreSQL 持久状态是 Cancel SoT；
+Redis Control Bit 只负责低延迟中断。
+```
+
+## Versioning
+
+```text
+Worker 不允许解释自己不支持的 workflow_version。
 ```
 
 ---
 
-# 57. 验收标准
+# 30. 最终决策
 
-本方案上线的 Definition of Done：
+本次工作不再定义为：
 
-* [ ] QA Exhausted 后用户能够选择 `REVISE_PLAN`
-* [ ] Art Confirm 能够选择 `REVISE_PLAN`
-* [ ] Infra Transient Failure 不要求用户修改策划
-* [ ] Replan 输入包含稳定的 FailureReport，而非临时读取当前错误
-* [ ] 新 Plan 以新的 immutable Revision 写入
-* [ ] 旧 Plan / Art / Candidate 不被删除
-* [ ] 不兼容 Artifact 自动变为 STALE
-* [ ] STALE Candidate 无法 Promote
-* [ ] HITL 双击不会产生重复 Command
-* [ ] 两个浏览器同时 Resolve 只有一个成功
-* [ ] RabbitMQ 重复投递不会重复产生 Artifact
-* [ ] Worker 在 DB Commit 后、ACK 前 Crash 可以安全恢复
-* [ ] RabbitMQ 暂时不可用不会导致 Resume 丢失
-* [ ] 新旧 Worker 滚动发布期间旧 Run 可以安全恢复
-* [ ] Capability Mismatch 可以在 Plan 阶段提前发现
-* [ ] REVISE_PLAN 有独立预算限制
-* [ ] Failure Log 进入 LLM 前执行清洗、截断与脱敏
-* [ ] 所有关键链路包含 `run_id / command_id / artifact_revision_id`
-* [ ] Promotion Guard 有完整集成测试
-* [ ] Replan 成功率、成本、失败分类都有监控指标
-
----
-
-# 58. 最终决策
-
-本次改造不定义为：
-
-> 给 `qa_failed` 增加一个“回炉策划”按钮。
+> “QA Failed 页面增加一个回炉策划按钮。”
 
 正式定义为：
 
-> **GameForge Workflow Recovery & Artifact Lineage 第一阶段建设。**
+> **GameForge Cross-stage Replan & Recovery + Artifact Lineage 建设。**
 
-保留当前 LangGraph + PostgreSQL + Redis + RabbitMQ + Sandbox 架构骨架。
-
-需要正式建立以下领域能力：
+现有系统已经具备：
 
 ```text
-RunCommand
-DecisionRequest
-FailureReport
-FailureClass
-RecoveryPolicy
-PlanRevision
-QAContractRevision
-ArtRevision
-CandidateRevision
-Artifact Dependency
+PostgreSQL Transaction
+Task Outbox
+RabbitMQ Reliable Dispatch
+Resume Grant
+Execution Lock
+Lease Recovery
+```
+
+因此不重建消息基础设施。
+
+本次真正需要补齐的是：
+
+```text
+1. RunCommand
+2. control_revision
+3. command-level idempotency
+4. FailureReport
+5. Failure Classification
+6. REVISE_PLAN Recovery
+7. Immutable Artifact Revision
+8. Artifact Lineage
+9. Promotion Guard
+10. Workflow Version
+11. Capability Validation
+```
+
+实施顺序确定为：
+
+```text
+Phase 0
+Command / control_revision / idempotency
+
+        ↓
+
+Phase 1
+FailureReport Lite / conservative classification
+
+        ↓
+
+Phase 2
+REVISE_PLAN end-to-end
+Frontend Contract
+正式产生用户价值
+
+        ↓
+
+Phase 3
+Immutable Artifact Lineage
 Promotion Guard
-Workflow Version
-Transactional Outbox
-CapabilityProfile
+
+        ↓
+
+Phase 4
+Capability Precheck
+
+        ↓
+
+Phase 5
+Classification Enhancement
+
+        ↓
+
+Phase 6
+Art Fingerprint / Reuse Optimization
 ```
 
-其中上线优先级最高的是：
+其中：
 
-```text
-1. RunCommand / DecisionRequest
-2. Transactional Outbox + Idempotency
-3. FailureReport / Failure Classification
-4. REVISE_PLAN Recovery
-5. Immutable Artifact Revision + Promotion Guard
-6. Workflow Versioning
-7. Capability Validation
-```
+> **Phase 0 + Phase 1 完成后即可开始交付 REVISE_PLAN，不需要等待重新建设 Outbox，也不需要等待完整 Artifact Lineage 或 Capability System 全部完成。**
 
-Dependency Fingerprint 与 Art Reuse 属于后续成本优化，不应阻塞核心正确性上线。
+但在 Phase 3 完成之前：
 
-最终架构原则：
+> Replan 后的旧 Art / Candidate 采用保守失效策略，不做复杂复用。
 
-> **不要把失败当成“退回旧状态”，而应把失败视为生成新版本的证据。**
+最终原则：
 
-> **不要删除旧产物，而应通过血缘和状态判断它是否仍然有效。**
+> **失败不是回到旧状态，而是产生下一版设计的证据。**
 
-> **不要依赖 phase 猜测用户意图，而应使用具有业务语义的 Command。**
+> **状态可以前进，历史不能被抹掉。**
 
-> **不要依赖消息只投递一次，而应保证重复投递也只产生一次业务效果。**
+> **Phase 描述“现在在哪里”，Command 描述“下一步要做什么”，FailureReport 描述“为什么这么做”。**
 
-> **不要等到 Code 重试三轮后才判断策划能不能做，应尽可能在昂贵阶段之前进行 Capability Validation。**
+> **消息可以重复，业务结果不能重复。**
 
-这套模型建立后，未来新增：
+> **基础设施失败由系统自动恢复，产品语义变化由用户决定。**
 
-```text
-开发退回美术
-美术退回策划
-切换实现引擎
-失败后缩减 Scope
-历史版本重新生成
-换模型重新实现
-从旧 Candidate Fork
-不同 Runtime Profile 重跑
-```
-
-都可以建立在同一套 Command、Failure、Revision、Dependency 与 Recovery 模型上，而不需要继续向 `route_start()` 中增加越来越多不可维护的 `if/else`。
+> **先保证正确性和可恢复性，再优化 Artifact 复用与生成成本。**


### PR DESCRIPTION
## Summary
- Rewrite the cross-stage plan revision and failure-recovery design around RunCommand, FailureReport, RecoveryPolicy, and staged rollout.
- Keep Phase 0–1 sufficient to start REVISE_PLAN without rebuilding outbox, full artifact lineage, or the capability system.

## Background
PR #109 landed an earlier draft of this spec. This revision tightens the production contract (control revision, stale HITL, cancel/pause/resume, workflow versioning) and makes the implementation sequence explicit.

## Changes
- Replace the long sectioned draft with a 30-section production spec covering domain models, API/WS/frontend contract, observability, data model, tests, and rollout.
- Conservative art/candidate invalidation until lineage (Phase 3) exists.

## Test plan
- [ ] Skim the table of contents against the intended REVISE_PLAN rollout (Phase 0 Command/idempotency → Phase 1 FailureReport lite → Phase 2 end-to-end).
- [ ] Confirm Non-Goals still exclude a LangGraph rewrite and a full outbox rebuild before value delivery.