### PR TITLE
feat(knowledge): production chunking MVP (#146)

### DIFF
--- a/backend/app/forge/knowledge/chunk_planner.py
+++ b/backend/app/forge/knowledge/chunk_planner.py
@@ -1,0 +1,160 @@
+"""ChunkPlanner：Markdown / 长文本分块（ADR-14 §3.6.5；#146 MVP）。"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from dataclasses import dataclass
+
+from app.forge.knowledge.chunk_policy import (
+    ChunkPolicy,
+    effective_max_tokens,
+    policy_by_name,
+    policy_for_category,
+)
+from app.forge.memory.context_builder import estimate_tokens
+
+_HEADING_RE = re.compile(r"^(#{2,3})\s+(.+)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class ChunkDraft:
+    text: str
+    chunk_index: int
+    chunk_policy: str
+    title_hint: str = ""
+
+
+def normalize_text(text: str) -> str:
+    """Unicode NFC + 压缩空白行。"""
+    normalized = unicodedata.normalize("NFC", text or "")
+    lines = [ln.rstrip() for ln in normalized.replace("\r\n", "\n").split("\n")]
+    return "\n".join(lines).strip()
+
+
+def content_hash_of(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _split_oversized(text: str, *, max_tokens: int, overlap_tokens: int) -> list[str]:
+    """按句/行滑动窗口切分，保证每段 ≤ max_tokens。"""
+    if estimate_tokens(text) <= max_tokens:
+        return [text]
+    # 优先按句号/换行切
+    parts = re.split(r"(?<=[。！？.!?\n])", text)
+    parts = [p for p in parts if p and p.strip()]
+    if not parts:
+        # 硬切字符（CJK 约 1 token/字）
+        step = max(1, max_tokens - overlap_tokens)
+        return [text[i : i + max_tokens] for i in range(0, len(text), step)]
+
+    out: list[str] = []
+    buf = ""
+    for part in parts:
+        candidate = f"{buf}{part}" if buf else part
+        if estimate_tokens(candidate) <= max_tokens:
+            buf = candidate
+            continue
+        if buf.strip():
+            out.append(buf.strip())
+        # overlap: 取 buf 尾部约 overlap_tokens
+        if overlap_tokens > 0 and buf:
+            tail = buf
+            while estimate_tokens(tail) > overlap_tokens and len(tail) > 1:
+                tail = tail[len(tail) // 4 :]
+            buf = f"{tail}{part}" if estimate_tokens(part) <= max_tokens else part
+            if estimate_tokens(buf) > max_tokens:
+                # part 本身过大：递归硬切
+                out.extend(_split_oversized(part, max_tokens=max_tokens, overlap_tokens=0))
+                buf = ""
+        else:
+            if estimate_tokens(part) > max_tokens:
+                out.extend(_split_oversized(part, max_tokens=max_tokens, overlap_tokens=0))
+                buf = ""
+            else:
+                buf = part
+    if buf.strip():
+        out.append(buf.strip())
+    return out or [text[:max_tokens]]
+
+
+def _markdown_sections(text: str) -> list[tuple[str, str]]:
+    """返回 (heading_title, body) 列表；无标题则整篇一段。"""
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        return [("", text.strip())] if text.strip() else []
+    sections: list[tuple[str, str]] = []
+    # 前言（第一个标题之前）
+    preface = text[: matches[0].start()].strip()
+    if preface:
+        sections.append(("", preface))
+    for i, match in enumerate(matches):
+        title = match.group(2).strip()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+        block = f"{title}\n{body}".strip() if body else title
+        sections.append((title, block))
+    return sections
+
+
+def plan_text(
+    text: str,
+    *,
+    policy: ChunkPolicy,
+) -> list[ChunkDraft]:
+    cleaned = normalize_text(text)
+    if not cleaned:
+        return []
+    max_tok = effective_max_tokens(policy)
+    pieces = _split_oversized(
+        cleaned,
+        max_tokens=max_tok,
+        overlap_tokens=policy.overlap_tokens,
+    )
+    return [
+        ChunkDraft(text=p, chunk_index=i, chunk_policy=policy.name) for i, p in enumerate(pieces)
+    ]
+
+
+def plan_markdown(
+    text: str,
+    *,
+    category: str,
+    policy_name: str | None = None,
+) -> list[ChunkDraft]:
+    policy = policy_by_name(policy_name) if policy_name else None
+    if policy is None:
+        policy = policy_for_category(category)
+    cleaned = normalize_text(text)
+    if not cleaned:
+        return []
+    max_tok = effective_max_tokens(policy)
+    drafts: list[ChunkDraft] = []
+    idx = 0
+    for title, section in _markdown_sections(cleaned):
+        for piece in _split_oversized(
+            section,
+            max_tokens=max_tok,
+            overlap_tokens=policy.overlap_tokens,
+        ):
+            drafts.append(
+                ChunkDraft(
+                    text=piece,
+                    chunk_index=idx,
+                    chunk_policy=policy.name,
+                    title_hint=title,
+                )
+            )
+            idx += 1
+    return drafts
+
+
+def assert_no_truncation(drafts: list[ChunkDraft], *, max_tokens: int | None = None) -> float:
+    """返回 truncation_rate（超限 chunk 占比）；生产目标 0。"""
+    if not drafts:
+        return 0.0
+    limit = max_tokens if max_tokens is not None else 480
+    bad = sum(1 for d in drafts if estimate_tokens(d.text) > limit)
+    return bad / len(drafts)

--- a/backend/app/forge/knowledge/chunk_policy.py
+++ b/backend/app/forge/knowledge/chunk_policy.py
@@ -1,0 +1,78 @@
+"""Chunk Policy Registry（ADR-14 §3.6.3；#146 MVP）。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ChunkPolicy:
+    name: str
+    max_tokens: int
+    target_min: int
+    target_max: int
+    overlap_tokens: int
+    categories: frozenset[str]
+
+
+_POLICIES: dict[str, ChunkPolicy] = {
+    "design_principle": ChunkPolicy(
+        name="design_principle",
+        max_tokens=400,
+        target_min=120,
+        target_max=280,
+        overlap_tokens=0,
+        categories=frozenset({"design_principle", "gameplay_mechanic"}),
+    ),
+    "gameplay_case": ChunkPolicy(
+        name="gameplay_case",
+        max_tokens=400,
+        target_min=150,
+        target_max=320,
+        overlap_tokens=0,
+        categories=frozenset({"gameplay_case", "game_genre", "historical_game"}),
+    ),
+    "art_direction": ChunkPolicy(
+        name="art_direction",
+        max_tokens=380,
+        target_min=100,
+        target_max=260,
+        overlap_tokens=0,
+        categories=frozenset({"art_direction", "ui_case", "ui_style"}),
+    ),
+    "platform_rule": ChunkPolicy(
+        name="platform_rule",
+        max_tokens=350,
+        target_min=80,
+        target_max=220,
+        overlap_tokens=0,
+        categories=frozenset({"engine_constraint", "coding_rule", "output_contract"}),
+    ),
+    "narrative_doc": ChunkPolicy(
+        name="narrative_doc",
+        max_tokens=450,
+        target_min=200,
+        target_max=380,
+        overlap_tokens=40,
+        categories=frozenset(),  # 长文 Markdown 默认
+    ),
+}
+
+# Embed 硬上限（bge-small-zh 512 留余量）；与 policy.max 取更严者
+EMBED_MAX_TOKENS = 480
+
+
+def policy_by_name(name: str) -> ChunkPolicy | None:
+    return _POLICIES.get(name.strip())
+
+
+def policy_for_category(category: str) -> ChunkPolicy:
+    cat = category.strip()
+    for policy in _POLICIES.values():
+        if cat in policy.categories:
+            return policy
+    return _POLICIES["narrative_doc"]
+
+
+def effective_max_tokens(policy: ChunkPolicy) -> int:
+    return min(policy.max_tokens, EMBED_MAX_TOKENS)

--- a/backend/app/forge/knowledge/ingest.py
+++ b/backend/app/forge/knowledge/ingest.py
@@ -1,24 +1,35 @@
-"""Curated Knowledge Ingestion（ADR-14 §3.5；Runtime Agent 禁止调用）。"""
+"""Curated Knowledge Ingestion（ADR-14 §3.5 / §3.6；Runtime Agent 禁止调用）。"""
 
 from __future__ import annotations
 
-import hashlib
 import json
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
 from app.core.config import settings
+from app.forge.knowledge.chunk_planner import (
+    assert_no_truncation,
+    content_hash_of,
+    plan_markdown,
+)
+from app.forge.knowledge.chunk_policy import (
+    EMBED_MAX_TOKENS,
+    effective_max_tokens,
+    policy_for_category,
+)
 from app.forge.knowledge.guards import (
     current_embedding_version_tag,
     validate_embedding_model_configured,
 )
 from app.forge.knowledge.pinecone_store import get_knowledge_writer
 from app.forge.knowledge.schema import metadata_validation_error
+from app.forge.memory.context_builder import estimate_tokens
 from app.llm.embeddings import embed_one
 
 _REQUIRED_CHUNK_KEYS = frozenset({"chunk_id", "text", "domain", "category", "title", "source_id"})
+_METADATA_TEXT_MAX_CHARS = 2000
 
 
 @dataclass(frozen=True)
@@ -34,6 +45,13 @@ class KnowledgeChunkSpec:
     acl: str = "internal"
     source_kind: str = "curated"
     locale: str = "zh-CN"
+    document_id: str = ""
+    chunk_index: int = 0
+    chunk_total: int = 1
+    chunk_policy: str = ""
+    parent_chunk_id: str = ""
+    content_ptr: str = ""
+    content_hash: str = ""
 
 
 @dataclass(frozen=True)
@@ -54,6 +72,59 @@ def _json_safe_meta(meta: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _parse_one_chunk(item: dict[str, Any], idx: int) -> KnowledgeChunkSpec:
+    missing = _REQUIRED_CHUNK_KEYS - item.keys()
+    if missing:
+        raise ValueError(f"chunk[{idx}] missing keys: {sorted(missing)}")
+    tags_raw = item.get("tags") or []
+    tags: tuple[str, ...]
+    if isinstance(tags_raw, list):
+        tags = tuple(str(t) for t in tags_raw)
+    elif isinstance(tags_raw, str):
+        tags = tuple(t.strip() for t in tags_raw.split(",") if t.strip())
+    else:
+        tags = ()
+    domain = str(item["domain"]).strip()
+    category = str(item["category"]).strip()
+    quality_tier = str(item.get("quality_tier") or "silver")
+    acl = str(item.get("acl") or "internal")
+    if settings.knowledge_metadata_validation_enabled:
+        err = metadata_validation_error(
+            domain=domain,
+            category=category,
+            acl=acl,
+            quality_tier=quality_tier,
+        )
+        if err:
+            raise ValueError(f"chunk[{idx}] {err}")
+    text = str(item["text"]).strip()
+    policy_name = str(item.get("chunk_policy") or "").strip()
+    if not policy_name:
+        policy_name = policy_for_category(category).name
+    doc_id = str(item.get("document_id") or item.get("source_id") or "").strip()
+    chunk_id = str(item["chunk_id"]).strip()
+    return KnowledgeChunkSpec(
+        chunk_id=chunk_id,
+        text=text,
+        domain=domain,
+        category=category,
+        title=str(item["title"]).strip(),
+        source_id=str(item["source_id"]).strip(),
+        tags=tags,
+        quality_tier=quality_tier,
+        acl=acl,
+        source_kind=str(item.get("source_kind") or "curated"),
+        locale=str(item.get("locale") or "zh-CN"),
+        document_id=doc_id,
+        chunk_index=int(item.get("chunk_index") or 0),
+        chunk_total=int(item.get("chunk_total") or 1),
+        chunk_policy=policy_name,
+        parent_chunk_id=str(item.get("parent_chunk_id") or ""),
+        content_ptr=str(item.get("content_ptr") or ""),
+        content_hash=str(item.get("content_hash") or content_hash_of(text)),
+    )
+
+
 def parse_corpus_document(data: object) -> list[KnowledgeChunkSpec]:
     """解析 JSON corpus：`{"chunks": [...]}` 或顶层数组。"""
     if isinstance(data, list):
@@ -71,51 +142,90 @@ def parse_corpus_document(data: object) -> list[KnowledgeChunkSpec]:
     for idx, item in enumerate(raw_chunks):
         if not isinstance(item, dict):
             raise ValueError(f"chunk[{idx}] must be an object")
-        missing = _REQUIRED_CHUNK_KEYS - item.keys()
-        if missing:
-            raise ValueError(f"chunk[{idx}] missing keys: {sorted(missing)}")
-        tags_raw = item.get("tags") or []
-        tags: tuple[str, ...]
-        if isinstance(tags_raw, list):
-            tags = tuple(str(t) for t in tags_raw)
-        elif isinstance(tags_raw, str):
-            tags = tuple(t.strip() for t in tags_raw.split(",") if t.strip())
-        else:
-            tags = ()
-        domain = str(item["domain"]).strip()
-        category = str(item["category"]).strip()
-        quality_tier = str(item.get("quality_tier") or "silver")
-        acl = str(item.get("acl") or "internal")
-        if settings.knowledge_metadata_validation_enabled:
-            err = metadata_validation_error(
-                domain=domain,
-                category=category,
-                acl=acl,
-                quality_tier=quality_tier,
-            )
-            if err:
-                raise ValueError(f"chunk[{idx}] {err}")
-        specs.append(
-            KnowledgeChunkSpec(
-                chunk_id=str(item["chunk_id"]).strip(),
-                text=str(item["text"]).strip(),
-                domain=domain,
-                category=category,
-                title=str(item["title"]).strip(),
-                source_id=str(item["source_id"]).strip(),
-                tags=tags,
-                quality_tier=quality_tier,
-                acl=acl,
-                source_kind=str(item.get("source_kind") or "curated"),
-                locale=str(item.get("locale") or "zh-CN"),
-            )
-        )
+        specs.append(_parse_one_chunk(item, idx))
     return specs
 
 
 def load_corpus_file(path: Path) -> list[KnowledgeChunkSpec]:
     data = json.loads(path.read_text(encoding="utf-8"))
     return parse_corpus_document(data)
+
+
+def specs_from_markdown(
+    markdown: str,
+    *,
+    document_id: str,
+    domain: str,
+    category: str,
+    title: str,
+    source_id: str,
+    policy_name: str | None = None,
+    content_ptr: str = "",
+    tags: tuple[str, ...] = (),
+    quality_tier: str = "silver",
+    acl: str = "internal",
+) -> list[KnowledgeChunkSpec]:
+    """Markdown → ChunkPlanner → KnowledgeChunkSpec[]。"""
+    drafts = plan_markdown(markdown, category=category, policy_name=policy_name)
+    if assert_no_truncation(drafts) > 0:
+        raise ValueError("chunk planner produced oversize chunks (truncation_rate > 0)")
+    total = len(drafts)
+    out: list[KnowledgeChunkSpec] = []
+    for draft in drafts:
+        chunk_id = f"{source_id}#{document_id}#{draft.chunk_index:04d}"
+        parent = (
+            f"{source_id}#{document_id}#{draft.chunk_index - 1:04d}"
+            if draft.chunk_index > 0
+            else ""
+        )
+        out.append(
+            KnowledgeChunkSpec(
+                chunk_id=chunk_id,
+                text=draft.text,
+                domain=domain,
+                category=category,
+                title=(draft.title_hint or title)[:500],
+                source_id=source_id,
+                tags=tags,
+                quality_tier=quality_tier,
+                acl=acl,
+                document_id=document_id,
+                chunk_index=draft.chunk_index,
+                chunk_total=total,
+                chunk_policy=draft.chunk_policy,
+                parent_chunk_id=parent,
+                content_ptr=content_ptr,
+                content_hash=content_hash_of(draft.text),
+            )
+        )
+    return out
+
+
+def _guard_embed_tokens(text: str, *, category: str, chunk_policy: str) -> str | None:
+    """超 EMBED_MAX / policy max 则返回错误信息（拒绝静默截断）。"""
+    from app.forge.knowledge.chunk_policy import policy_by_name
+
+    policy = policy_by_name(chunk_policy) or policy_for_category(category)
+    limit = effective_max_tokens(policy)
+    tokens = estimate_tokens(text)
+    if tokens > limit:
+        return f"chunk exceeds token limit: {tokens} > {limit}"
+    if tokens > EMBED_MAX_TOKENS:
+        return f"chunk exceeds embed max: {tokens} > {EMBED_MAX_TOKENS}"
+    return None
+
+
+async def _content_hash_exists(content_hash: str) -> bool:
+    """尽量探测 store 中是否已有同 hash（InMemory 扫描；HTTP 暂靠批内去重）。"""
+    store = get_knowledge_writer()
+    if store is None or not content_hash:
+        return False
+    rows = getattr(store, "_rows", None)
+    if isinstance(rows, dict):
+        for _vid, (_vec, meta) in rows.items():
+            if isinstance(meta, dict) and meta.get("content_hash") == content_hash:
+                return True
+    return False
 
 
 async def upsert_knowledge_chunk(
@@ -131,13 +241,26 @@ async def upsert_knowledge_chunk(
     acl: str = "internal",
     source_kind: str = "curated",
     locale: str = "zh-CN",
-) -> bool:
+    document_id: str = "",
+    chunk_index: int = 0,
+    chunk_total: int = 1,
+    chunk_policy: str = "",
+    parent_chunk_id: str = "",
+    content_ptr: str = "",
+    content_hash: str = "",
+    known_hashes: set[str] | None = None,
+) -> str:
+    """返回 'upserted' | 'skipped' | 'error'。"""
     store = get_knowledge_writer()
     if store is None:
-        return False
+        return "error"
     body = text.strip()
     if not body:
-        return False
+        return "error"
+    policy_name = chunk_policy.strip() or policy_for_category(category).name
+    guard_err = _guard_embed_tokens(body, category=category, chunk_policy=policy_name)
+    if guard_err:
+        return "error"
     if settings.knowledge_metadata_validation_enabled:
         err = metadata_validation_error(
             domain=domain,
@@ -146,17 +269,24 @@ async def upsert_knowledge_chunk(
             quality_tier=quality_tier,
         )
         if err:
-            return False
+            return "error"
+    digest = content_hash or content_hash_of(body)
+    if known_hashes is not None and digest in known_hashes:
+        return "skipped"
+    if await _content_hash_exists(digest):
+        if known_hashes is not None:
+            known_hashes.add(digest)
+        return "skipped"
     if not validate_embedding_model_configured():
-        return False
+        return "error"
     vector = await embed_one(body)
     if vector is None:
-        return False
+        return "error"
     expected_dim = int(settings.knowledge_embedding_expected_dim)
     if expected_dim > 0 and len(vector) != expected_dim:
-        return False
-    content_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        return "error"
     embedding_version = current_embedding_version_tag()
+    doc_id = document_id.strip() or source_id
     meta: dict[str, Any] = {
         "domain": domain,
         "category": category,
@@ -169,8 +299,16 @@ async def upsert_knowledge_chunk(
         "quality_tier": quality_tier,
         "acl": acl,
         "trust_level": source_kind,
-        "text": body[:4000],
-        "content_hash": content_hash,
+        "text": body[:_METADATA_TEXT_MAX_CHARS],
+        "content_hash": digest,
+        "document_id": doc_id,
+        "chunk_index": int(chunk_index),
+        "chunk_total": int(chunk_total),
+        "chunk_policy": policy_name,
+        "parent_chunk_id": parent_chunk_id,
+        "content_ptr": content_ptr,
+        "char_count": len(body),
+        "token_estimate": estimate_tokens(body),
         "created_at": int(time.time()),
     }
     if embedding_version:
@@ -180,11 +318,17 @@ async def upsert_knowledge_chunk(
         values=vector,
         metadata=_json_safe_meta(meta),
     )
-    return True
+    if known_hashes is not None:
+        known_hashes.add(digest)
+    return "upserted"
 
 
-async def upsert_knowledge_spec(spec: KnowledgeChunkSpec) -> bool:
-    return await upsert_knowledge_chunk(
+async def upsert_knowledge_spec(
+    spec: KnowledgeChunkSpec,
+    *,
+    known_hashes: set[str] | None = None,
+) -> bool:
+    status = await upsert_knowledge_chunk(
         chunk_id=spec.chunk_id,
         text=spec.text,
         domain=spec.domain,
@@ -196,7 +340,16 @@ async def upsert_knowledge_spec(spec: KnowledgeChunkSpec) -> bool:
         acl=spec.acl,
         source_kind=spec.source_kind,
         locale=spec.locale,
+        document_id=spec.document_id,
+        chunk_index=spec.chunk_index,
+        chunk_total=spec.chunk_total,
+        chunk_policy=spec.chunk_policy,
+        parent_chunk_id=spec.parent_chunk_id,
+        content_ptr=spec.content_ptr,
+        content_hash=spec.content_hash,
+        known_hashes=known_hashes,
     )
+    return status == "upserted"
 
 
 async def ingest_corpus(
@@ -204,13 +357,26 @@ async def ingest_corpus(
     *,
     dry_run: bool = False,
 ) -> IngestResult:
+    errors: list[str] = []
     if dry_run:
-        valid = sum(1 for c in chunks if c.text.strip() and c.chunk_id)
+        valid = 0
+        for c in chunks:
+            if not c.text.strip() or not c.chunk_id:
+                continue
+            err = _guard_embed_tokens(
+                c.text,
+                category=c.category,
+                chunk_policy=c.chunk_policy or policy_for_category(c.category).name,
+            )
+            if err:
+                errors.append(f"{c.chunk_id}: {err}")
+                continue
+            valid += 1
         return IngestResult(
             total=len(chunks),
             upserted=valid,
             skipped=len(chunks) - valid,
-            errors=(),
+            errors=tuple(errors),
         )
 
     if get_knowledge_writer() is None:
@@ -226,22 +392,61 @@ async def ingest_corpus(
 
     upserted = 0
     skipped = 0
-    errors: list[str] = []
+    known_hashes: set[str] = set()
     for spec in chunks:
         if not spec.chunk_id or not spec.text.strip():
             skipped += 1
             continue
+        # JSON fast path：超限则拒绝（不静默截断）；调用方应先走 ChunkPlanner
+        guard = _guard_embed_tokens(
+            spec.text,
+            category=spec.category,
+            chunk_policy=spec.chunk_policy or policy_for_category(spec.category).name,
+        )
+        if guard:
+            skipped += 1
+            errors.append(f"{spec.chunk_id}: {guard}")
+            continue
+        enriched = spec
+        if not enriched.content_hash:
+            enriched = replace(spec, content_hash=content_hash_of(spec.text))
+        if not enriched.chunk_policy:
+            enriched = replace(enriched, chunk_policy=policy_for_category(spec.category).name)
+        if not enriched.document_id:
+            enriched = replace(enriched, document_id=spec.source_id)
         try:
-            ok = await upsert_knowledge_spec(spec)
+            status = await upsert_knowledge_chunk(
+                chunk_id=enriched.chunk_id,
+                text=enriched.text,
+                domain=enriched.domain,
+                category=enriched.category,
+                title=enriched.title,
+                source_id=enriched.source_id,
+                tags=list(enriched.tags),
+                quality_tier=enriched.quality_tier,
+                acl=enriched.acl,
+                source_kind=enriched.source_kind,
+                locale=enriched.locale,
+                document_id=enriched.document_id,
+                chunk_index=enriched.chunk_index,
+                chunk_total=enriched.chunk_total,
+                chunk_policy=enriched.chunk_policy,
+                parent_chunk_id=enriched.parent_chunk_id,
+                content_ptr=enriched.content_ptr,
+                content_hash=enriched.content_hash,
+                known_hashes=known_hashes,
+            )
         except Exception as exc:  # noqa: BLE001 — 单条失败不阻断整批
             errors.append(f"{spec.chunk_id}: {type(exc).__name__}")
             skipped += 1
             continue
-        if ok:
+        if status == "upserted":
             upserted += 1
+        elif status == "skipped":
+            skipped += 1
         else:
             skipped += 1
-            errors.append(f"{spec.chunk_id}: upsert returned false")
+            errors.append(f"{spec.chunk_id}: upsert returned error")
     return IngestResult(
         total=len(chunks),
         upserted=upserted,
@@ -253,3 +458,28 @@ async def ingest_corpus(
 async def ingest_corpus_file(path: Path, *, dry_run: bool = False) -> IngestResult:
     chunks = load_corpus_file(path)
     return await ingest_corpus(chunks, dry_run=dry_run)
+
+
+async def ingest_markdown_file(
+    path: Path,
+    *,
+    document_id: str,
+    domain: str,
+    category: str,
+    title: str,
+    source_id: str,
+    policy_name: str | None = None,
+    dry_run: bool = False,
+) -> IngestResult:
+    text = path.read_text(encoding="utf-8")
+    specs = specs_from_markdown(
+        text,
+        document_id=document_id,
+        domain=domain,
+        category=category,
+        title=title,
+        source_id=source_id,
+        policy_name=policy_name,
+        content_ptr=str(path.resolve()),
+    )
+    return await ingest_corpus(specs, dry_run=dry_run)

--- a/backend/tests/forge/knowledge/test_chunk_ingest.py
+++ b/backend/tests/forge/knowledge/test_chunk_ingest.py
@@ -1,0 +1,110 @@
+"""Production chunking ingest wiring (#146)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.forge.cache.pinecone_store import InMemoryPineconeStore
+from app.forge.knowledge.ingest import (
+    ingest_corpus,
+    specs_from_markdown,
+    upsert_knowledge_spec,
+)
+from app.forge.knowledge.pinecone_store import (
+    reset_knowledge_pinecone_store_override,
+    set_knowledge_pinecone_store_override,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_knowledge_pinecone_store_override()
+    store = InMemoryPineconeStore()
+    set_knowledge_pinecone_store_override(store)
+    monkeypatch.setattr(settings, "knowledge_metadata_validation_enabled", True)
+
+    async def _fake_embed(text: str) -> list[float]:
+        _ = text
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr("app.forge.knowledge.ingest.embed_one", _fake_embed)
+    yield
+    reset_knowledge_pinecone_store_override()
+
+
+@pytest.mark.asyncio
+async def test_markdown_ingest_writes_chunk_metadata() -> None:
+    md = """## 机制
+
+随机成长应绑定稀有度曲线。
+
+## 案例
+
+经典塔防强调路线与射程覆盖。
+"""
+    specs = specs_from_markdown(
+        md,
+        document_id="doc_td",
+        domain="design",
+        category="gameplay_mechanic",
+        title="塔防笔记",
+        source_id="src_md",
+        content_ptr="/tmp/td.md",
+    )
+    assert len(specs) >= 2
+    assert specs[0].document_id == "doc_td"
+    assert specs[0].chunk_policy == "design_principle"
+    assert specs[0].chunk_index == 0
+    assert specs[0].chunk_total == len(specs)
+    assert specs[0].content_hash
+
+    result = await ingest_corpus(specs)
+    assert result.upserted == len(specs)
+    assert result.errors == ()
+
+    store = __import__(
+        "app.forge.knowledge.pinecone_store", fromlist=["get_knowledge_writer"]
+    ).get_knowledge_writer()
+    assert store is not None
+    rows = store._rows  # type: ignore[attr-defined]
+    meta = next(iter(rows.values()))[1]
+    assert meta["document_id"] == "doc_td"
+    assert "chunk_index" in meta
+    assert meta["chunk_policy"] == "design_principle"
+    assert len(meta["text"]) <= 2000
+
+
+@pytest.mark.asyncio
+async def test_reingest_same_content_hash_is_idempotent() -> None:
+    specs = specs_from_markdown(
+        "## 原则\n\n短文本即可。",
+        document_id="doc_x",
+        domain="design",
+        category="design_principle",
+        title="t",
+        source_id="src",
+    )
+    first = await ingest_corpus(specs)
+    second = await ingest_corpus(specs)
+    assert first.upserted == len(specs)
+    assert second.upserted == 0
+    assert second.skipped == len(specs)
+
+
+@pytest.mark.asyncio
+async def test_oversized_json_chunk_rejected() -> None:
+    from app.forge.knowledge.ingest import KnowledgeChunkSpec
+
+    huge = "机" * 600
+    spec = KnowledgeChunkSpec(
+        chunk_id="too_big",
+        text=huge,
+        domain="design",
+        category="design_principle",
+        title="t",
+        source_id="s",
+        chunk_policy="design_principle",
+    )
+    ok = await upsert_knowledge_spec(spec)
+    assert ok is False

--- a/backend/tests/forge/knowledge/test_chunk_planner.py
+++ b/backend/tests/forge/knowledge/test_chunk_planner.py
@@ -1,0 +1,47 @@
+"""ChunkPlanner and policy registry tests (#146)."""
+
+from __future__ import annotations
+
+from app.forge.knowledge.chunk_planner import (
+    assert_no_truncation,
+    plan_markdown,
+    plan_text,
+)
+from app.forge.knowledge.chunk_policy import (
+    EMBED_MAX_TOKENS,
+    effective_max_tokens,
+    policy_for_category,
+)
+from app.forge.memory.context_builder import estimate_tokens
+
+
+def test_policy_for_gameplay_mechanic() -> None:
+    p = policy_for_category("gameplay_mechanic")
+    assert p.name == "design_principle"
+    assert effective_max_tokens(p) <= EMBED_MAX_TOKENS
+
+
+def test_plan_markdown_splits_headings() -> None:
+    md = """# Ignore H1
+
+## 原则一
+
+肉鸽塔防需要随机成长与构筑深度。
+
+## 原则二
+
+塔协同应形成明确 combo，而不是数值膨胀。
+"""
+    drafts = plan_markdown(md, category="design_principle")
+    assert len(drafts) >= 2
+    assert assert_no_truncation(drafts) == 0.0
+    assert all(estimate_tokens(d.text) <= EMBED_MAX_TOKENS for d in drafts)
+
+
+def test_plan_text_splits_oversized() -> None:
+    policy = policy_for_category("design_principle")
+    long = "塔防协同机制。" * 200
+    assert estimate_tokens(long) > EMBED_MAX_TOKENS
+    drafts = plan_text(long, policy=policy)
+    assert len(drafts) > 1
+    assert assert_no_truncation(drafts) == 0.0

--- a/docs/superpowers/specs/2026-08-30-knowledge-chunking-mvp-design.md
+++ b/docs/superpowers/specs/2026-08-30-knowledge-chunking-mvp-design.md
@@ -1,0 +1,32 @@
+# Design: Knowledge Production Chunking MVP (#146)
+
+**Status:** Approved via user “继续” (option A)
+**Date:** 2026-08-30
+
+## Goal
+
+Close #146 acceptance without S3/PostgreSQL two-tier storage.
+
+## Scope (in)
+
+- Chunk Policy Registry (subset of ADR-14 §3.6.3)
+- `ChunkPlanner`: Markdown `##`/`###` split + oversized sliding split
+- Pre-embed token guard ≤480 (`estimate_tokens`); never silent truncate
+- Metadata: `document_id`, `chunk_index`, `chunk_total`, `chunk_policy`, `content_hash`, optional `content_ptr` (local path placeholder)
+- Metadata `text` cap 2000 chars
+- Idempotent skip on same `content_hash` (batch + InMemory scan; HTTP via metadata filter query when possible)
+- Chunking eval helper: `truncation_rate` must be 0 after plan
+- JSON curated corpus remains fast path (enrich metadata if missing)
+
+## Scope (out)
+
+- Real S3 / `knowledge_source` PostgreSQL
+- Full boundary_precision human eval
+- MMR / small-to-big runtime expand
+
+## Interfaces
+
+- `app/forge/knowledge/chunk_policy.py` — registry
+- `app/forge/knowledge/chunk_planner.py` — `plan_markdown` / `plan_text` / `enrich_spec`
+- `ingest.py` — token guard, hash skip, metadata fields
+- `tests/forge/knowledge/test_chunk_planner.py`, `test_chunk_ingest.py`


### PR DESCRIPTION
## Summary
- Chunk Policy Registry + `ChunkPlanner` (Markdown `##`/`###` + oversized split)
- Pre-embed token hard guard (≤480 / policy max); reject silent truncate
- Metadata contract: `document_id`, `chunk_index`, `chunk_total`, `chunk_policy`, `content_hash`, optional `content_ptr`
- Metadata `text` capped at 2000 chars
- Idempotent skip on same `content_hash`
- `specs_from_markdown` / `ingest_markdown_file` path
- Design: `docs/superpowers/specs/2026-08-30-knowledge-chunking-mvp-design.md`

## Out of scope (follow-up)
- Real S3 + PostgreSQL source archive
- Human boundary_precision eval suite

## Background
Stacked on #152 (`feat/knowledge-circuit-tokenizer-budget`). Implements #146 MVP (option A).

## Test plan
- [x] `uv run pytest tests/forge/knowledge/` (59 passed locally before commit; chunk tests 11 passed)
- [ ] CI green
- [ ] Merge **after** #152

## Related
- Closes #146 (MVP acceptance; S3/PG deferred)