### PR TITLE
docs(eval): refresh offline eval reports after local verification

### DIFF
--- a/docs/analysis/output_audit_eval_report.md
+++ b/docs/analysis/output_audit_eval_report.md
@@ -6,14 +6,14 @@ This eval measures output-side content moderation effectiveness using Guard `qui
 
 - Detection rate: **95.0%** (target >= 90%) ✅
 - False-positive rate: **0.0%** (target < 3%) ✅
-- Audit latency p95: **1.377 ms**
+- Audit latency p95: **1.624 ms**
 
 ## 2. Methodology
 
 - Dataset: `eval/datasets/output_violations.json`
 - Runner: `eval/runners/output_audit_eval.py`
 - Layers tested: regex blacklist + AC lexicon (no LLM)
-- Timestamp: 2026-08-20T03:35:51.927880+00:00
+- Timestamp: 2026-08-21T14:19:59.512264+00:00
 
 ## 3. Results
 
@@ -23,7 +23,7 @@ This eval measures output-side content moderation effectiveness using Guard `qui
 |---|---:|---|---|
 | detection_rate | 95.0% | >= 90% | ✅ |
 | false_positive_rate | 0.0% | < 3% | ✅ |
-| audit_latency_p95_ms | 1.377ms | documented | ✅ |
+| audit_latency_p95_ms | 1.624ms | documented | ✅ |
 
 ### 3.2 Breakdown by Violation Type
 
@@ -46,4 +46,4 @@ This eval measures output-side content moderation effectiveness using Guard `qui
 
 ## 5. Conclusion
 
-Quick-filter baseline results: detection_rate=95.0%, false_positive_rate=0.0%, audit_latency_p95_ms=1.377ms.
+Quick-filter baseline results: detection_rate=95.0%, false_positive_rate=0.0%, audit_latency_p95_ms=1.624ms.

--- a/docs/evals/code-quality-eval-report.md
+++ b/docs/evals/code-quality-eval-report.md
@@ -10,8 +10,8 @@ Static structural analysis on **20** curated snippets. Structure detection accur
 - **Runner**: `eval/runners/code_quality_eval.py`
 - **Mode**: `static_baseline`
 - **Reproduce**: `cd backend && uv run python -m eval.runners.<module>`
-- **Git SHA**: `0e09085`
-- **Date**: 2026-08-20
+- **Git SHA**: `0497cc6`
+- **Date**: 2026-08-21
 
 ## 3. Results
 

--- a/docs/evals/output-audit-eval-report.md
+++ b/docs/evals/output-audit-eval-report.md
@@ -6,14 +6,14 @@ This eval measures output-side content moderation effectiveness using Guard `qui
 
 - Detection rate: **95.0%** (target >= 90%) ✅
 - False-positive rate: **0.0%** (target < 3%) ✅
-- Audit latency p95: **1.377 ms**
+- Audit latency p95: **1.624 ms**
 
 ## 2. Methodology
 
 - Dataset: `eval/datasets/output_violations.json`
 - Runner: `eval/runners/output_audit_eval.py`
 - Layers tested: regex blacklist + AC lexicon (no LLM)
-- Timestamp: 2026-08-20T03:35:51.927880+00:00
+- Timestamp: 2026-08-21T14:19:59.512264+00:00
 
 ## 3. Results
 
@@ -23,7 +23,7 @@ This eval measures output-side content moderation effectiveness using Guard `qui
 |---|---:|---|---|
 | detection_rate | 95.0% | >= 90% | ✅ |
 | false_positive_rate | 0.0% | < 3% | ✅ |
-| audit_latency_p95_ms | 1.377ms | documented | ✅ |
+| audit_latency_p95_ms | 1.624ms | documented | ✅ |
 
 ### 3.2 Breakdown by Violation Type
 
@@ -46,4 +46,4 @@ This eval measures output-side content moderation effectiveness using Guard `qui
 
 ## 5. Conclusion
 
-Quick-filter baseline results: detection_rate=95.0%, false_positive_rate=0.0%, audit_latency_p95_ms=1.377ms.
+Quick-filter baseline results: detection_rate=95.0%, false_positive_rate=0.0%, audit_latency_p95_ms=1.624ms.

