### PR TITLE
fix(forge): keep HITL visible when event log expands

### DIFF
--- a/frontend/src/components/forge/ChatPanel.tsx
+++ b/frontend/src/components/forge/ChatPanel.tsx
@@ -282,7 +282,8 @@ export function ChatPanel({
       {composerCover ? (
         <div
           className={cn(
-            "min-h-0 max-h-[min(58vh,32rem)] shrink-0 overflow-y-auto",
+            // 相对聊天面板高度封顶，避免日志带展开后仍按 58vh 抢高把确认卡裁切/盖住
+            "min-h-0 max-h-[min(42%,22rem)] shrink-0 overflow-y-auto",
             hero
               ? "border-t border-[var(--gf-border)] bg-[var(--gf-surface)] p-3 md:p-3.5"
               : "gf-border-subtle border-t p-3",

--- a/frontend/src/components/forge/ForgeLogDock.test.tsx
+++ b/frontend/src/components/forge/ForgeLogDock.test.tsx
@@ -1,8 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
 import { RunPhase } from '@/api/enums'
 import { emptyStagePipeline } from '@/lib/stage-pipeline-state'
 import { ForgeLogDock } from './ForgeLogDock'
+
+afterEach(() => {
+  cleanup()
+  localStorage.removeItem('gf-forge-log-height')
+})
 
 describe('ForgeLogDock', () => {
   it('展开时阶段条在滚动区外，事件流单独滚动', () => {
@@ -27,5 +32,21 @@ describe('ForgeLogDock', () => {
     expect(screen.getByLabelText('生成流程')).toBeInTheDocument()
     expect(screen.getByText('事件 11')).toBeInTheDocument()
     fireEvent.wheel(scroll!, { deltaY: 200 })
+  })
+
+  it('HITL 共存时加上安全高度 class，避免日志带过高', () => {
+    localStorage.setItem('gf-forge-log-height', String(Math.round(window.innerHeight * 0.5)))
+    const { container } = render(
+      <ForgeLogDock
+        open
+        reserveForHitl
+        onToggle={() => undefined}
+        runPhase={RunPhase.plan}
+        stages={emptyStagePipeline()}
+        items={[]}
+      />,
+    )
+    const dock = container.querySelector('.gf-forge-log-dock')
+    expect(dock).toHaveClass('gf-forge-log-dock--hitl-safe')
   })
 })

--- a/frontend/src/components/forge/ForgeLogDock.tsx
+++ b/frontend/src/components/forge/ForgeLogDock.tsx
@@ -5,6 +5,7 @@ import { FailureRecoveryBar } from '@/components/forge/FailureRecoveryBar'
 import { StageLogGrid } from '@/components/forge/StageLogGrid'
 import type { TimelineItem } from '@/components/forge/RunTimeline'
 import type { StagePipelineState } from '@/lib/stage-pipeline-state'
+import { cn } from '@/lib/cn'
 import { useT } from '@/i18n/use-t'
 
 /** 失败恢复卡所需的上下文（来自 ForgePage） */
@@ -26,12 +27,19 @@ type Props = {
   stages: StagePipelineState
   items: TimelineItem[]
   failureRecovery?: ForgeLogDockFailure | null
+  /**
+   * HITL 确认卡与日志带争用底部视口：为 true 时压低日志最大高度，
+   * 避免展开后盖住聊天区底部的人工确认操作。
+   */
+  reserveForHitl?: boolean
 }
 
 const HEIGHT_KEY = 'gf-forge-log-height'
-const DEFAULT_HEIGHT_RATIO = 0.25
+const DEFAULT_HEIGHT_RATIO = 0.22
 const MIN_HEIGHT_RATIO = 0.12
-const MAX_HEIGHT_RATIO = 0.5
+const MAX_HEIGHT_RATIO = 0.42
+const HITL_DEFAULT_HEIGHT_RATIO = 0.16
+const HITL_MAX_HEIGHT_RATIO = 0.24
 
 function readStoredHeight(): number | null {
   try {
@@ -45,20 +53,31 @@ function readStoredHeight(): number | null {
   }
 }
 
-function defaultHeightPx(): number {
-  return Math.round(window.innerHeight * DEFAULT_HEIGHT_RATIO)
+function heroBasisPx(): number {
+  const hero = document.querySelector('.gf-forge-hero')
+  if (hero instanceof HTMLElement && hero.clientHeight > 0) {
+    return hero.clientHeight
+  }
+  return window.innerHeight
+}
+
+function defaultHeightPx(reserveForHitl: boolean): number {
+  const ratio = reserveForHitl ? HITL_DEFAULT_HEIGHT_RATIO : DEFAULT_HEIGHT_RATIO
+  return Math.round(heroBasisPx() * ratio)
 }
 
 function minHeightPx(): number {
-  return Math.round(window.innerHeight * MIN_HEIGHT_RATIO)
+  return Math.round(heroBasisPx() * MIN_HEIGHT_RATIO)
 }
 
-function maxHeightPx(): number {
-  return Math.round(window.innerHeight * MAX_HEIGHT_RATIO)
+function maxHeightPx(reserveForHitl: boolean): number {
+  const ratio = reserveForHitl ? HITL_MAX_HEIGHT_RATIO : MAX_HEIGHT_RATIO
+  return Math.round(heroBasisPx() * ratio)
 }
 
 /**
- * 底部横跨的「执行日志带」：默认折叠；展开后约 25vh，可拖拽至 50vh。
+ * 底部横跨的「执行日志带」：默认折叠；展开后约占工坊高度 22%，可拖高；
+ * 有 HITL 时进一步压低，避免遮挡聊天底部确认卡。
  */
 export function ForgeLogDock({
   open,
@@ -67,22 +86,29 @@ export function ForgeLogDock({
   stages,
   items,
   failureRecovery,
+  reserveForHitl = false,
 }: Props) {
   const t = useT()
   const showGrid = runPhase !== 'idle' || items.length > 0
-  const [height, setHeight] = useState(() => readStoredHeight() ?? defaultHeightPx())
+  const [height, setHeight] = useState(() => readStoredHeight() ?? defaultHeightPx(false))
   const draggingRef = useRef(false)
   const dockRef = useRef<HTMLElement | null>(null)
 
-  const persistHeight = useCallback((next: number) => {
-    const clamped = Math.min(maxHeightPx(), Math.max(minHeightPx(), next))
-    setHeight(clamped)
-    try {
-      localStorage.setItem(HEIGHT_KEY, String(clamped))
-    } catch {
-      /* ignore quota errors */
-    }
-  }, [])
+  const persistHeight = useCallback(
+    (next: number) => {
+      const clamped = Math.min(
+        maxHeightPx(reserveForHitl),
+        Math.max(minHeightPx(), next),
+      )
+      setHeight(clamped)
+      try {
+        localStorage.setItem(HEIGHT_KEY, String(clamped))
+      } catch {
+        /* ignore quota errors */
+      }
+    },
+    [reserveForHitl],
+  )
 
   useEffect(() => {
     function onMove(event: PointerEvent) {
@@ -104,16 +130,27 @@ export function ForgeLogDock({
   }, [persistHeight])
 
   useEffect(() => {
-    if (open && failureRecovery && height < defaultHeightPx()) {
-      persistHeight(defaultHeightPx())
-    }
-  }, [open, failureRecovery, height, persistHeight])
+    // 打开时按工坊高度回夹；HITL 时强制落到安全默认高度，避免旧 localStorage 盖住确认卡
+    if (!open) return
+    const ceiling = maxHeightPx(reserveForHitl)
+    const target = reserveForHitl
+      ? Math.min(height, defaultHeightPx(true), ceiling)
+      : Math.min(height, ceiling)
+    if (target < height) persistHeight(target)
+  }, [open, reserveForHitl, height, persistHeight])
 
   const latest = items[0]
   const errorCount = items.filter((i) => i.tone === 'err').length
 
   return (
-    <section ref={dockRef} className="gf-forge-log-dock" aria-label={t('eventLog')}>
+    <section
+      ref={dockRef}
+      className={cn(
+        'gf-forge-log-dock',
+        reserveForHitl && open && 'gf-forge-log-dock--hitl-safe',
+      )}
+      aria-label={t('eventLog')}
+    >
       {open ? (
         <div
           role="separator"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -847,13 +847,18 @@ body.gf-forge-resizing * {
 /* 底部横跨执行日志带：标题栏常驻；body 展开时固定高度，事件流内部滚动 */
 .gf-forge-log-dock {
   position: relative;
-  z-index: 1;
+  z-index: 0;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   border-top: 1px solid var(--gf-border);
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(8px);
+}
+
+/* HITL 共存：限制日志带 body 上限，给聊天底部确认卡留出空间 */
+.gf-forge-log-dock--hitl-safe .gf-forge-log-dock-body {
+  max-height: min(24vh, 12rem);
 }
 
 .gf-forge-log-dock-header {

--- a/frontend/src/pages/forge/ForgePage.tsx
+++ b/frontend/src/pages/forge/ForgePage.tsx
@@ -1461,6 +1461,7 @@ export function ForgePage() {
           runPhase={phase}
           stages={stagePipeline}
           items={items}
+          reserveForHitl={Boolean(hitl)}
           failureRecovery={
             showFailureRecovery && runId
               ? {


### PR DESCRIPTION
## Summary
- Confirmed HITL can be covered when the event log dock expands: dock height was based on window height (up to 50vh) with `flex-shrink: 0`, while HITL used a large `58vh` cap.
- Cap log-dock height against the forge hero, shrink further when `reserveForHitl` is set, and bound the chat composer cover to panel percentage height.

## Test plan
- [ ] Start a forge run until HITL (plan/art confirm) appears
- [ ] Expand Event Log and confirm HITL actions remain reachable (not covered)
- [ ] Drag the log dock taller and confirm HITL-safe max still leaves room
- [ ] Collapse the log dock and confirm normal height behavior without HITL
- [ ] `pnpm exec vitest run src/components/forge/ForgeLogDock.test.tsx`
