### PR TITLE
fix(llm): disable thinking by default on OpenAI-compat paths

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -121,9 +121,8 @@ LLM_CONTINUATION_TAIL_CHARS=8000
 # 注册表代理（即便无 *_PROXY 环境变量），国内 provider 走它常因无出口而超时；默认列国内厂商。
 # 海外/未知 host 仍沿用系统代理，保留「用代理访问 OpenAI 等」的能力。
 LLM_DIRECT_HOSTS=dashscope.aliyuncs.com,api.deepseek.com,api.moonshot.cn,open.bigmodel.cn,api.siliconflow.cn,api.minimaxi.com,api.baichuan-ai.com,api.lingyiwanwu.com
-# 是否对 qwen3 系列模型关掉 thinking（默认关）。DashScope 约定「非流式调用必须
-# enable_thinking=false」，而 complete() 为非流式；关后既合规又省时省 token。
-# 需深度推理置 false（且需切到流式）。
+# OpenAI 兼容路径默认关 thinking（用户模型 + 审核模型共用；纯推理如 qwq 会跳过）。
+# 关后避免思考链占满 max_tokens。需深度推理置 false。
 LLM_DISABLE_THINKING=true
 
 # 流式打字机输出：LLM 流式吐 token → 微批 LLM_DELTA 事件给前端。

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -218,9 +218,9 @@ class Settings(BaseSettings):
         "open.bigmodel.cn,api.siliconflow.cn,api.minimaxi.com,"
         "api.baichuan-ai.com,api.lingyiwanwu.com"
     )
-    # 是否对 qwen3 系列模型关掉 thinking（默认关）。
-    # DashScope 约定「非流式调用必须 enable_thinking=false」，而 complete() 为非流式；
-    # 关后既合规又省时省 token，避免思考链拉长触发读超时。需深度推理置 false（且需切到流式）。
+    # OpenAI 兼容路径默认关 thinking（含用户模型与审核模型）。
+    # 避免思考链占满 max_tokens、流式又丢弃 reasoning_content 导致空正文。
+    # 纯推理模型（如 qwq）由 provider 侧跳过注入。需深度推理置 false。
     llm_disable_thinking: bool = True
 
     # 流式输出（打字机）：complete_stream 微批 LLM_DELTA 事件给前端。关闭则 run_streamed_llm

--- a/backend/app/llm/provider.py
+++ b/backend/app/llm/provider.py
@@ -164,14 +164,23 @@ def _build_llm_client(url: str, timeout: httpx.Timeout) -> httpx.AsyncClient:
     return httpx.AsyncClient(timeout=timeout)
 
 
-def _is_qwen_thinking_model(model: str) -> bool:
-    """qwen3 系列（DashScope 默认开 thinking 的混合思考模型）。
+def _requires_thinking_enabled(model: str) -> bool:
+    """纯推理模型：只允许 enable_thinking=true，注入 false 会 400。"""
+    name = (model or "").lower()
+    return any(tok in name for tok in ("qwq",))
 
-    仅匹配 qwen3：qwq 等纯推理模型只允许 enable_thinking=true，注入 false 反而触发 400。
-    DashScope 约定「非流式调用必须 enable_thinking=false」，而本模块 complete() 为非流式，
-    故对 qwen3 关闭 thinking 既是性能优化（避免思考链拉长/触发读超时），也是调用合规。
+
+def _should_disable_thinking(provider: LLMProvider, base_url: str | None, model: str) -> bool:
+    """OpenAI 兼容路径默认关 thinking；Anthropic 原生与纯推理模型跳过。
+
+    plan JSON / 审核 0|1 都不需要思考链：思考 token 会占满 max_tokens，
+    且流式解析只收 content、丢弃 reasoning_content，易得到空正文。
     """
-    return "qwen3" in (model or "").lower()
+    if not settings.llm_disable_thinking:
+        return False
+    if _uses_anthropic_native_api(provider, base_url):
+        return False
+    return not _requires_thinking_enabled(model)
 
 
 async def test_connectivity(
@@ -240,7 +249,7 @@ def _build_body(
     """构造 chat/messages 请求体。非流式与流式共用，仅 stream 字段不同。
 
     Anthropic 官方域名走原生 /messages（system 独立字段）；其余一律 OpenAI 兼容。