--- a/docs/evals/performance-eval-report.md
+++ b/docs/evals/performance-eval-report.md
@@ -2,7 +2,7 @@
 
 ## 1. Summary
 
-Guard quick_filter latency over **124** prompts: p50=0.729ms, p95=1.203ms.
+Guard quick_filter latency over **124** prompts: p50=0.839ms, p95=1.576ms.
 
 ## 2. Methodology
 
@@ -10,8 +10,8 @@ Guard quick_filter latency over **124** prompts: p50=0.729ms, p95=1.203ms.
 - **Runner**: `eval/runners/performance_eval.py`
 - **Mode**: `offline_guard_baseline`
 - **Reproduce**: `cd backend && uv run python -m eval.runners.<module>`
-- **Git SHA**: `0e09085`
-- **Date**: 2026-08-20
+- **Git SHA**: `0497cc6`
+- **Date**: 2026-08-21
 
 ## 3. Results
 
@@ -19,11 +19,11 @@ Guard quick_filter latency over **124** prompts: p50=0.729ms, p95=1.203ms.
 
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
-| guard_p50_ms | 0.729ms | documented | - |
-| guard_p95_ms | 1.203ms | documented | - |
-| guard_p99_ms | 1.554ms | documented | - |
-| e2e_p50_s | n/a | tracked | - |
-| e2e_p95_s | n/a | tracked | - |
+| guard_p50_ms | 0.839ms | documented | - |
+| guard_p95_ms | 1.576ms | documented | - |
+| guard_p99_ms | 1.994ms | documented | - |
+| e2e_p50_s | 381.2 | tracked | - |
+| e2e_p95_s | 381.2 | tracked | - |
 
 ## 7. Conclusion
 

--- a/docs/evals/preference-eval-report.md
+++ b/docs/evals/preference-eval-report.md
@@ -10,8 +10,8 @@ Context injection baseline on **15** scenarios. Cross-session injection rate: **
 - **Runner**: `eval/runners/preference_eval.py`
 - **Mode**: `context_builder_baseline`
 - **Reproduce**: `cd backend && uv run python -m eval.runners.<module>`
-- **Git SHA**: `0e09085`
-- **Date**: 2026-08-20
+- **Git SHA**: `0497cc6`
+- **Date**: 2026-08-21
 
 ## 3. Results
 

--- a/docs/evals/reliability-eval-report.md
+++ b/docs/evals/reliability-eval-report.md
@@ -10,8 +10,8 @@ Unit-style reliability checks on **10** scenarios. Pass rate: **100.0%**.
 - **Runner**: `eval/runners/reliability_eval.py`
 - **Mode**: `unit_baseline`
 - **Reproduce**: `cd backend && uv run python -m eval.runners.<module>`
-- **Git SHA**: `0e09085`
-- **Date**: 2026-08-20
+- **Git SHA**: `0497cc6`
+- **Date**: 2026-08-21
 
 ## 3. Results
 


### PR DESCRIPTION
## Summary
- Refresh committed offline eval reports after local re-runs of output-audit, code-quality, performance, preference, and reliability runners.
- Keep the existing live generation baseline (`gen-001`–`gen-010`, 100%) unchanged on purpose (a smaller local smoke would have overwritten it).

## Background
Local verification on 2026-08-21 re-executed the offline eval suite while API/worker/middleware were up. Report timestamps and latency numbers moved slightly; metric pass/fail status is unchanged for the offline baselines.

## Changes
- `docs/evals/output-audit-eval-report.md` (+ analysis mirror)
- `docs/evals/code-quality-eval-report.md`
- `docs/evals/performance-eval-report.md` (also records e2e p50/p95 when a local generation report is present)
- `docs/evals/preference-eval-report.md`
- `docs/evals/reliability-eval-report.md`

## Test plan
- [x] `uv run --project backend python -m eval.runners.output_audit_eval`
- [x] `uv run --project backend python -m eval.runners.code_quality_eval`
- [x] `uv run --project backend python -m eval.runners.performance_eval`
- [x] `uv run --project backend python -m eval.runners.preference_eval`
- [x] `uv run --project backend python -m eval.runners.reliability_eval`
- [x] `uv run --project backend python backend/scripts/ci_offline_eval_gate.py`
- [x] Confirm `docs/evals/generation-eval-report.md` still documents the 10/10 live baseline