### PR TITLE
chore(release): bump version to 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">🎮 GameForge</h1>
 
 <p align="center">
-  <a href="https://github.com/ByteTitan-star/GameForge-Copilot/releases/tag/v2.1.1"><img src="https://img.shields.io/badge/GameForge-v2.1.1-6e40c9" alt="GameForge v2.1.1" /></a>
+  <a href="https://github.com/ByteTitan-star/GameForge-Copilot/releases/tag/v2.1.2"><img src="https://img.shields.io/badge/GameForge-v2.1.2-6e40c9" alt="GameForge v2.1.2" /></a>
   <img src="https://img.shields.io/badge/python-3.12-3776AB" alt="Python 3.12" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/English-0A66C2" alt="English" />

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,7 @@
 <h1 align="center">🎮 GameForge</h1>
 
 <p align="center">
-  <a href="https://github.com/ByteTitan-star/GameForge-Copilot/releases/tag/v2.1.1"><img src="https://img.shields.io/badge/GameForge-v2.1.1-6e40c9" alt="GameForge v2.1.1" /></a>
+  <a href="https://github.com/ByteTitan-star/GameForge-Copilot/releases/tag/v2.1.2"><img src="https://img.shields.io/badge/GameForge-v2.1.2-6e40c9" alt="GameForge v2.1.2" /></a>
   <img src="https://img.shields.io/badge/python-3.12-3776AB" alt="Python 3.12" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <a href="./README.md"><img src="https://img.shields.io/badge/English-555555" alt="English" /></a>

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,7 +81,7 @@ async def _dev_seed_official_games() -> None:
 
 app = FastAPI(
     title="GameForge-Copilot",
-    version="2.1.1",
+    version="2.1.2",
     openapi_url="/openapi.json",
     docs_url="/docs",
     redoc_url=None,

--- a/backend/openapi_fresh.json
+++ b/backend/openapi_fresh.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "GameForge-Copilot",
-    "version": "2.1.1"
+    "version": "2.1.2"
   },
   "paths": {
     "/healthz": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gameforge-backend"
-version = "2.1.1"
+version = "2.1.2"
 description = "GameForge-Copilot backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "gameforge-backend"
-version = "2.1.1"
+version = "2.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aio-pika" },

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "GameForge-Copilot",
-    "version": "2.1.1"
+    "version": "2.1.2"
   },
   "paths": {
     "/healthz": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gameforge-frontend",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump project version from 2.1.1 to 2.1.2 (patch)
- Align README badges, backend, frontend, OpenAPI contracts, and uv.lock

## Test plan
- [ ] Confirm README badges show v2.1.2
- [ ] Confirm backend FastAPI / OpenAPI info.version is 2.1.2
- [ ] Confirm frontend package.json version is 2.1.2