-    qwen3 关 thinking 仅对 OpenAI 兼容路径生效（见 _is_qwen_thinking_model 注释）。
+    thinking 默认关闭（见 _should_disable_thinking）。
     """
     if _uses_anthropic_native_api(provider, base_url):
         body = {
@@ -262,13 +271,7 @@ def _build_body(
         # 缺失时由 complete_stream 兜底估算。
         if stream:
             body["stream_options"] = {"include_usage": True}
-    # qwen3 默认开 thinking 会拉长代码生成、易触发读超时；DashScope 非流式调用也要求
-    # enable_thinking=false。命中 qwen3 则按配置关闭（仅 OpenAI 兼容路径）。
-    if (
-        not _uses_anthropic_native_api(provider, base_url)
-        and settings.llm_disable_thinking
-        and _is_qwen_thinking_model(model)
-    ):
+    if _should_disable_thinking(provider, base_url, model):
         body["enable_thinking"] = False
     if stream:
         body["stream"] = True

--- a/backend/tests/infra/test_logging_and_llm_null.py
+++ b/backend/tests/infra/test_logging_and_llm_null.py
@@ -110,24 +110,39 @@ _DASHSCOPE = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 
 
 @pytest.mark.asyncio
-async def test_complete_injects_enable_thinking_for_qwen3(
+@pytest.mark.parametrize(
+    "model",
+    ["qwen3-max", "glm-5.1", "deepseek-v4-flash", "gpt-4o"],
+)
+async def test_complete_injects_enable_thinking_false_by_default(
     monkeypatch: pytest.MonkeyPatch,
+    model: str,
 ) -> None:
+    """OpenAI 兼容路径默认关 thinking（plan/审核都不需要思考链占满 max_tokens）。"""
     cap = _CapturingClient()
     monkeypatch.setattr("app.llm.provider.httpx.AsyncClient", lambda **_k: cap)
-    await complete(
-        LLMProvider.OPENAI_COMPAT, "key", "qwen3-max", "sys", "user", base_url=_DASHSCOPE
-    )
+    await complete(LLMProvider.OPENAI_COMPAT, "key", model, "sys", "user", base_url=_DASHSCOPE)
     assert cap.last_json["enable_thinking"] is False
 
 
 @pytest.mark.asyncio
-async def test_complete_skips_enable_thinking_for_non_qwen(
+async def test_complete_skips_enable_thinking_for_qwq(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """纯推理模型注入 false 会 400，必须跳过。"""
+    cap = _CapturingClient()
+    monkeypatch.setattr("app.llm.provider.httpx.AsyncClient", lambda **_k: cap)
+    await complete(LLMProvider.OPENAI_COMPAT, "key", "qwq-32b", "sys", "user", base_url=_DASHSCOPE)
+    assert "enable_thinking" not in cap.last_json
+
+
+@pytest.mark.asyncio
+async def test_complete_skips_enable_thinking_on_anthropic_native(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cap = _CapturingClient()
     monkeypatch.setattr("app.llm.provider.httpx.AsyncClient", lambda **_k: cap)
-    await complete(LLMProvider.OPENAI, "key", "gpt-4o", "sys", "user")
+    await complete(LLMProvider.ANTHROPIC, "key", "claude-sonnet-5", "sys", "user")
     assert "enable_thinking" not in cap.last_json
 
 


### PR DESCRIPTION
## Summary
- Default `enable_thinking=false` on OpenAI-compatible LLM calls (user models and audit/guardrail share the same path).
- Skip injection for pure-reasoning models (`qwq`) and native Anthropic Messages API to avoid 400s / wrong protocol.
- Fixes empty plan JSON when models like `glm-5.1` burn `max_tokens` on hidden reasoning while stream parsing keeps only `content`.

## Background
Plan validation failed with a full empty-doc checklist after `glm-5.1` runs that reported ~8192 output tokens but null content in Langfuse. Qwen3 worked because it alone previously received `enable_thinking=false`.

## Changes
- `backend/app/llm/provider.py`: `_should_disable_thinking` default-off policy
- Config / `.env.example` comment updates
- Unit tests for qwen3 / glm / deepseek / gpt-4o / qwq / Anthropic native

## Test plan
- [x] `pytest tests/infra/test_logging_and_llm_null.py` (thinking injection cases)
- [ ] Restart API + worker on deploy; run a forge plan with `glm-5.1` and confirm non-empty design JSON
- [ ] Confirm audit/guardrail still returns 0/1 with thinking disabled
- [ ] Spot-check `qwq` (if used) still works without injected `false`