### PR TITLE
feat(knowledge): local source archive + readiness gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ htmlcov/
 
 # 产物托管本地目录
 .hosting/
+.knowledge-sources/
 .pnpm-store/
 
 # 本机 TEI embedding 模型权重（scripts/download_embedding_model.sh）

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -238,7 +238,9 @@ PINECONE_KNOWLEDGE_INDEX=gameforge-knowledge
 # KNOWLEDGE_EMBEDDING_EXPECTED_MODEL=bge-small-zh-v1.5
 # KNOWLEDGE_EMBEDDING_VERSION=bge-small-zh-v1.5:v1
 # KNOWLEDGE_METADATA_VALIDATION_ENABLED=true
+# KNOWLEDGE_SOURCE_ROOT=.knowledge-sources
 # Ops bootstrap: uv run python -m scripts.knowledge_bootstrap
+# Gate check (does NOT enable RAG): uv run python -m scripts.knowledge_readiness_gate
 
 # ADR-13 Native Engine（Godot-first；默认关）
 NATIVE_ENGINE_ENABLED=false

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -199,6 +199,8 @@ class Settings(BaseSettings):
     knowledge_embedding_expected_model: str = ""  # 空=跳过；应与 EMBEDDING_MODEL 一致
     knowledge_embedding_version: str = ""  # 空=跳过；ingest 写入 metadata.embedding_version
     knowledge_metadata_validation_enabled: bool = True
+    # ADR-14 §3.6.2：原文本地归档根目录（真 S3/PG 后续）；content_ptr=local://...
+    knowledge_source_root: str = ".knowledge-sources"
 
     # ADR-13 Native Engine（Godot-first；默认关，不影响 Web 管线）
     native_engine_enabled: bool = False

--- a/backend/app/forge/knowledge/ingest.py
+++ b/backend/app/forge/knowledge/ingest.py
@@ -471,7 +471,14 @@ async def ingest_markdown_file(
     policy_name: str | None = None,
     dry_run: bool = False,
 ) -> IngestResult:
+    from app.forge.knowledge.source_store import archive_source_text
+
     text = path.read_text(encoding="utf-8")
