### PR TITLE
fix(forge): keep play stage beside chat when opened mid-run

### DIFF
--- a/frontend/src/components/forge/ForgeSplitLayout.test.tsx
+++ b/frontend/src/components/forge/ForgeSplitLayout.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ForgeSplitLayout } from "./ForgeSplitLayout";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ForgeSplitLayout", () => {
+  it("applies stage-open class and three-track grid when stage is open", () => {
+    const { container } = render(
+      <ForgeSplitLayout
+        stageOpen
+        left={<div>chat-panel</div>}
+        right={<div>stage-panel</div>}
+      />,
+    );
+    const split = container.querySelector(".gf-forge-split");
+    expect(split).toHaveClass("gf-forge-split--stage-open");
+    const cols = (split as HTMLElement).style.gridTemplateColumns;
+    expect(cols).toContain("6px");
+    expect(cols).toContain("minmax(0, 1fr)");
+    expect(screen.getByText("chat-panel")).toBeInTheDocument();
+    expect(screen.getByText("stage-panel")).toBeInTheDocument();
+  });
+
+  it("does not mount the stage panel when closed", () => {
+    render(
+      <ForgeSplitLayout
+        stageOpen={false}
+        left={<div>chat-only</div>}
+        right={<div>stage-hidden</div>}
+      />,
+    );
+    expect(screen.getByText("chat-only")).toBeInTheDocument();
+    expect(screen.queryByText("stage-hidden")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/forge/ForgeSplitLayout.tsx
+++ b/frontend/src/components/forge/ForgeSplitLayout.tsx
@@ -113,19 +113,19 @@ export function ForgeSplitLayout({
     <div
       ref={containerRef}
       className={cn(
-        "gf-forge-split flex h-full min-h-0 flex-col gap-3 lg:grid lg:gap-0",
+        // 关闭：单列 flex。打开：由 CSS --stage-open 在 lg+ 切 grid 左右分栏。
+        // 勿在此叠 lg:grid + flex-col：handle 若晚于 lg 才显示，右栏会被塞进 6px 中轨。
+        "gf-forge-split flex h-full min-h-0 flex-col gap-3",
         stageOpen && "gf-forge-split--stage-open",
         className,
       )}
       style={
         stageOpen
           ? ({
-              gridTemplateColumns: `${leftRatio} 6px 1fr`,
+              ["--gf-forge-left-col" as string]: leftRatio,
+              gridTemplateColumns: `${leftRatio} 6px minmax(0, 1fr)`,
             } as CSSProperties)
-          : // 关闭预览时显式单列填满，避免 grid 退到 auto 隐式列导致面板宽度不确定/溢出
-            ({
-              gridTemplateColumns: "minmax(0, 1fr)",
-            } as CSSProperties)
+          : undefined
       }
     >
       {onMobileViewChange ? (
@@ -185,7 +185,7 @@ export function ForgeSplitLayout({
             tabIndex={0}
             aria-label={t("forgeDragToResize")}
             title={t("forgeDragToResize")}
-            className="gf-forge-split-handle group relative hidden cursor-col-resize touch-none place-items-center outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--gf-primary-rgb),0.4)] focus-visible:ring-offset-2 xl:grid"
+            className="gf-forge-split-handle group relative hidden cursor-col-resize touch-none place-items-center outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--gf-primary-rgb),0.4)] focus-visible:ring-offset-2 lg:grid"
             onPointerDown={(event) => {
               event.preventDefault();
               draggingRef.current = true;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -757,8 +757,6 @@ body {
   position: relative;
   z-index: 1;
   flex: 1 1 0;
-  flex-direction: column;
-  grid-template-rows: minmax(0, 1fr);
   min-height: 0;
   padding: 0.75rem 1rem;
 }
@@ -769,10 +767,19 @@ body {
   }
 }
 
+/* 桌面：试玩区打开时固定左右 grid，避免 Tailwind flex/grid 混用把右栏挤到下方或 6px 中轨 */
 .gf-forge-split--stage-open {
-  flex-direction: row;
-  align-items: stretch;
-  gap: 0;
+  gap: 0.75rem;
+}
+
+@media (min-width: 1024px) {
+  .gf-forge-split--stage-open {
+    display: grid;
+    grid-template-columns: var(--gf-forge-left-col, 36%) 6px minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
+    align-items: stretch;
+    gap: 0;
+  }
 }
 
 /* 拖拽手柄：6px 宽，hover/focus 高亮。面板间距由此 + gridTemplateColumns 共同决定 */
@@ -805,29 +812,10 @@ body.gf-forge-resizing * {
   user-select: none !important;
 }
 
-/* 移动端：双栏降级为纵向堆叠，handle 转横向 */
+/* 移动端：仍用 flex 列 + 顶栏 tab 互斥显示；勿强制双栏同屏堆叠（会像「试玩区在聊天下方」） */
 @media (max-width: 1023px) {
-  .gf-forge-split--stage-open {
-    flex-direction: column;
-  }
-
-  .gf-forge-split--stage-open .gf-forge-panel-left {
-    min-height: 42vh;
-    max-height: 52vh;
-  }
-
   .gf-forge-split-handle {
-    width: auto;
-    height: 6px;
-    cursor: row-resize;
-  }
-
-  .gf-forge-split-handle::before {
-    inset: 2px 0.5rem;
-  }
-
-  .gf-forge-split--stage-open .gf-forge-panel-right {
-    min-height: 36vh;
+    display: none !important;
   }
 }
 

--- a/frontend/src/pages/forge/ForgePage.tsx
+++ b/frontend/src/pages/forge/ForgePage.tsx
@@ -1125,7 +1125,12 @@ export function ForgePage() {
               className="!min-h-10 !rounded-xl !px-3 text-xs !text-[var(--gf-text)]"
               onClick={() => {
                 userToggledStageRef.current = true;
-                setStageOpen((open) => !open);
+                setStageOpen((open) => {
+                  const next = !open;
+                  // 窄屏靠 tab 互斥；打开试玩时切到 play，避免右栏被 max-lg:hidden 藏住却又占文档流
+                  setMobileView(next ? "play" : "chat");
+                  return next;
+                });
               }}
               aria-pressed={stageOpen}
               title={stageOpen ? t("forgeHidePreview") : t("forgeShowPreview")}
@@ -1368,6 +1373,7 @@ export function ForgePage() {
                   onClick={() => {
                     userToggledStageRef.current = true;
                     setStageOpen(false);
+                    setMobileView("chat");
                   }}
                   className="ml-1 grid h-8 w-8 cursor-pointer place-items-center rounded-lg text-[#94A3B8] transition-colors hover:bg-black/[0.04] hover:text-[#0F172A] focus-visible:ring-2 focus-visible:ring-[rgba(59,130,246,0.3)]"
                 >
@@ -1398,7 +1404,7 @@ export function ForgePage() {
                     accessToken={token}
                   />
                 ) : (
-                  <div className="grid h-full min-h-[320px] place-items-center rounded-xl border border-white/[0.06] bg-[radial-gradient(circle_at_center,rgba(var(--gf-primary-rgb),0.10),transparent_60%)] px-6 text-center">
+                  <div className="grid h-full min-h-0 place-items-center rounded-xl border border-white/[0.06] bg-[radial-gradient(circle_at_center,rgba(var(--gf-primary-rgb),0.10),transparent_60%)] px-6 text-center">
                     <div className="max-w-sm">
                       <div className="gf-forge-stage-empty-icon mx-auto grid h-14 w-14 place-items-center rounded-2xl border border-white/10 bg-white/[0.05] shadow-[0_0_36px_rgba(var(--gf-primary-rgb),0.14)]">
                         <Box


### PR DESCRIPTION
Desktop stage-open now uses an explicit lg grid with the resize handle visible from lg, so the preview no longer falls into the 6px middle track or stacks under chat. Narrow screens switch to the play tab when toggling the stage button.