### PR TITLE
fix(knowledge): strict Pinecone transport and local embedding (#147)

### DIFF
--- a/backend/app/forge/cache/pinecone_store.py
+++ b/backend/app/forge/cache/pinecone_store.py
@@ -17,6 +17,10 @@ from app.core.config import settings
 log = logging.getLogger(__name__)
 
 
+class PineconeTransportError(RuntimeError):
+    """Pinecone data-plane HTTP 失败；Knowledge ingest/query 严格模式必须抛出。"""
+
+
 @dataclass(frozen=True)
 class VectorMatch:
     id: str
@@ -77,10 +81,18 @@ class InMemoryPineconeStore:
 class HttpPineconeStore:
     """Pinecone data-plane REST（需 host + api_key）。"""
 
-    def __init__(self, *, host: str, api_key: str, namespace: str) -> None:
+    def __init__(
+        self,
+        *,
+        host: str,
+        api_key: str,
+        namespace: str,
+        strict_errors: bool = False,
+    ) -> None:
         self._host = host.rstrip("/").removeprefix("https://").removeprefix("http://")
         self._api_key = api_key
         self._namespace = namespace
+        self._strict_errors = strict_errors
 
     async def upsert(
         self,
@@ -149,6 +161,8 @@ class HttpPineconeStore:
                 return data if isinstance(data, dict) else {}
         except (httpx.HTTPError, ValueError) as exc:
             log.warning("pinecone request failed: %s", type(exc).__name__)
+            if self._strict_errors:
+                raise PineconeTransportError(str(exc)) from exc
             return {}
 
 

--- a/backend/app/forge/knowledge/pinecone_store.py
+++ b/backend/app/forge/knowledge/pinecone_store.py
@@ -59,4 +59,5 @@ def get_knowledge_pinecone_store() -> _KnowledgeStore | None:
         host=settings.pinecone_knowledge_host.strip(),
         api_key=settings.pinecone_api_key.strip(),
         namespace=settings.pinecone_knowledge_namespace or "global",
+        strict_errors=True,
     )

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -37,7 +37,7 @@ async def embed_texts(texts: Sequence[str]) -> list[list[float]] | None:
     body = {"model": settings.embedding_model.strip(), "input": cleaned}
     timeout = httpx.Timeout(settings.embedding_timeout_s)
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, trust_env=False) as client:
             resp = await client.post(url, headers=headers, json=body)
             resp.raise_for_status()
             data = resp.json()

--- a/backend/tests/forge/knowledge/test_knowledge_pinecone_strict.py
+++ b/backend/tests/forge/knowledge/test_knowledge_pinecone_strict.py
@@ -1,0 +1,59 @@
+"""Knowledge Pinecone strict transport semantics (#147)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.forge.cache.pinecone_store import HttpPineconeStore, PineconeTransportError
+from app.forge.knowledge.pinecone_store import get_knowledge_pinecone_store
+
+
+def test_knowledge_store_uses_strict_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pinecone_enabled", True)
+    monkeypatch.setattr(settings, "pinecone_api_key", "key")
+    monkeypatch.setattr(settings, "pinecone_knowledge_host", "knowledge.pinecone.io")
+    monkeypatch.setattr(settings, "pinecone_knowledge_namespace", "global")
+
+    store = get_knowledge_pinecone_store()
+    assert isinstance(store, HttpPineconeStore)
+    assert store._strict_errors is True
+
+
+@pytest.mark.asyncio
+async def test_strict_upsert_raises_on_http_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = HttpPineconeStore(
+        host="example.pinecone.io",
+        api_key="key",
+        namespace="global",
+        strict_errors=True,
+    )
+
+    async def _fail_post(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise PineconeTransportError("simulated outage")
+
+    monkeypatch.setattr(store, "_post", _fail_post)
+
+    with pytest.raises(PineconeTransportError):
+        await store.upsert(vector_id="x", values=[1.0], metadata={"text": "t"})
+
+
+@pytest.mark.asyncio
+async def test_cache_store_swallows_http_failure_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = HttpPineconeStore(
+        host="example.pinecone.io",
+        api_key="key",
+        namespace="default",
+        strict_errors=False,
+    )
+
+    async def _empty_post(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
+
+    monkeypatch.setattr(store, "_post", _empty_post)
+
+    await store.upsert(vector_id="x", values=[1.0], metadata={"text": "t"})

--- a/backend/tests/forge/knowledge/test_knowledge_verify.py
+++ b/backend/tests/forge/knowledge/test_knowledge_verify.py
@@ -51,8 +51,12 @@ async def test_verify_knowledge_retrieval_after_upsert(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio
-async def test_ingest_fails_fast_without_pinecone() -> None:
+async def test_ingest_fails_fast_without_pinecone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.forge.knowledge.ingest import ingest_corpus
+
+    monkeypatch.setattr(settings, "pinecone_knowledge_host", "")
 
     spec = KnowledgeChunkSpec(
         chunk_id="x",

--- a/backend/tests/llm/test_embeddings_trust_env.py
+++ b/backend/tests/llm/test_embeddings_trust_env.py
@@ -1,0 +1,47 @@
+"""Embedding client uses trust_env=False for local TEI (#147)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.llm import embeddings
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_uses_trust_env_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "embedding_enabled", True)
+    monkeypatch.setattr(settings, "embedding_apikey", "local")
+    monkeypatch.setattr(settings, "embedding_base_url", "http://127.0.0.1:8080/v1")
+    monkeypatch.setattr(settings, "embedding_model", "test-model")
+    monkeypatch.setattr(settings, "embedding_timeout_s", 5)
+
+    captured: dict[str, bool] = {}
+
+    class _FakeClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            captured["trust_env"] = bool(kwargs.get("trust_env"))
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def post(self, *_args: object, **_kwargs: object) -> object:
+            class _Resp:
+                def raise_for_status(self) -> None:
+                    return None
+
+                def json(self) -> dict[str, object]:
+                    return {"data": [{"index": 0, "embedding": [0.1, 0.2]}]}
+
+            return _Resp()
+
+    monkeypatch.setattr(embeddings.httpx, "AsyncClient", _FakeClient)
+
+    out = await embeddings.embed_texts(["hello"])
+    assert out == [[0.1, 0.2]]
+    assert captured.get("trust_env") is False


### PR DESCRIPTION
## Summary
- Add PineconeTransportError and strict_errors mode to HttpPineconeStore; knowledge store enables strict mode so ingest no longer treats HTTP failures as success.
- Set httpx trust_env=False on embedding client to bypass Windows system proxy when calling local TEI (127.0.0.1).
- Add regression tests; make ingest fail-fast test independent of developer .env Pinecone config.

## Background
Closes the first P0 item from Issue #147 / ADR-14 production hardening: knowledge ingest must fail loudly on Pinecone outages, and local embedding must work behind Windows proxy.

## Test plan
- [x] uv run pytest tests/forge/knowledge/ tests/llm/test_embeddings_trust_env.py tests/forge/cache/test_pinecone_store.py
- [x] pre-commit hooks pass