+    content_ptr = archive_source_text(
+        text,
+        source_id=source_id,
+        document_id=document_id,
+    )
     specs = specs_from_markdown(
         text,
         document_id=document_id,
@@ -480,6 +487,6 @@ async def ingest_markdown_file(
         title=title,
         source_id=source_id,
         policy_name=policy_name,
-        content_ptr=str(path.resolve()),
+        content_ptr=content_ptr,
     )
     return await ingest_corpus(specs, dry_run=dry_run)

--- a/backend/app/forge/knowledge/source_store.py
+++ b/backend/app/forge/knowledge/source_store.py
@@ -1,0 +1,87 @@
+"""Knowledge Source 本地归档（ADR-14 §3.6.2 MVP；真 S3/PG 后续）。
+
+Pinecone 只存注入用短 `text` + `content_ptr`；原文落在本地归档根目录。
+指针格式：`local://knowledge-sources/{source_id}/{document_id}/{content_hash[:16]}.md`
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.core.config import settings
+from app.forge.knowledge.chunk_planner import content_hash_of, normalize_text
+
+_PTR_RE = re.compile(
+    r"^local://knowledge-sources/"
+    r"(?P<source_id>[^/]+)/"
+    r"(?P<document_id>[^/]+)/"
+    r"(?P<name>[a-f0-9]{16})\.md$"
+)
+
+
+def knowledge_source_root() -> Path:
+    return Path(settings.knowledge_source_root).expanduser().resolve()
+
+
+def build_content_ptr(*, source_id: str, document_id: str, content_hash: str) -> str:
+    sid = _safe_segment(source_id)
+    did = _safe_segment(document_id)
+    digest = (content_hash or "")[:16].lower()
+    if len(digest) < 16:
+        digest = content_hash_of(f"{sid}:{did}:{content_hash}")[:16]
+    return f"local://knowledge-sources/{sid}/{did}/{digest}.md"
+
+
+def archive_source_text(
+    text: str,
+    *,
+    source_id: str,
+    document_id: str,
+) -> str:
+    """写入本地归档并返回 content_ptr。"""
+    cleaned = normalize_text(text)
+    digest = content_hash_of(cleaned)
+    ptr = build_content_ptr(
+        source_id=source_id,
+        document_id=document_id,
+        content_hash=digest,
+    )
+    path = resolve_content_ptr(ptr)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(cleaned, encoding="utf-8")
+    return ptr
+
+
+def resolve_content_ptr(content_ptr: str) -> Path:
+    """解析 local:// 指针到归档文件路径；非法指针抛 ValueError。"""
+    ptr = (content_ptr or "").strip()
+    match = _PTR_RE.match(ptr)
+    if not match:
+        raise ValueError(f"unsupported content_ptr: {ptr!r}")
+    root = knowledge_source_root()
+    sid = _safe_segment(match.group("source_id"))
+    did = _safe_segment(match.group("document_id"))
+    name = match.group("name")
+    target = (root / "knowledge-sources" / sid / did / f"{name}.md").resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("content_ptr escapes knowledge_source_root") from exc
+    return target
+
+
+def read_source_text(content_ptr: str) -> str:
+    path = resolve_content_ptr(content_ptr)
+    if not path.is_file():
+        raise FileNotFoundError(content_ptr)
+    return path.read_text(encoding="utf-8")
+
+
+def _safe_segment(value: str) -> str:
+    raw = (value or "").strip() or "unknown"
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", raw).strip("._")
+    if not cleaned or cleaned in {".", ".."} or ".." in cleaned:
+        return "unknown"
+    return cleaned[:120]

--- a/backend/scripts/knowledge_readiness_gate.py
+++ b/backend/scripts/knowledge_readiness_gate.py
@@ -1,0 +1,145 @@
+"""Knowledge RAG Production Readiness Gate checker (#147 follow-up).
+
+Does NOT enable KNOWLEDGE_RAG_ENABLED. Prints pass/fail checklist for ops.
+Exit 0 only when all hard checks pass (soft warnings still exit 0 with WARN lines).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+from app.core.config import settings
+from app.forge.knowledge.pinecone_store import knowledge_pinecone_configured
+from app.llm.embeddings import embedding_configured
+
+
+@dataclass(frozen=True)
+class GateItem:
+    name: str
+    ok: bool
+    detail: str
+    hard: bool = True
+
+
+def collect_gate_items() -> list[GateItem]:
+    items: list[GateItem] = []
+    items.append(
+        GateItem(
+            name="default_flag_off",
+            ok=settings.knowledge_rag_enabled is False,
+            detail=(
+                "KNOWLEDGE_RAG_ENABLED is false (safe default)"
+                if not settings.knowledge_rag_enabled
+                else "KNOWLEDGE_RAG_ENABLED is TRUE — confirm ops approval before prod"
+            ),
+            hard=False,
+        )
+    )
+    items.append(
+        GateItem(
+            name="pinecone_knowledge_host",
+            ok=knowledge_pinecone_configured(),
+            detail=(
+                "PINECONE_KNOWLEDGE_HOST configured"
+                if knowledge_pinecone_configured()
+                else "missing PINECONE_KNOWLEDGE_HOST / API key / pinecone_enabled"
+            ),
+        )
+    )
+    items.append(
+        GateItem(
+            name="embedding",
+            ok=embedding_configured(),
+            detail=(
+                "embedding client configured"
+                if embedding_configured()
+                else "embedding not configured (EMBEDDING_*)"
+            ),
+        )
+    )
+    dim_ok = int(settings.knowledge_embedding_expected_dim) > 0
+    items.append(
+        GateItem(
+            name="embedding_dim_contract",
+            ok=dim_ok,
+            detail=(
+                f"knowledge_embedding_expected_dim={settings.knowledge_embedding_expected_dim}"
+                if dim_ok
+                else "set KNOWLEDGE_EMBEDDING_EXPECTED_DIM (e.g. 512)"
+            ),
+        )
+    )
+    model_ok = bool(settings.knowledge_embedding_expected_model.strip())
+    items.append(
+        GateItem(
+            name="embedding_model_contract",
+            ok=model_ok,
+            detail=(
+                f"expected_model={settings.knowledge_embedding_expected_model!r}"
+                if model_ok
+                else "set KNOWLEDGE_EMBEDDING_EXPECTED_MODEL"
+            ),
+        )
+    )
+    ver_ok = bool(settings.knowledge_embedding_version.strip())
+    items.append(
+        GateItem(
+            name="embedding_version",
+            ok=ver_ok,
+            detail=(
+                f"version={settings.knowledge_embedding_version!r}"
+                if ver_ok
+                else "set KNOWLEDGE_EMBEDDING_VERSION for stale-vector skip"
+            ),
+            hard=False,
+        )
+    )
+    items.append(
+        GateItem(
+            name="circuit_enabled",
+            ok=bool(settings.knowledge_circuit_enabled),
+            detail="knowledge circuit breaker enabled",
+            hard=False,
+        )
+    )
+    items.append(
+        GateItem(
+            name="metadata_validation",
+            ok=bool(settings.knowledge_metadata_validation_enabled),
+            detail="metadata taxonomy validation enabled",
+            hard=False,
+        )
+    )
+    root = settings.knowledge_source_root.strip()
+    items.append(
+        GateItem(
+            name="source_archive_root",
+            ok=bool(root),
+            detail=f"KNOWLEDGE_SOURCE_ROOT={root!r}",
+            hard=False,
+        )
+    )
+    return items
+
+
+def main() -> int:
+    items = collect_gate_items()
+    hard_fail = 0
+    for item in items:
+        mark = "PASS" if item.ok else ("FAIL" if item.hard else "WARN")
+        if item.hard and not item.ok:
+            hard_fail += 1
+        print(f"[{mark}] {item.name}: {item.detail}")
+    print()
+    if hard_fail:
+        print(f"Gate NOT ready: {hard_fail} hard failure(s).")
+        print("Do not set KNOWLEDGE_RAG_ENABLED=true until hard checks pass.")
+        return 1
+    print("Hard checks passed. Soft warnings above (if any) should be reviewed.")
+    print("Enabling RAG in production still requires explicit ops approval.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/forge/knowledge/test_chunk_ingest.py
+++ b/backend/tests/forge/knowledge/test_chunk_ingest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from app.core.config import settings
@@ -73,6 +75,37 @@ async def test_markdown_ingest_writes_chunk_metadata() -> None:
     assert "chunk_index" in meta
     assert meta["chunk_policy"] == "design_principle"
     assert len(meta["text"]) <= 2000
+
+
+@pytest.mark.asyncio
+async def test_ingest_markdown_file_archives_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.forge.knowledge.ingest import ingest_markdown_file
+
+    monkeypatch.setattr(settings, "knowledge_source_root", str(tmp_path / "ks"))
+    md = tmp_path / "note.md"
+    md.write_text("## 原则\n\n短文即可归档。\n", encoding="utf-8")
+    result = await ingest_markdown_file(
+        md,
+        document_id="doc_md",
+        domain="design",
+        category="design_principle",
+        title="note",
+        source_id="src_md",
+    )
+    assert result.upserted >= 1
+    store = __import__(
+        "app.forge.knowledge.pinecone_store", fromlist=["get_knowledge_writer"]
+    ).get_knowledge_writer()
+    assert store is not None
+    meta = next(iter(store._rows.values()))[1]  # type: ignore[attr-defined]
+    ptr = str(meta["content_ptr"])
+    assert ptr.startswith("local://knowledge-sources/")
+    from app.forge.knowledge.source_store import read_source_text
+
+    assert "短文即可归档" in read_source_text(ptr)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/forge/knowledge/test_knowledge_readiness_gate.py
+++ b/backend/tests/forge/knowledge/test_knowledge_readiness_gate.py
@@ -1,0 +1,26 @@
+"""Knowledge readiness gate script tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from scripts.knowledge_readiness_gate import collect_gate_items, main
+
+
+def test_collect_gate_items_reports_default_flag_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "knowledge_rag_enabled", False)
+    items = {i.name: i for i in collect_gate_items()}
+    assert items["default_flag_off"].ok is True
+
+
+def test_main_fails_on_hard_gaps(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pinecone_enabled", False)
+    monkeypatch.setattr(settings, "pinecone_api_key", "")
+    monkeypatch.setattr(settings, "pinecone_knowledge_host", "")
+    monkeypatch.setattr(settings, "embedding_enabled", False)
+    monkeypatch.setattr(settings, "knowledge_embedding_expected_dim", 0)
+    monkeypatch.setattr(settings, "knowledge_embedding_expected_model", "")
+    assert main() == 1

--- a/backend/tests/forge/knowledge/test_source_store.py
+++ b/backend/tests/forge/knowledge/test_source_store.py
@@ -1,0 +1,52 @@
+"""Local knowledge source archive tests (#146 follow-up)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.core.config import settings
+from app.forge.knowledge.source_store import (
+    archive_source_text,
+    build_content_ptr,
+    read_source_text,
+    resolve_content_ptr,
+)
+
+
+@pytest.fixture()
+def archive_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "ks"
+    monkeypatch.setattr(settings, "knowledge_source_root", str(root))
+    return root
+
+
+def test_archive_and_read_roundtrip(archive_root: Path) -> None:
+    ptr = archive_source_text(
+        "## Hello\n\n世界",
+        source_id="src_a",
+        document_id="doc_1",
+    )
+    assert ptr.startswith("local://knowledge-sources/")
+    path = resolve_content_ptr(ptr)
+    assert path.is_file()
+    assert "世界" in read_source_text(ptr)
+    # idempotent
+    ptr2 = archive_source_text(
+        "## Hello\n\n世界",
+        source_id="src_a",
+        document_id="doc_1",
+    )
+    assert ptr2 == ptr
+
+
+def test_build_content_ptr_stable() -> None:
+    a = build_content_ptr(source_id="s", document_id="d", content_hash="a" * 64)
+    b = build_content_ptr(source_id="s", document_id="d", content_hash="a" * 64)
+    assert a == b
+
+
+def test_reject_path_traversal(archive_root: Path) -> None:
+    with pytest.raises(ValueError):
+        resolve_content_ptr("local://knowledge-sources/../etc/passwd")


### PR DESCRIPTION
## Summary
- Local Knowledge Source archive (`local://knowledge-sources/...`) replacing raw absolute paths in markdown ingest
- Config: `KNOWLEDGE_SOURCE_ROOT` (default `.knowledge-sources`)
- Ops script: `uv run python -m scripts.knowledge_readiness_gate` (hard checks; does **not** flip `KNOWLEDGE_RAG_ENABLED`)

## Out of scope
- Real S3 + PostgreSQL `knowledge_source` table — tracked in #154

## Test plan
- [x] `uv run pytest tests/forge/knowledge/test_source_store.py tests/forge/knowledge/test_knowledge_readiness_gate.py tests/forge/knowledge/test_chunk_ingest.py`
- [ ] CI green