### PR TITLE
feat(knowledge): S3 + Postgres knowledge_source archive (#154)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -239,6 +239,9 @@ PINECONE_KNOWLEDGE_INDEX=gameforge-knowledge
 # KNOWLEDGE_EMBEDDING_VERSION=bge-small-zh-v1.5:v1
 # KNOWLEDGE_METADATA_VALIDATION_ENABLED=true
 # KNOWLEDGE_SOURCE_ROOT=.knowledge-sources
+# KNOWLEDGE_SOURCE_BACKEND=local
+# KNOWLEDGE_S3_PREFIX=knowledge-sources
+# KNOWLEDGE_SOURCE_PERSIST_DB=true
 # Ops bootstrap: uv run python -m scripts.knowledge_bootstrap
 # Gate check (does NOT enable RAG): uv run python -m scripts.knowledge_readiness_gate
 

--- a/backend/alembic/versions/0021_knowledge_sources.py
+++ b/backend/alembic/versions/0021_knowledge_sources.py
@@ -1,0 +1,48 @@
+"""0021: knowledge_sources table for ADR-14 two-tier archive."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0021_knowledge_sources"
+down_revision = "0020_art_fingerprint"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "knowledge_sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("source_id", sa.String(length=128), nullable=False),
+        sa.Column("document_id", sa.String(length=128), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("content_ptr", sa.String(length=512), nullable=False),
+        sa.Column("title", sa.String(length=500), nullable=False, server_default=""),
+        sa.Column("locale", sa.String(length=16), nullable=False, server_default="zh-CN"),
+        sa.Column("byte_size", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("backend", sa.String(length=16), nullable=False, server_default="local"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_id",
+            "document_id",
+            "content_hash",
+            name="uq_knowledge_sources_src_doc_hash",
+        ),
+    )
+    op.create_index("ix_knowledge_sources_source_id", "knowledge_sources", ["source_id"])
+    op.create_index("ix_knowledge_sources_document_id", "knowledge_sources", ["document_id"])
+    op.create_index("ix_knowledge_sources_content_hash", "knowledge_sources", ["content_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_knowledge_sources_content_hash", table_name="knowledge_sources")
+    op.drop_index("ix_knowledge_sources_document_id", table_name="knowledge_sources")
+    op.drop_index("ix_knowledge_sources_source_id", table_name="knowledge_sources")
+    op.drop_table("knowledge_sources")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -199,8 +199,11 @@ class Settings(BaseSettings):
     knowledge_embedding_expected_model: str = ""  # 空=跳过；应与 EMBEDDING_MODEL 一致
     knowledge_embedding_version: str = ""  # 空=跳过；ingest 写入 metadata.embedding_version
     knowledge_metadata_validation_enabled: bool = True
-    # ADR-14 §3.6.2：原文本地归档根目录（真 S3/PG 后续）；content_ptr=local://...
+    # ADR-14 §3.6.2：原文归档（local 默认；s3 复用 S3_* 凭据）
     knowledge_source_root: str = ".knowledge-sources"
+    knowledge_source_backend: str = "local"  # local | s3
+    knowledge_s3_prefix: str = "knowledge-sources"
+    knowledge_source_persist_db: bool = True  # archive 时写 knowledge_sources 行（需传入 session）
 
     # ADR-13 Native Engine（Godot-first；默认关，不影响 Web 管线）
     native_engine_enabled: bool = False

--- a/backend/app/forge/knowledge/ingest.py
+++ b/backend/app/forge/knowledge/ingest.py
@@ -470,14 +470,23 @@ async def ingest_markdown_file(
     source_id: str,
     policy_name: str | None = None,
     dry_run: bool = False,
+    session: object | None = None,
 ) -> IngestResult:
-    from app.forge.knowledge.source_store import archive_source_text
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.forge.knowledge.source_store import archive_source
 
     text = path.read_text(encoding="utf-8")
-    content_ptr = archive_source_text(
+    db = session if isinstance(session, AsyncSession) else None
+    if db is None and settings.knowledge_source_persist_db:
+        # 无 session 时仍归档 blob；DB 行跳过（脚本可显式传入 SessionLocal）
+        db = None
+    content_ptr = await archive_source(
         text,
         source_id=source_id,
         document_id=document_id,
+        title=title,
+        session=db,
     )
     specs = specs_from_markdown(
         text,

--- a/backend/app/forge/knowledge/source_store.py
+++ b/backend/app/forge/knowledge/source_store.py
@@ -1,22 +1,36 @@
-"""Knowledge Source 本地归档（ADR-14 §3.6.2 MVP；真 S3/PG 后续）。
+"""Knowledge Source 归档（ADR-14 §3.6.2）。
 
-Pinecone 只存注入用短 `text` + `content_ptr`；原文落在本地归档根目录。
-指针格式：`local://knowledge-sources/{source_id}/{document_id}/{content_hash[:16]}.md`
+Backend:
+- local → `local://knowledge-sources/...` 落盘
+- s3 → `s3://{bucket}/knowledge-sources/...`（复用托管 S3_* 凭据，独立 key 前缀）
+
+可选写入 PostgreSQL `knowledge_sources` 元数据行。
 """
 
 from __future__ import annotations
 
+import asyncio
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from app.core.config import settings
 from app.forge.knowledge.chunk_planner import content_hash_of, normalize_text
 
-_PTR_RE = re.compile(
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_LOCAL_PTR_RE = re.compile(
     r"^local://knowledge-sources/"
     r"(?P<source_id>[^/]+)/"
     r"(?P<document_id>[^/]+)/"
     r"(?P<name>[a-f0-9]{16})\.md$"
+)
+
+_S3_PTR_RE = re.compile(
+    r"^s3://(?P<bucket>[^/]+)/"
+    r"(?P<key>.+\.md)$"
 )
 
 
@@ -24,42 +38,58 @@ def knowledge_source_root() -> Path:
     return Path(settings.knowledge_source_root).expanduser().resolve()
 
 
-def build_content_ptr(*, source_id: str, document_id: str, content_hash: str) -> str:
+def _safe_segment(value: str) -> str:
+    raw = (value or "").strip() or "unknown"
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", raw).strip("._")
+    if not cleaned or cleaned in {".", ".."} or ".." in cleaned:
+        return "unknown"
+    return cleaned[:120]
+
+
+def _digest16(content_hash: str, *, sid: str, did: str) -> str:
+    digest = (content_hash or "")[:16].lower()
+    if len(digest) < 16 or not re.fullmatch(r"[a-f0-9]{16}", digest):
+        return content_hash_of(f"{sid}:{did}:{content_hash}")[:16]
+    return digest
+
+
+def build_local_content_ptr(*, source_id: str, document_id: str, content_hash: str) -> str:
     sid = _safe_segment(source_id)
     did = _safe_segment(document_id)
-    digest = (content_hash or "")[:16].lower()
-    if len(digest) < 16:
-        digest = content_hash_of(f"{sid}:{did}:{content_hash}")[:16]
+    digest = _digest16(content_hash, sid=sid, did=did)
     return f"local://knowledge-sources/{sid}/{did}/{digest}.md"
 
 
-def archive_source_text(
-    text: str,
-    *,
-    source_id: str,
-    document_id: str,
-) -> str:
-    """写入本地归档并返回 content_ptr。"""
-    cleaned = normalize_text(text)
-    digest = content_hash_of(cleaned)
-    ptr = build_content_ptr(
-        source_id=source_id,
-        document_id=document_id,
-        content_hash=digest,
+def build_s3_content_ptr(*, source_id: str, document_id: str, content_hash: str) -> str:
+    bucket = settings.s3_bucket.strip()
+    if not bucket:
+        raise ValueError("S3_BUCKET required for knowledge_source_backend=s3")
+    sid = _safe_segment(source_id)
+    did = _safe_segment(document_id)
+    digest = _digest16(content_hash, sid=sid, did=did)
+    prefix = (settings.knowledge_s3_prefix or "knowledge-sources").strip().strip("/")
+    key = f"{prefix}/{sid}/{did}/{digest}.md"
+    return f"s3://{bucket}/{key}"
+
+
+# 兼容旧名
+def build_content_ptr(*, source_id: str, document_id: str, content_hash: str) -> str:
+    backend = (settings.knowledge_source_backend or "local").strip().lower()
+    if backend == "s3":
+        return build_s3_content_ptr(
+            source_id=source_id, document_id=document_id, content_hash=content_hash
+        )
+    return build_local_content_ptr(
+        source_id=source_id, document_id=document_id, content_hash=content_hash
     )
-    path = resolve_content_ptr(ptr)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not path.exists():
-        path.write_text(cleaned, encoding="utf-8")
-    return ptr
 
 
 def resolve_content_ptr(content_ptr: str) -> Path:
-    """解析 local:// 指针到归档文件路径；非法指针抛 ValueError。"""
+    """仅解析 local:// 指针。"""
     ptr = (content_ptr or "").strip()
-    match = _PTR_RE.match(ptr)
+    match = _LOCAL_PTR_RE.match(ptr)
     if not match:
-        raise ValueError(f"unsupported content_ptr: {ptr!r}")
+        raise ValueError(f"unsupported local content_ptr: {ptr!r}")
     root = knowledge_source_root()
     sid = _safe_segment(match.group("source_id"))
     did = _safe_segment(match.group("document_id"))
@@ -72,16 +102,189 @@ def resolve_content_ptr(content_ptr: str) -> Path:
     return target
 
 
+def _archive_local(cleaned: str, *, source_id: str, document_id: str, digest: str) -> str:
+    ptr = build_local_content_ptr(source_id=source_id, document_id=document_id, content_hash=digest)
+    path = resolve_content_ptr(ptr)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(cleaned, encoding="utf-8")
+    return ptr
+
+
+def _s3_client():  # type: ignore[no-untyped-def]
+    missing = [
+        name
+        for name, value in (
+            ("S3_BUCKET", settings.s3_bucket),
+            ("S3_AK", settings.s3_ak),
+            ("S3_SK", settings.s3_sk),
+            ("S3_ENDPOINT", settings.s3_endpoint),
+            ("S3_REGION", settings.s3_region),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"S3 knowledge archive missing config: {', '.join(missing)}")
+    import boto3  # type: ignore[import-untyped]
+    from botocore.config import Config  # type: ignore[import-untyped]
+
+    return boto3.client(
+        "s3",
+        endpoint_url=settings.s3_endpoint.rstrip("/"),
+        region_name=settings.s3_region,
+        aws_access_key_id=settings.s3_ak,
+        aws_secret_access_key=settings.s3_sk,
+        config=Config(
+            signature_version="s3v4",
+            s3={"addressing_style": settings.s3_addressing_style},
+            connect_timeout=settings.s3_connect_timeout,
+            read_timeout=settings.s3_read_timeout,
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+
+
+async def _archive_s3(cleaned: str, *, source_id: str, document_id: str, digest: str) -> str:
+    ptr = build_s3_content_ptr(source_id=source_id, document_id=document_id, content_hash=digest)
+    parsed = urlparse(ptr)
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+
+    def _put() -> None:
+        client = _s3_client()
+        client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=cleaned.encode("utf-8"),
+            ContentType="text/markdown; charset=utf-8",
+        )
+
+    await asyncio.to_thread(_put)
+    return ptr
+
+
+async def _read_s3(content_ptr: str) -> str:
+    match = _S3_PTR_RE.match(content_ptr.strip())
+    if not match:
+        raise ValueError(f"unsupported s3 content_ptr: {content_ptr!r}")
+    bucket = match.group("bucket")
+    key = match.group("key")
+
+    def _get() -> bytes:
+        client = _s3_client()
+        resp = client.get_object(Bucket=bucket, Key=key)
+        body = resp["Body"].read()
+        return bytes(body)
+
+    raw = await asyncio.to_thread(_get)
+    return bytes(raw).decode("utf-8")
+
+
+async def _persist_db_row(
+    session: AsyncSession,
+    *,
+    source_id: str,
+    document_id: str,
+    content_hash: str,
+    content_ptr: str,
+    title: str,
+    locale: str,
+    byte_size: int,
+    backend: str,
+) -> None:
+    from sqlalchemy import select
+
+    from app.models.knowledge_source import KnowledgeSource
+
+    existing = await session.scalar(
+        select(KnowledgeSource).where(
+            KnowledgeSource.source_id == source_id,
+            KnowledgeSource.document_id == document_id,
+            KnowledgeSource.content_hash == content_hash,
+        )
+    )
+    if existing is not None:
+        existing.content_ptr = content_ptr
+        existing.title = title[:500]
+        existing.byte_size = byte_size
+        existing.backend = backend
+        return
+    session.add(
+        KnowledgeSource(
+            source_id=source_id,
+            document_id=document_id,
+            content_hash=content_hash,
+            content_ptr=content_ptr,
+            title=title[:500],
+            locale=locale,
+            byte_size=byte_size,
+            backend=backend,
+        )
+    )
+
+
+async def archive_source(
+    text: str,
+    *,
+    source_id: str,
+    document_id: str,
+    title: str = "",
+    locale: str = "zh-CN",
+    session: AsyncSession | None = None,
+) -> str:
+    """归档原文并返回 content_ptr；可选写入 knowledge_sources 表。"""
+    cleaned = normalize_text(text)
+    digest = content_hash_of(cleaned)
+    backend = (settings.knowledge_source_backend or "local").strip().lower()
+    if backend == "s3":
+        ptr = await _archive_s3(
+            cleaned, source_id=source_id, document_id=document_id, digest=digest
+        )
+    else:
+        ptr = _archive_local(cleaned, source_id=source_id, document_id=document_id, digest=digest)
+        backend = "local"
+    if session is not None:
+        await _persist_db_row(
+            session,
+            source_id=_safe_segment(source_id),
+            document_id=_safe_segment(document_id),
+            content_hash=digest,
+            content_ptr=ptr,
+            title=title,
+            locale=locale,
+            byte_size=len(cleaned.encode("utf-8")),
+            backend=backend,
+        )
+        await session.commit()
+    return ptr
+
+
+def archive_source_text(
+    text: str,
+    *,
+    source_id: str,
+    document_id: str,
+) -> str:
+    """同步本地归档（兼容旧调用）；s3 backend 请用 archive_source。"""
+    cleaned = normalize_text(text)
+    digest = content_hash_of(cleaned)
+    return _archive_local(cleaned, source_id=source_id, document_id=document_id, digest=digest)
+
+
 def read_source_text(content_ptr: str) -> str:
+    """同步读取 local:// 指针。"""
     path = resolve_content_ptr(content_ptr)
     if not path.is_file():
         raise FileNotFoundError(content_ptr)
     return path.read_text(encoding="utf-8")
 
 
-def _safe_segment(value: str) -> str:
-    raw = (value or "").strip() or "unknown"
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", raw).strip("._")
-    if not cleaned or cleaned in {".", ".."} or ".." in cleaned:
-        return "unknown"
-    return cleaned[:120]
+async def read_source(content_ptr: str) -> str:
+    """读取 local:// 或 s3:// 原文（runtime small-to-big 入口）。"""
+    ptr = (content_ptr or "").strip()
+    if ptr.startswith("local://"):
+        return read_source_text(ptr)
+    if ptr.startswith("s3://"):
+        return await _read_s3(ptr)
+    raise ValueError(f"unsupported content_ptr scheme: {ptr!r}")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.game import Game
 from app.models.game_reaction import GameReaction
 from app.models.game_version import GameVersion
 from app.models.generation_run import GenerationRun
+from app.models.knowledge_source import KnowledgeSource
 from app.models.llm_config import UserLLMConfig
 from app.models.notification import Notification
 from app.models.oauth_account import OAuthAccount
@@ -33,6 +34,7 @@ __all__ = [
     "ForgeMessage",
     "FailureReport",
     "ArtifactRevision",
+    "KnowledgeSource",
     "GenerationRun",
     "RunCheckpoint",
     "RunCommand",

--- a/backend/app/models/knowledge_source.py
+++ b/backend/app/models/knowledge_source.py
@@ -1,0 +1,37 @@
+"""Knowledge Source 元数据表（ADR-14 §3.6.2；原文在 local/S3，指针在 Pinecone）。"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
+
+from app.models.base import Base
+
+
+class KnowledgeSource(Base):
+    __tablename__ = "knowledge_sources"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_id",
+            "document_id",
+            "content_hash",
+            name="uq_knowledge_sources_src_doc_hash",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    source_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    document_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    content_ptr: Mapped[str] = mapped_column(String(512), nullable=False)
+    title: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    locale: Mapped[str] = mapped_column(String(16), nullable=False, default="zh-CN")
+    byte_size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    backend: Mapped[str] = mapped_column(String(16), nullable=False, default="local")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/scripts/knowledge_readiness_gate.py
+++ b/backend/scripts/knowledge_readiness_gate.py
@@ -120,6 +120,34 @@ def collect_gate_items() -> list[GateItem]:
             hard=False,
         )
     )
+    backend = (settings.knowledge_source_backend or "local").strip().lower()
+    items.append(
+        GateItem(
+            name="source_backend",
+            ok=backend in {"local", "s3"},
+            detail=f"KNOWLEDGE_SOURCE_BACKEND={backend!r}",
+            hard=True,
+        )
+    )
+    if backend == "s3":
+        s3_ok = bool(
+            settings.s3_bucket.strip()
+            and settings.s3_ak.strip()
+            and settings.s3_sk.strip()
+            and settings.s3_endpoint.strip()
+            and settings.s3_region.strip()
+        )
+        items.append(
+            GateItem(
+                name="source_s3_credentials",
+                ok=s3_ok,
+                detail=(
+                    "S3_* configured for knowledge archive"
+                    if s3_ok
+                    else "knowledge_source_backend=s3 requires S3_BUCKET/AK/SK/ENDPOINT/REGION"
+                ),
+            )
+        )
     return items
 
 

--- a/backend/tests/forge/knowledge/test_knowledge_source_s3_pg.py
+++ b/backend/tests/forge/knowledge/test_knowledge_source_s3_pg.py
@@ -1,0 +1,95 @@
+"""S3 + DB knowledge source archive tests (#154)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.forge.knowledge.source_store import (
+    archive_source,
+    build_s3_content_ptr,
+    read_source,
+)
+from app.models.knowledge_source import KnowledgeSource
+
+
+@pytest.mark.asyncio
+async def test_archive_s3_and_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "knowledge_source_backend", "s3")
+    monkeypatch.setattr(settings, "s3_bucket", "gf-test")
+    monkeypatch.setattr(settings, "s3_ak", "ak")
+    monkeypatch.setattr(settings, "s3_sk", "sk")
+    monkeypatch.setattr(settings, "s3_endpoint", "http://127.0.0.1:9000")
+    monkeypatch.setattr(settings, "s3_region", "us-east-1")
+    monkeypatch.setattr(settings, "knowledge_s3_prefix", "knowledge-sources")
+
+    store: dict[tuple[str, str], bytes] = {}
+
+    class _Body:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def read(self) -> bytes:
+            return self._data
+
+    class _FakeS3:
+        def put_object(self, *, Bucket: str, Key: str, Body: bytes, **_kw: object) -> None:
+            store[(Bucket, Key)] = Body if isinstance(Body, bytes) else bytes(Body)
+
+        def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            return {"Body": _Body(store[(Bucket, Key)])}
+
+    monkeypatch.setattr(
+        "app.forge.knowledge.source_store._s3_client",
+        lambda: _FakeS3(),
+    )
+
+    ptr = await archive_source(
+        "## S3\n\n对象存储原文",
+        source_id="src",
+        document_id="doc",
+        title="t",
+    )
+    assert ptr.startswith("s3://gf-test/knowledge-sources/")
+    text = await read_source(ptr)
+    assert "对象存储原文" in text
+
+
+@pytest.mark.asyncio
+async def test_archive_persists_db_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    db_session,
+) -> None:
+    monkeypatch.setattr(settings, "knowledge_source_backend", "local")
+    monkeypatch.setattr(settings, "knowledge_source_root", str(tmp_path / "ks"))
+
+    ptr = await archive_source(
+        "## DB\n\n元数据行",
+        source_id="src_db",
+        document_id="doc_db",
+        title="db-title",
+        session=db_session,
+    )
+    assert ptr.startswith("local://")
+    rows = (
+        await db_session.scalars(
+            select(KnowledgeSource).where(KnowledgeSource.source_id == "src_db")
+        )
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].content_ptr == ptr
+    assert rows[0].title == "db-title"
+    assert rows[0].backend == "local"
+
+
+def test_build_s3_ptr(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "s3_bucket", "bkt")
+    monkeypatch.setattr(settings, "knowledge_s3_prefix", "knowledge-sources")
+    ptr = build_s3_content_ptr(source_id="s", document_id="d", content_hash="ab" * 32)
+    assert ptr.startswith("s3://bkt/knowledge-sources/s/d/")


### PR DESCRIPTION
## Summary
- Alembic `0021_knowledge_sources` + ORM `KnowledgeSource`
- `knowledge_source_backend=local|s3`; S3 uses hosting `S3_*` creds with `KNOWLEDGE_S3_PREFIX`
- `archive_source` / `read_source` support `local://` and `s3://` content_ptr
- Optional DB persist when AsyncSession is passed
- Readiness gate checks S3 creds when backend=s3

## Test plan
- [x] related knowledge source tests
- [ ] CI green
- [ ] `alembic upgrade head` in deploy

## Related
- Closes #154